### PR TITLE
adds file type icon support based off of mime type of a file

### DIFF
--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -1,0 +1,26 @@
+module Constants
+  FILE_ICON = {
+    'application/msword' => 'fa-file-word-o',
+    'application/pdf' => 'fa-file-pdf-o',
+    'application/vnd.ms-powerpointtd>' => 'fa-file-powerpoint-o',
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation' => 'fa-file-powerpoint-o',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => 'fa-file-word-o',
+    'application/vnd.ms-excel' => 'fa-file-excel-o',
+    'application/x-compressed-zip' => 'fa-file-archive-o',
+    'application/x-gzip' => 'fa-file-archive-o',
+    'application/x-tar' => 'fa-file-archive-o',
+    'application/zip' => 'fa-file-archive-o',
+    'audio/mpeg' => 'fa-file-audio-o',
+    'image/gif' => 'fa-file-image-o',
+    'image/jp2' => 'fa-file-image-o',
+    'image/jpeg' => 'fa-file-image-o',
+    'image/png' => 'fa=file-image-o',
+    'text/plain' => 'fa-file-text-o',
+    'text/x-c++' => 'fa-file-code-o',
+    'video/avi' => 'fa-file-video-o',
+    'video/mp4' => 'fa-file-video-o',
+    'video/msvideo' => 'fa-file-video-o',
+    'video/quicktime' => 'fa-file-video-o',
+    'video/x-msvideo' => 'fa-file-video-o'
+  }
+end

--- a/lib/embed.rb
+++ b/lib/embed.rb
@@ -1,4 +1,5 @@
 module Embed
+  require 'constants'
   require 'embed/url_schemes'
   require 'embed/request'
   require 'embed/response'

--- a/lib/embed/viewer/file.rb
+++ b/lib/embed/viewer/file.rb
@@ -28,7 +28,7 @@ module Embed
                         doc.text file_count += 1
                       end
                       doc.div(class: 'sul-embed-media-object pull-left') do
-                        doc.i(class: 'fa fa-file fa-3x')
+                        doc.i(class: "fa fa-3x #{file_type_icon(file.mimetype)}")
                       end
                       doc.div(class: 'sul-embed-media-body') do
                         doc.div(class: 'sul-embed-media-heading') do
@@ -54,6 +54,14 @@ module Embed
             doc.script { doc.text ";jQuery.getScript(\"#{asset_url('file.js')}\");" }
           end
         end.to_html
+      end
+
+      def file_type_icon(mimetype)
+        if Constants::FILE_ICON[mimetype].nil?
+          'fa-file-o'
+        else
+          Constants::FILE_ICON[mimetype]
+        end
       end
 
       def pretty_filesize(size)

--- a/spec/lib/embed/viewer/file_spec.rb
+++ b/spec/lib/embed/viewer/file_spec.rb
@@ -41,4 +41,14 @@ describe Embed::Viewer::File do
       expect(html).to have_css '.sul-embed-file-list'
     end
   end
+  describe 'file_type_icon' do
+    it 'should return default file icon if mimetype is not recognized' do
+      expect(request).to receive(:purl_object).and_return(nil)
+      expect(file_viewer.file_type_icon('application/null')).to eq 'fa-file-o'
+    end
+    it 'should return translated file icon for recognized mime type' do
+      expect(request).to receive(:purl_object).and_return(nil)
+      expect(file_viewer.file_type_icon('application/zip')).to eq 'fa-file-archive-o'
+    end
+  end
 end


### PR DESCRIPTION
Closes #51 

Adds the most common file type translations to font awesome file icons.

![screen shot 2014-10-14 at 11 31 07 am](https://cloud.githubusercontent.com/assets/1656824/4634439/4c0165a2-53d0-11e4-97d9-11f1fff75932.png)
