### PR TITLE
Return errors when the resource URL does not have an ID or the object...

### DIFF
--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -21,6 +21,10 @@ class EmbedController < ApplicationController
     render body: e.to_s, status: 404
   end
 
+  rescue_from Embed::PURL::ResourceNotAvailable do |e|
+    render body: e.to_s, status: 404
+  end
+
   rescue_from Embed::Request::InvalidFormat do |e|
     render body: e.to_s, status: 501
   end

--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -53,16 +53,23 @@ module Embed
     def response
       @response ||= begin
         conn = Faraday.new(url: purl_url)
-        conn.get do |request|
+        response = conn.get do |request|
           request.options = {
             timeout: 2,
             open_timeout: 2
           }
-        end.body
+        end
+        raise ResourceNotAvailable unless response.success?
+        response.body
       rescue Faraday::Error::ConnectionFailed => error
         nil
       rescue Faraday::Error::TimeoutError => error
         nil
+      end
+    end
+    class ResourceNotAvailable < StandardError
+      def initialize(msg = "The requested PURL resource was not available")
+        super
       end
     end
     class Resource

--- a/lib/embed/request.rb
+++ b/lib/embed/request.rb
@@ -46,7 +46,7 @@ module Embed
     def url_scheme_is_valid?
       url_schemes.any? do |scheme|
         url =~ scheme
-      end
+      end && url =~ /\/\w+$/
     end
     def validate_format
       fail InvalidFormat unless format_is_valid?

--- a/spec/controllers/embed_controller_spec.rb
+++ b/spec/controllers/embed_controller_spec.rb
@@ -10,12 +10,20 @@ describe EmbedController do
       get :get, url: 'http://www.example.com'
       expect(response.status).to eq(404)
     end
+    it 'has a 404 status code without a druid in the URL' do
+      get :get, url: 'http://purl.stanford.edu/'
+      expect(response.status).to eq(404)
+    end
+    it 'has a 404 status for a PURL object that does not exists' do
+      get :get, url: 'http://purl.stanford.edu/abc123notanobject'
+      expect(response.status).to eq(404)
+    end
     it 'has a 501 status code for an invalid format' do
-      get :get, url: 'http://purl.stanford.edu/', format: 'yml'
+      get :get, url: 'http://purl.stanford.edu/abc123', format: 'yml'
       expect(response.status).to eq(501)
     end
-    pending 'has a 200 status code for a matched url scheme param' do
-      get :get, url: 'http://purl.stanford.edu/ab123cd4567'
+    it 'has a 200 status code for a matched url scheme param' do
+      get :get, url: 'http://purl.stanford.edu/fn662rv4961'
       expect(response.status).to eq(200)
     end
   end

--- a/spec/lib/embed/request_spec.rb
+++ b/spec/lib/embed/request_spec.rb
@@ -29,8 +29,11 @@ describe Embed::Request do
     it 'should raise an error when a URL is provided that does not match the scheme' do
       expect(->{ Embed::Request.new({url: 'http://library.stanford.edu'}) }).to raise_error(Embed::Request::InvalidURLScheme)
     end
+    it 'should raise an error when the scheme matches but there is no valid ID in the URL' do
+      expect(->{ Embed::Request.new({url: 'http://purl.stanford.edu/'}) }).to raise_error(Embed::Request::InvalidURLScheme)
+    end
     it 'should raise an error when an invalid format is requested' do
-      expect(->{ Embed::Request.new({url: 'http://purl.stanford.edu/', format: 'yml'}) }).to raise_error(Embed::Request::InvalidFormat)
+      expect(->{ Embed::Request.new({url: 'http://purl.stanford.edu/abc', format: 'yml'}) }).to raise_error(Embed::Request::InvalidFormat)
     end
   end
 end


### PR DESCRIPTION
... isn't available.

Closes #21 
