### PR TITLE
Set max-width on preview image so it doesn't cause scroll-bars.

### DIFF
--- a/app/assets/stylesheets/file.css.scss
+++ b/app/assets/stylesheets/file.css.scss
@@ -47,6 +47,9 @@
   .#{$namespace}-preview {
     @include padding-top;
     text-align: center;
+    img {
+      max-width: 100%;
+    }
   }
 
   .#{$namespace}-preview-toggle {


### PR DESCRIPTION
### Preview on thin embed
#### Before

![preview-thin-before](https://cloud.githubusercontent.com/assets/96776/4832055/31db155e-5f99-11e4-92bc-870a10a0667b.png)
#### After

![preview-thin-after](https://cloud.githubusercontent.com/assets/96776/4832054/31da9796-5f99-11e4-8ef6-c59355a30a1e.png)
