### PR TITLE
[PROPOSAL] Handle flash of unstyled text.

### DIFF
--- a/app/assets/javascripts/file.js
+++ b/app/assets/javascripts/file.js
@@ -1,7 +1,9 @@
 //= require modules/css_injection
 //= require vendor/list.min
 //= require modules/file_search
+//= require modules/common_viewer_behavior
 
 CssInjection.injectFontAwesome();
 CssInjection.appendToHead();
+CommonViewerBehavior.showViewer();
 FileSearch.init();

--- a/app/assets/javascripts/image.js
+++ b/app/assets/javascripts/image.js
@@ -1,8 +1,9 @@
 //= require vendor/openseadragon.min
 //= require modules/css_injection
 //= require modules/jquery.embedOsdViewer
+//= require modules/common_viewer_behavior
 
 CssInjection.injectFontAwesome();
 CssInjection.appendToHead();
-
+CommonViewerBehavior.showViewer();
 $('.sul-embed-osd').embedOsdViewer();

--- a/app/assets/javascripts/modules/common_viewer_behavior.js
+++ b/app/assets/javascripts/modules/common_viewer_behavior.js
@@ -1,0 +1,15 @@
+// Module handles common viewer behaviors
+
+(function( global ) {
+  var Module = (function() {
+
+    return {
+      showViewer: function() {
+        $("#sul-embed-object").show();
+      }
+    };
+  })();
+
+  global.CommonViewerBehavior = Module;
+
+})( this );

--- a/lib/embed/viewer/common_viewer.rb
+++ b/lib/embed/viewer/common_viewer.rb
@@ -20,7 +20,7 @@ module Embed
       end
 
       def to_html
-        '<div class="sul-embed-container" id="sul-embed-object">' << header_html << body_html << footer_html << '</div>'
+        '<div class="sul-embed-container" id="sul-embed-object" style="display:none;">' << header_html << body_html << footer_html << '</div>'
       end
 
       def header_html

--- a/spec/lib/embed/viewer/common_viewer_spec.rb
+++ b/spec/lib/embed/viewer/common_viewer_spec.rb
@@ -29,10 +29,11 @@ describe Embed::Viewer::CommonViewer do
       expect(file_viewer).to receive(:header_html).and_return('<div class="sul-embed-header"></div>')
       expect(file_viewer).to receive(:footer_html).and_return('<div class="sul-embed-footer"></div>')
       html = Capybara.string(file_viewer.to_html)
-      expect(html).to have_css 'div.sul-embed-container'
-      expect(html).to have_css 'div.sul-embed-body'
-      expect(html).to have_css 'div.sul-embed-header'
-      expect(html).to have_css 'div.sul-embed-footer'
+      # visible false because we display:none the container until we've loaded the CSS.
+      expect(html).to have_css 'div.sul-embed-container', visible: false
+      expect(html).to have_css 'div.sul-embed-body', visible: false
+      expect(html).to have_css 'div.sul-embed-header', visible: false
+      expect(html).to have_css 'div.sul-embed-footer', visible: false
     end
   end
 end

--- a/spec/lib/embed/viewer/file_spec.rb
+++ b/spec/lib/embed/viewer/file_spec.rb
@@ -38,7 +38,8 @@ describe Embed::Viewer::File do
       stub_purl_response_and_request(multi_resource_multi_file_purl, request)
       expect(file_viewer).to receive(:asset_host).at_least(:twice).and_return('http://example.com/')
       html = Capybara.string(file_viewer.to_html)
-      expect(html).to have_css '.sul-embed-file-list'
+      # visible false because we display:none the container until we've loaded the CSS.
+      expect(html).to have_css '.sul-embed-file-list', visible: false
     end
   end
   describe 'file_type_icon' do

--- a/spec/lib/embed/viewer/image_spec.rb
+++ b/spec/lib/embed/viewer/image_spec.rb
@@ -49,8 +49,9 @@ describe Embed::Viewer::Image do
       stub_purl_response_and_request(image_purl, request)
       expect(image_viewer).to receive(:asset_host).at_least(:twice).and_return('http://example.com/')
       html = Capybara.string(image_viewer.to_html)
-      expect(html).to have_css '.sul-embed-image-list'
-      expect(html).to have_css '#osd-Title_of_the_image.sul-embed-osd'
+      # visible false because we display:none the container until we've loaded the CSS.
+      expect(html).to have_css '.sul-embed-image-list', visible: false
+      expect(html).to have_css '#osd-Title_of_the_image.sul-embed-osd', visible: false
 
       within '.sul-embed-osd-toolbar' do
         expect(html).to have_css '#osd-Title_of_the_image-zoom-in.fa.fa-plus-circle'


### PR DESCRIPTION
Closes #49 

Add CommonViewerBehavior jQuery module w/ a showViewer function called by both file and image viewers.

We add an explicit display: none to the container and then add a function (`CommonViewerBehavior.showViewer()`) to toggle the viewer on after we've appended the the stylesheet to the head of the document.
