### PR TITLE
Add data and title attributes to Stanford Only files.

### DIFF
--- a/lib/embed/viewer/file.rb
+++ b/lib/embed/viewer/file.rb
@@ -28,7 +28,7 @@ module Embed
               doc.ul(class: 'sul-embed-media-list') do
                 @purl_object.contents.each do |resource|
                   resource.files.each do |file|
-                    doc.li(class: 'sul-embed-media') do
+                    doc.li(class: 'sul-embed-media', title: tooltip_text(file), 'data-sul-embed-tooltip' => file_is_stanford_only?(file)) do
                       doc.div(class: 'sul-embed-count pull-left') do
                         doc.text file_count += 1
                       end
@@ -40,7 +40,7 @@ module Embed
                         end
                       end
                       doc.div(class: 'sul-embed-media-body') do
-                        doc.div(class: 'sul-embed-media-heading') do
+                        doc.div(class: "sul-embed-media-heading #{'stanford-only' if file_is_stanford_only?(file)}") do
                           doc.a(href: file_url(file.title)) do
                             doc.text file.title
                           end
@@ -111,6 +111,14 @@ module Embed
 
       private
 
+      def tooltip_text(file)
+        if file_is_stanford_only?(file)
+          ["Available only to Stanford-affiliated patrons", @purl_object.embargo_release_date].compact.join(" until ")
+        end
+      end
+      def file_is_stanford_only?(file)
+        @purl_object.embargoed? || file.stanford_only?
+      end
       def file_search_logic
         return false if @request.params[:hide_search] && @request.params[:hide_search] == 'true'
         :file_search_html

--- a/spec/lib/embed/viewer/file_spec.rb
+++ b/spec/lib/embed/viewer/file_spec.rb
@@ -60,4 +60,14 @@ describe Embed::Viewer::File do
       expect(file_viewer.file_type_icon('application/zip')).to eq 'fa-file-archive-o'
     end
   end
+  describe 'embargo/Stanford only' do
+    it 'does something' do
+      stub_purl_response_and_request(embargoed_purl, request)
+      expect(file_viewer).to receive(:asset_host).at_least(:twice).and_return('http://example.com')
+      html = Capybara.string(file_viewer.body_html)
+      expect(html).to have_css('li[data-sul-embed-tooltip="true"]')
+      expect(html).to have_css("li[title='Available only to Stanford-affiliated patrons until #{(Time.now + 1.month).strftime('%Y-%m-%d')}']")
+      expect(html).to have_css('.sul-embed-media-heading.stanford-only')
+    end
+  end
 end


### PR DESCRIPTION
Begins work on #62. Still need to add popover/tooltip styling/behavior but this adds the data and attributes necessary to make that happen. (implemented as a simple title attribute currently)

In the future we can instantiate the tooltip based on the `data-sul-embed-tooltip` attribute "true":

```
$('[data-sul-embed-tooltip="true"]').whateverTooltipPlugin();
```
### Stanford Only Example (tn148pd5374)

![tn148pd5374](https://cloud.githubusercontent.com/assets/96776/4670462/5d5da8bc-5577-11e4-82e8-e893744c4258.png)
### Embargo Example (wb383gy5311)

![wb383gy5311](https://cloud.githubusercontent.com/assets/96776/4670463/5d6207fe-5577-11e4-927b-569c0dc213be.png)
