### PR TITLE
Add logic for dynamically injecting markup into header.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,24 @@ The file that the class is defined in (or your preferred method) should register
     => #<Embed::Request>
     $ viewer.new(request).to_html
     => # your body_html with header and footer html
+
+### Adding Header Tools
+
+Viewers can dynamically add their own elements to the header, change element order, or remove elements from the viewer.  In order to add your own tools to the header you need to append a method (represented by a symbol) to the `header_tools_logic` array.
+
+    def initialize(*args)
+      super
+      header_tools_logic << :render_demo_tool
+    end
+
+The method added to the `header_tools_logic` array should return false if the tool should not display or return a symbol representing a method that will return HTML given the `Nokigiri::HTML` document context.
+
+    def render_demo_tool
+      return false if should_render_demo_tool?
+      :demo_tool_html
+    end
+    def domo_tool_html(document)
+      document.div(class: 'sul-embed-demo-tool') do
+        document.text("ToolText")
+      end
+    end

--- a/app/assets/javascripts/modules/file_search.js
+++ b/app/assets/javascripts/modules/file_search.js
@@ -12,12 +12,8 @@
 
     return {
       init: function() {
-        this.showSearchInput();
         mediaObjectList = new List("sul-embed-object", options);
         return mediaObjectList;
-      },
-      showSearchInput: function() {
-        $(".sul-embed-search").removeClass("sul-embed-hidden");
       }
     };
   })();

--- a/app/views/pages/sandbox.html.erb
+++ b/app/views/pages/sandbox.html.erb
@@ -73,6 +73,9 @@
     <label for="">&maxwidth=</label><input type="text" class="max-width" size="4" value="">
     <label for="">&maxheight=</label><input type="text" class="max-height" size="4" value="">
     <br>
+    <label for="hide-title">Hide title?</label> <input type="checkbox" id="hide-title" class="hide-title" />
+    <label for="hide-search">Hide search?</label> <input type="checkbox" id="hide-search" class="hide-search" />
+    <br>
     <input type="button" class="btn-render" value="Embed">
   </form>
 
