### PR TITLE
[PROPOSAL] Include sul_variables in css files that need them for precompilation.

### DIFF
--- a/app/assets/stylesheets/modules/media.css.scss
+++ b/app/assets/stylesheets/modules/media.css.scss
@@ -3,6 +3,7 @@
 // Source: http://stubbornella.org/content/?p=497
 // --------------------------------------------------
 
+@import 'sul_variables';
 
 // Common styles
 // -------------------------

--- a/app/assets/stylesheets/modules/utility.css.scss
+++ b/app/assets/stylesheets/modules/utility.css.scss
@@ -1,3 +1,4 @@
+@import 'sul_variables';
 @import 'modules/bootstrap_mixins';
 // From Bootstrap SASS https://github.com/twbs/bootstrap-sass/blob/master/assets/stylesheets/bootstrap/_utilities.scss
 //


### PR DESCRIPTION
Cannot rake asset:precompile on deploy because $namespace isn't available when trying to precompile assets.

I'm guessing mixins will also need this, but I think viewers can decide if they should include it or not.
