### PR TITLE
[PROPOSAL] Use full asset URLs instead of relative paths.

### DIFF
--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -10,7 +10,7 @@ class EmbedController < ApplicationController
   end
 
   def validate_request
-    @embed_request ||= Embed::Request.new(params)
+    @embed_request ||= Embed::Request.new(params, request)
   end
 
   rescue_from Embed::Request::NoURLProvided do |e|

--- a/lib/embed/request.rb
+++ b/lib/embed/request.rb
@@ -1,9 +1,10 @@
 module Embed
   class Request
     include URLSchemes
-    attr_reader :params
-    def initialize(params)
+    attr_reader :params, :rails_request
+    def initialize(params, rails_request=nil)
       @params = params
+      @rails_request = rails_request
       validate
     end
 

--- a/lib/embed/viewer/common_viewer.rb
+++ b/lib/embed/viewer/common_viewer.rb
@@ -6,8 +6,13 @@ module Embed
         @purl_object = request.purl_object
       end
 
-      def asset_path(file)
-        ActionController::Base.helpers.asset_path(file)
+      def asset_url(file)
+        "#{asset_host}#{ActionController::Base.helpers.asset_url(file)}"
+      end
+
+      def asset_host
+        # We should use https but it's not enabled on our servers yet.
+        "http://#{@request.rails_request.host_with_port}"
       end
 
       def to_html

--- a/lib/embed/viewer/file.rb
+++ b/lib/embed/viewer/file.rb
@@ -29,7 +29,7 @@ module Embed
                 end
               end
             end
-            doc.script { doc.text ";jQuery.getScript(\"#{asset_path('file.js')}\");" }
+            doc.script { doc.text ";jQuery.getScript(\"#{asset_url('file.js')}\");" }
           end
         end.to_html
       end

--- a/spec/lib/embed/request_spec.rb
+++ b/spec/lib/embed/request_spec.rb
@@ -15,6 +15,12 @@ describe Embed::Request do
       expect(Embed::Request.new({url: purl}).object_druid).to eq "abc123"
     end
   end
+  describe 'rails_request' do
+    let(:rails_request) { double('rails-request') }
+    it 'should include the rails request (for generating asset URLs in viewer HTML)' do
+      expect(Embed::Request.new({url: purl}, rails_request).rails_request).to eq rails_request
+    end
+  end
   describe 'purl_object' do
     let(:object) { double('purl') }
     it 'should instantiate a PURL object w/ the object druid' do

--- a/spec/lib/embed/viewer/file_spec.rb
+++ b/spec/lib/embed/viewer/file_spec.rb
@@ -36,6 +36,7 @@ describe Embed::Viewer::File do
   describe 'body_html' do
     it 'should return a table of files' do
       stub_purl_response_and_request(multi_resource_multi_file_purl, request)
+      expect(file_viewer).to receive(:asset_host).and_return('http://example.com/')
       html = Capybara.string(file_viewer.to_html)
       expect(html).to have_css 'table'
       expect(html).to have_css 'tr', count: 4


### PR DESCRIPTION
If you include HTML into a different site w/ a relative path to javascript it won't be loaded (since it doesn't exists on the local server).

I'm up for other options for being able to generate the absolute URL to the javascript assets, but I couldn't find anything that wouldn't necessitate requiring the entire routing framework wholesale into all our viewers.