@@ -111,6 +114,8 @@
       function isValidUrl() {
         var apiEndpoint = $.trim($('.api-endpoint').val()),
             urlScheme = $.trim($('.url-scheme').val()),
+            hideTitle = $('.hide-title').is(':checked'),
+            hideSearch = $('.hide-search').is(':checked'),
             maxWidth = parseInt($('.max-width').val(), 10),
             maxHeight = parseInt($('.max-height').val(), 10);
 
@@ -119,6 +124,8 @@
         if (apiEndpoint !== "" && urlScheme !== "") {
           url = apiEndpoint + "/?url=" + urlScheme + "&format=" + format;
 
+          if (hideTitle) url += "&hide_title=true";
+          if (hideSearch) url += "&hide_search=true";
           if (!isNaN(maxWidth)) url += "&maxwidth=" + maxWidth;
           if (!isNaN(maxHeight)) url += "&maxheight=" + maxHeight;
 

--- a/lib/embed/request.rb
+++ b/lib/embed/request.rb
@@ -24,6 +24,10 @@ module Embed
       params[:maxwidth]
     end
 
+    def hide_title?
+      params[:hide_title] && params[:hide_title] == "true"
+    end
+
     def object_druid
       url[/\w*$/]
     end

--- a/lib/embed/viewer/file.rb
+++ b/lib/embed/viewer/file.rb
@@ -3,6 +3,11 @@ module Embed
     class File
       include Embed::Viewer::CommonViewer
 
+      def initialize(*args)
+        super
+        header_tools_logic << :file_search_logic
+      end
+
       def self.default_viewer?
         true
       end
@@ -66,6 +71,22 @@ module Embed
 
       def self.supported_types
         [:media]
+      end
+
+      private
+
+      def file_search_logic
+        return false if @request.params[:hide_search] && @request.params[:hide_search] == 'true'
+        :file_search_html
+      end
+
+      def file_search_html(doc)
+        doc.div(class: 'sul-embed-header-tools') do
+          doc.div(class: 'sul-embed-search') do
+            doc.label(for: 'sul-embed-search-input') { doc.text 'Search this list' }
+            doc.input(class: 'sul-embed-search-input', id: 'sul-embed-search-input')
+          end
+        end
       end
     end
   end

--- a/spec/features/feature_testing_spec.rb
+++ b/spec/features/feature_testing_spec.rb
@@ -8,8 +8,16 @@ describe 'feature testing of viewers', js: true do
       send_embed_response
       expect(page).to have_css('.sul-embed-container')
       expect(page).to have_css('.sul-embed-header')
+      expect(page).to have_css('.sul-embed-header-title')
       expect(page).to have_css('.sul-embed-body')
       expect(page).to have_css('.sul-embed-footer')
+    end
+    it 'should hide the title when requested' do
+      stub_purl_response_with_fixture(file_purl)
+      visit_sandbox
+      check("Hide title?")
+      click_button "Embed"
+      expect(page).to_not have_css('.sul-embed-header-title')
     end
   end
   describe 'file viewer' do

--- a/spec/features/file_search_spec.rb
+++ b/spec/features/file_search_spec.rb
@@ -9,4 +9,11 @@ describe 'file viewer search bar', js: true do
     fill_in 'sul-embed-search-input', with: 'test'
     expect(page).to_not have_css('.sul-embed-count')
   end
+  it 'should hide the search box when requested' do
+    stub_purl_response_with_fixture(file_purl)
+    visit_sandbox
+    check("Hide search?")
+    click_button "Embed"
+    expect(page).to_not have_css('.sul-embed-search')
+  end
 end

--- a/spec/lib/embed/request_spec.rb
+++ b/spec/lib/embed/request_spec.rb
@@ -10,6 +10,14 @@ describe Embed::Request do
       expect(Embed::Request.new({url: purl, format: 'xml'}).format).to eq 'xml'
     end
   end
+  describe 'hide_title?' do
+    it 'should return false by default' do
+      expect(Embed::Request.new({url: purl}).hide_title?).to be_falsy
+    end
+    it 'should return true if the incoming request asked to hide the title' do
+      expect(Embed::Request.new({url: purl, hide_title: 'true'}).hide_title?).to be_truthy
+    end
+  end
   describe 'object_druid' do
     it 'should parse the druid out of the incoming URL parameter' do
       expect(Embed::Request.new({url: purl}).object_druid).to eq "abc123"

--- a/spec/lib/embed/viewer/common_viewer_spec.rb
+++ b/spec/lib/embed/viewer/common_viewer_spec.rb
@@ -8,9 +8,18 @@ describe Embed::Viewer::CommonViewer do
 
   describe 'header_html' do
     it 'should return the objects title' do
+      expect(request).to receive(:params).at_least(:once).and_return({})
+      expect(request).to receive(:hide_title?).at_least(:once).and_return(false)
       stub_purl_response_and_request(file_purl, request)
       html = Capybara.string(file_viewer.header_html)
-      expect(html).to have_css 'div.sul-embed-header', text: 'File Title'
+      expect(html).to have_css '.sul-embed-header-title', text: 'File Title'
+    end
+    it 'should not return the object title if the consumer requested to hide it' do
+      expect(request).to receive(:params).at_least(:once).and_return({})
+      expect(request).to receive(:hide_title?).at_least(:once).and_return(true)
+      stub_request(request)
+      html = Capybara.string(file_viewer.header_html)
+      expect(html).to_not have_css '.sul-embed-header-title'
     end
   end
   describe 'footer_html' do

--- a/spec/lib/embed/viewer/file_spec.rb
+++ b/spec/lib/embed/viewer/file_spec.rb
@@ -33,8 +33,16 @@ describe Embed::Viewer::File do
       expect(file_viewer.height).to_not be nil
     end
   end
+  describe 'header tools' do
+    it 'should include the search in the header tools' do
+      stub_request(request)
+      expect(file_viewer.send(:header_tools_logic)).to include(:file_search_logic)
+    end
+  end
   describe 'body_html' do
     it 'should return a table of files' do
+      expect(request).to receive(:params).at_least(:once).and_return({})
+      expect(request).to receive(:hide_title?).at_least(:once).and_return(false)
       stub_purl_response_and_request(multi_resource_multi_file_purl, request)
       expect(file_viewer).to receive(:asset_host).at_least(:twice).and_return('http://example.com/')
       html = Capybara.string(file_viewer.to_html)

--- a/spec/lib/embed/viewer/image_spec.rb
+++ b/spec/lib/embed/viewer/image_spec.rb
@@ -46,6 +46,7 @@ describe Embed::Viewer::Image do
   end
   describe 'body_html' do
     it 'should return image(s) list' do
+      expect(request).to receive(:hide_title?).at_least(:once).and_return(false)
       stub_purl_response_and_request(image_purl, request)
       expect(image_viewer).to receive(:asset_host).at_least(:twice).and_return('http://example.com/')
       html = Capybara.string(image_viewer.to_html)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,10 +66,18 @@ def stub_request(request)
   expect(request).to receive(:purl_object).and_return(Embed::PURL.new('12345'))
 end
 
-def send_embed_response
+def visit_sandbox
   visit page_path(id: 'sandbox')
+end
+
+def fill_in_default_sandbox_form
   fill_in 'api-endpoint', with: embed_path
   fill_in 'url-scheme', with: 'http://purl.stanford.edu/ab123cd4567'
+end
+
+def send_embed_response
+  visit_sandbox
+  fill_in_default_sandbox_form
   click_button 'Embed'
   expect(page).to have_css('.sul-embed-container')
 end


### PR DESCRIPTION
Closes #64 
Closes #73 
Closes #75 

Make title and file search box configurable (visible by default).
#### Default

![all](https://cloud.githubusercontent.com/assets/96776/4638653/78021e80-53fd-11e4-8ea3-3bae7dc6890e.png)
#### All configured to be hidden

![none](https://cloud.githubusercontent.com/assets/96776/4638657/7a7129cc-53fd-11e4-959a-ac7c92daedaa.png)
#### Title only

![title-only](https://cloud.githubusercontent.com/assets/96776/4638655/7a4a3e5c-53fd-11e4-9d28-aadb974bfc8d.png)
#### Search only

![search-only](https://cloud.githubusercontent.com/assets/96776/4638658/7a73079c-53fd-11e4-9327-e8a544a28539.png)
