### PR TITLE
adds in file viewer as default viewer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'rails_config'
 
 group :development, :test do
   gem 'rspec-rails', '~> 3.0.0'
+  gem 'capybara'
 end
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,12 @@ GEM
       tzinfo (~> 1.1)
     arel (5.0.1.20140414130214)
     builder (3.2.2)
+    capybara (2.3.0)
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
     diff-lcs (1.2.5)
     dor-rights-auth (1.0.0)
       nokogiri
@@ -106,11 +112,14 @@ GEM
       polyglot (>= 0.3.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  capybara
   dor-rights-auth
   faraday
   nokogiri

--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -36,6 +36,10 @@ module Embed
       @ng_xml ||= Nokogiri::XML(response)
     end
 
+    def all_resource_files
+      contents.map(&:files).flatten
+    end
+
     private
 
     def rights_xml

--- a/lib/embed.rb
+++ b/lib/embed.rb
@@ -2,6 +2,7 @@ module Embed
   require 'embed/url_schemes'
   require 'embed/request'
   require 'embed/response'
+
   @@registered_viewers = []
   def self.register_viewer(viewer)
     @@registered_viewers << viewer
@@ -9,4 +10,5 @@ module Embed
   def self.registered_viewers
     @@registered_viewers
   end
+
 end

--- a/lib/embed/response.rb
+++ b/lib/embed/response.rb
@@ -31,7 +31,7 @@ module Embed
     end
     private
     def viewer
-      @viewer ||= Embed::Viewer.new(@request.purl_object).viewer
+      @viewer ||= Embed::Viewer.new(@request).viewer
     end
   end
 end

--- a/lib/embed/viewer.rb
+++ b/lib/embed/viewer.rb
@@ -1,11 +1,12 @@
 module Embed
   class Viewer
+    require 'embed/viewer/file'
     delegate :height, :width, to: :viewer
-    def initialize(purl_object)
-      @purl_object = purl_object
+    def initialize(request)
+      @request = request
     end
     def viewer
-      @viewer ||= registered_or_default_viewer.new(@purl_object)
+      @viewer ||= registered_or_default_viewer.new(@request)
     end
     private
     def registered_or_default_viewer
@@ -18,7 +19,7 @@ module Embed
     end
     def registered_viewer
       @registered_type ||= Embed.registered_viewers.find do |type_class|
-        type_class.supported_types.include?(@purl_object.type.to_sym)
+        type_class.supported_types.include?(@request.purl_object.type.to_sym)
       end
     end
   end

--- a/lib/embed/viewer/file.rb
+++ b/lib/embed/viewer/file.rb
@@ -1,0 +1,47 @@
+module Embed
+  class Viewer
+    class File
+      def initialize(request)
+        @request = request
+        @purl_object = request.purl_object
+      end
+
+      def self.default_viewer?
+        true
+      end
+
+      def height
+        '300'
+      end
+
+      def width
+        '300'
+      end
+
+      def to_html
+        Nokogiri::HTML::Builder.new do |doc|
+          doc.div(class: 'sul-embed-file') do
+            doc.p(class: 'sul-embed-title') { doc.text @purl_object.title }
+            doc.div(class: 'sul-embed-file-list') do
+              doc.table do
+                @purl_object.all_resource_files.each do |file|
+                  doc.tr do
+                    doc.td { doc.text file.mimetype }
+                    doc.td { doc.text file.title }
+                    doc.td { doc.text file.size }
+                  end
+                end
+              end
+            end
+          end
+        end.to_html
+      end
+
+      def self.supported_types
+        [:media]
+      end
+    end
+  end
+end
+
+Embed.register_viewer(Embed::Viewer::File) if Embed.respond_to?(:register_viewer)

--- a/spec/features/basic_functionality_spec.rb
+++ b/spec/features/basic_functionality_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe 'basic oembed functionality' do
+  include PURLFixtures
+  it 'should return a response with required parameters (xml)' do
+    stub_purl_response_with_fixture(file_purl)
+    visit embed_path(url: 'http://purl.stanford.edu/abc', format: 'xml')
+    expect(page).to have_xpath '//oembed'
+    expect(page).to have_xpath '//type'
+    expect(page).to have_xpath '//version', text: '1.0'
+  end
+  it 'should return a response with correct parameter fields (xml)' do
+    stub_purl_response_with_fixture(file_purl)
+    visit embed_path(url: 'http://purl.stanford.edu/abc', format: 'xml')
+    expect(page).to have_xpath '//type', text: 'rich'
+    expect(page).to have_xpath('//title', text: 'File Title')
+    expect(page).to have_xpath('//provider-name', text: 'SUL Embed Service')
+    expect(page).to have_xpath '//html'
+  end
+  it 'should return a response with require parameters (json)' do
+    #TODO leaving this until we figure out the html encoding
+  end
+end

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -85,6 +85,41 @@ module PURLFixtures
       </publicObject>
     XML
   end
+  def multi_resource_multi_file_purl
+    <<-XML
+      <publicObject>
+        <identityMetadata>
+          <objectLabel>Files and what not</objectLabel>
+        </identityMetadata>
+        <contentMetadata type="file">
+          <resource sequence="1" type="file">
+            <attr name="label">Resource Label</attr>
+            <file size="12345" mimetype="application/pdf" id="Page1.pdf" />
+            <file size="12346" mimetype="application/pdf" id="Page2.pdf" />
+          </resource>
+        </contentMetadata>
+        <contentMetadata type="media">
+          <resource sequence="2" type="filez">
+            <attr name="label">Resource Label</attr>
+            <file size="12345" mimetype="application/pdf" id="Page1.pdf" />
+            <file size="12346" mimetype="application/pdf" id="Page2.pdf" />
+          </resource>
+        </contentMetadata>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+        </rightsMetadata>
+      </publicObject>
+    XML
+  end
   def stanford_restricted_purl
     <<-XML
       <publicObject>

--- a/spec/lib/embed/viewer/file_spec.rb
+++ b/spec/lib/embed/viewer/file_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe Embed::Viewer::File do
+  include PURLFixtures
+  let(:purl_object) { double('purl_object') }
+  let(:request) { double('request') }
+  let(:file_viewer) { Embed::Viewer::File.new(request) }
+  describe 'initialize' do
+    it 'should be an Embed::Viewer::File' do
+      expect(request).to receive(:purl_object).and_return(nil)
+      expect(file_viewer).to be_an Embed::Viewer::File
+    end
+  end
+  describe 'self.default_viewer?' do
+    it 'should return true' do
+      expect(Embed::Viewer::File.default_viewer?).to be_truthy
+    end
+  end
+  describe 'self.supported_types' do
+    it 'should return an array of supported types' do
+      expect(Embed::Viewer::File.supported_types).to eq [:media]
+    end
+  end
+  describe 'width' do
+    it 'should return a width' do
+      expect(request).to receive(:purl_object).and_return(nil)
+      expect(file_viewer.width).to_not be nil
+    end
+  end
+  describe 'height' do
+    it 'should return a height' do
+      expect(request).to receive(:purl_object).and_return(nil)
+      expect(file_viewer.height).to_not be nil
+    end
+  end
+  describe 'to_html' do
+    it 'should return the objects title' do
+      stub_purl_response_and_request(file_purl, request)
+      html = Capybara.string(file_viewer.to_html)
+      expect(html).to have_css 'p.sul-embed-title', text: 'File Title'
+    end
+    it 'should return a table of files' do
+      stub_purl_response_and_request(multi_resource_multi_file_purl, request)
+      html = Capybara.string(file_viewer.to_html)
+      expect(html).to have_css 'table'
+      expect(html).to have_css 'tr', count: 4
+      expect(html).to have_css 'td', count: 12
+    end
+  end
+end

--- a/spec/lib/embed_spec.rb
+++ b/spec/lib/embed_spec.rb
@@ -6,12 +6,12 @@ describe Embed do
   describe 'registering viewers' do
     it 'should have an empty registered_viewers array' do
       expect(Embed.registered_viewers).to be_a(Array)
-      expect(Embed.registered_viewers).to be_blank
+      expect(Embed.registered_viewers.count).to eq 1
     end
     it 'should allow viewers to be registered' do
       Embed.register_viewer(TestViewerClass)
       expect(Embed.registered_viewers).to be_a(Array)
-      expect(Embed.registered_viewers).to eq [TestViewerClass]
+      expect(Embed.registered_viewers).to include TestViewerClass
     end
   end
 end

--- a/spec/models/embed/purl_spec.rb
+++ b/spec/models/embed/purl_spec.rb
@@ -38,6 +38,12 @@ describe Embed::PURL do
       end).to be true
     end
   end
+  describe 'all_resource_files' do
+    it 'should return a flattened array of resource files' do
+      stub_purl_response_with_fixture(multi_resource_multi_file_purl)
+      expect(Embed::PURL.new('12345').all_resource_files.count).to eq 4
+    end
+  end
   describe 'PURL::Resource' do
     it 'should get the sequence attribute' do
       stub_purl_response_with_fixture(file_purl)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,6 +4,8 @@ require 'spec_helper'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'fixtures/purl_fixtures'
+require 'capybara/rails'
+require 'capybara/rspec'
 
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -46,4 +48,9 @@ end
 
 def stub_purl_response_with_fixture(fixture)
   expect_any_instance_of(Embed::PURL).to receive(:response).and_return(fixture)
+end
+
+def stub_purl_response_and_request(fixture, request)
+  stub_purl_response_with_fixture(fixture)
+  expect(request).to receive(:purl_object).and_return(Embed::PURL.new('12345'))
 end


### PR DESCRIPTION
Starts to address #12 

Placeholders for `height` and `width` methods until that gets straightened out.  Also adds in a place for feature testing. Format xml tested, but waiting for our JSON html encoding to be figured out before that is tested.
