### PR TITLE
Validate on viewer registration that viewer has not already been registe...

### DIFF
--- a/lib/embed.rb
+++ b/lib/embed.rb
@@ -5,10 +5,24 @@ module Embed
 
   @@registered_viewers = []
   def self.register_viewer(viewer)
+    raise DuplicateViewerRegistration if self.viewer_suppoted_type_already_registered?(viewer)
     @@registered_viewers << viewer
   end
   def self.registered_viewers
     @@registered_viewers
   end
 
+  private
+  def self.viewer_suppoted_type_already_registered?(viewer)
+    viewer.supported_types.any? do |supported_type|
+      @@registered_viewers.any? do |registered_viewer|
+        registered_viewer.supported_types.include?(supported_type)
+      end
+    end
+  end
+  class DuplicateViewerRegistration < StandardError
+    def initialize(msg="A viewer has registered a supported type that another viewer has already registered.")
+      super
+    end
+  end
 end

--- a/spec/lib/embed_spec.rb
+++ b/spec/lib/embed_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
-class TestViewerClass; end
+class TestViewerClass
+  def self.supported_types
+    [:test_view]
+  end
+end
 
 describe Embed do
   describe 'registering viewers' do
@@ -12,6 +16,9 @@ describe Embed do
       Embed.register_viewer(TestViewerClass)
       expect(Embed.registered_viewers).to be_a(Array)
       expect(Embed.registered_viewers).to include TestViewerClass
+    end
+    it 'should raise an error if a viewer registers itself w/ a supported type that is already registered' do
+      expect( ->{ Embed.register_viewer(Embed.registered_viewers.first) } ).to raise_error(Embed::DuplicateViewerRegistration)
     end
   end
 end


### PR DESCRIPTION
...red w/ the same supported type.

Closes #22
