### PR TITLE
sets max number of files to 99999

### DIFF
--- a/app/assets/javascripts/modules/file_search.js
+++ b/app/assets/javascripts/modules/file_search.js
@@ -7,6 +7,7 @@
       itemCount = $("<div class='sul-embed-item-count'></div>"),
       options = {
         listClass: "sul-embed-media-list",
+        page: 99999,
         searchClass: "sul-embed-search-input",
         valueNames: [ "sul-embed-media-heading", "sul-embed-description" ]
       };


### PR DESCRIPTION
I could not reproduce #90 exactly but I believe this solves the issue. The list.js plugin was maxing out the number of items to be displayed at 200 (for performance http://listjs.com/docs/options). I set the max to 99999. I don't think there is an unlimited option but I hope this should take care of the upper max issue.

Open to other suggestions here. :open_hands: 
