### PR TITLE
Filters non-image files for image viewer

### DIFF
--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -150,6 +150,9 @@ module Embed
         def previewable?
           preview_types.include?(mimetype)
         end
+        def is_image?
+          mimetype =~ /image\/jp2/i
+        end
         def size
           @file.attributes['size'].try(:value)
         end
@@ -179,4 +182,3 @@ module Embed
     end
   end
 end
-

--- a/lib/embed/viewer/image.rb
+++ b/lib/embed/viewer/image.rb
@@ -28,11 +28,13 @@ module Embed
 
         contents.each do |resource|
           resource.files.each do |image|
-            data.push({
-              id: iiif_image_id(image),
-              height: image.image_height,
-              width: image.image_width
-            })
+            if image.is_image?
+              data.push({
+                id: iiif_image_id(image),
+                height: image.image_height,
+                width: image.image_width
+              })
+            end
           end
         end
 

--- a/spec/models/embed/purl_spec.rb
+++ b/spec/models/embed/purl_spec.rb
@@ -111,6 +111,16 @@ describe Embed::PURL do
           expect(Embed::PURL.new('12345').contents.first.files.first).to_not be_previewable
         end
       end
+      describe 'is_image?' do
+        it 'should return true if the mimetype of the file is an image' do
+          stub_purl_response_with_fixture(image_purl)
+          expect(Embed::PURL.new('12345').contents.first.files.first).to be_is_image
+        end
+        it 'should return false if the mimetype of the file is not an image' do
+          stub_purl_response_with_fixture(file_purl)
+          expect(Embed::PURL.new('12345').contents.first.files.first).to_not be_is_image
+        end
+      end
       describe 'rights' do
         describe 'stanford_only?' do
           it 'should identify stanford_only objects' do


### PR DESCRIPTION
Closes #150 

Example druid - tm910qj8897

![image](https://cloud.githubusercontent.com/assets/302258/4929328/17c54d0c-6551-11e4-99ce-9aed30b89068.png)
