### PR TITLE
validates parameters made in a get request to the oembed service

### DIFF
--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -1,0 +1,22 @@
+class EmbedController < ApplicationController
+  before_action :validate_request
+
+  def get
+  end
+
+  def validate_request
+    @embed_request ||= Embed::Request.new(params)
+  end
+
+  rescue_from Embed::Request::NoURLProvided do |e|
+    render body: e.to_s, status: 400
+  end
+
+  rescue_from Embed::Request::InvalidURLScheme do |e|
+    render body: e.to_s, status: 404
+  end
+
+  rescue_from Embed::Request::InvalidFormat do |e|
+    render body: e.to_s, status: 501
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'embed' => 'embed#get'
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/lib/embed/request.rb
+++ b/lib/embed/request.rb
@@ -35,6 +35,7 @@ module Embed
     def validate
       require_url_parameter
       validate_url_scheme
+      validate_format
     end
     def require_url_parameter
       raise NoURLProvided unless url.present?
@@ -47,6 +48,14 @@ module Embed
         url =~ scheme
       end
     end
+    def validate_format
+      fail InvalidFormat unless format_is_valid?
+    end
+    def format_is_valid?
+      [/^json$/, /^xml$/].any? do |supported_format|
+        format =~ supported_format
+      end
+    end
     class NoURLProvided < StandardError
       def initialize(msg="You must provide a URL parameter")
         super
@@ -54,6 +63,11 @@ module Embed
     end
     class InvalidURLScheme < StandardError
       def initialize(msg="The provided URL is not a supported scheme for this embed service")
+        super
+      end
+    end
+    class InvalidFormat < StandardError
+      def initialize(msg='The provided format is not supported for this embed service')
         super
       end
     end

--- a/spec/controllers/embed_controller_spec.rb
+++ b/spec/controllers/embed_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe EmbedController do
+  describe 'GET embed' do
+    it 'has a 400 status code without url params' do
+      get :get
+      expect(response.status).to eq(400)
+    end
+    it 'has a 404 status code without matched url scheme params' do
+      get :get, url: 'http://www.example.com'
+      expect(response.status).to eq(404)
+    end
+    it 'has a 501 status code for an invalid format' do
+      get :get, url: 'http://purl.stanford.edu/', format: 'yml'
+      expect(response.status).to eq(501)
+    end
+    it 'has a 200 status code for a matched url scheme param' do
+      get :get, url: 'http://purl.stanford.edu/ab123cd4567'
+      expect(response.status).to eq(200)
+    end
+  end
+end

--- a/spec/lib/embed/request_spec.rb
+++ b/spec/lib/embed/request_spec.rb
@@ -29,6 +29,8 @@ describe Embed::Request do
     it 'should raise an error when a URL is provided that does not match the scheme' do
       expect(->{ Embed::Request.new({url: 'http://library.stanford.edu'}) }).to raise_error(Embed::Request::InvalidURLScheme)
     end
+    it 'should raise an error when an invalid format is requested' do
+      expect(->{ Embed::Request.new({url: 'http://purl.stanford.edu/', format: 'yml'}) }).to raise_error(Embed::Request::InvalidFormat)
+    end
   end
 end
-


### PR DESCRIPTION
Choosing the route `/embed`

Will validate that the required parameter `url` is present. Also will validate that the url matches one of the agreed upon URL schemes.

Closes #16 
Closes #1 
