### PR TITLE
updates project to capybara-webkit for js testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,9 @@ env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 
-script: bundle exec rspec spec
+before_install:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3
+
+script: xvfb-run bundle exec rspec spec

--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,8 @@ gem 'therubyracer'
 
 group :development, :test do
   gem 'rspec-rails', '~> 3.0.0'
-  gem 'capybara'
-  gem 'poltergeist'
+  gem 'capybara', '~> 2.4.4'
+  gem 'capybara-webkit'
 end
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,13 +62,15 @@ GEM
     capistrano-rvm (0.1.1)
       capistrano (~> 3.0)
       sshkit (~> 1.2)
-    capybara (2.3.0)
+    capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    cliver (0.3.2)
+    capybara-webkit (1.3.0)
+      capybara (>= 2.0.2, < 2.5.0)
+      json
     colorize (0.7.3)
     diff-lcs (1.2.5)
     dor-rights-auth (1.0.0)
@@ -96,11 +98,6 @@ GEM
     net-ssh (2.9.1)
     nokogiri (1.6.3.1)
       mini_portile (= 0.6.0)
-    poltergeist (1.5.1)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      multi_json (~> 1.0)
-      websocket-driver (>= 0.2.0)
     polyglot (0.3.5)
     rack (1.5.2)
     rack-test (0.6.2)
@@ -176,7 +173,6 @@ GEM
     uglifier (2.5.3)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
-    websocket-driver (0.3.4)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -188,14 +184,14 @@ DEPENDENCIES
   capistrano-bundler
   capistrano-rails
   capistrano-rvm
-  capybara
+  capybara (~> 2.4.4)
+  capybara-webkit
   dor-rights-auth
   faraday
   filesize
   high_voltage
   lyberteam-capistrano-devel!
   nokogiri
-  poltergeist
   rails (= 4.1.5)
   rails-api
   rails_config

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,12 +6,8 @@ require 'rspec/rails'
 require 'fixtures/purl_fixtures'
 require 'capybara/rails'
 require 'capybara/rspec'
-require 'capybara/poltergeist'
 
-Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, {timeout: 60})
-end
-Capybara.javascript_driver = :poltergeist
+Capybara.javascript_driver = :webkit
 
 Capybara.default_wait_time = 10
 


### PR DESCRIPTION
Removes `poltergeist` for js testing and instead moves to capybara-webkit. In a test this is a more reliable option and I am not getting the random phantom js errors. Capybara-webkit is maintained by Thoughtbot and seems to be well supported (more so than poltergeist).

To use you need to have qt installed: https://github.com/thoughtbot/capybara-webkit/wiki/Installing-Qt-and-compiling-capybara-webkit

```
brew update
brew install qt
```
