### PR TITLE
Set max-age for production.

### DIFF
--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -1,5 +1,6 @@
 class EmbedController < ApplicationController
   before_action :validate_request
+  before_filter :set_cache
   before_filter :allow_iframe, only: :iframe
 
   def get
@@ -35,6 +36,13 @@ class EmbedController < ApplicationController
   end
 
   private
+
+  def set_cache
+    if Rails.env.production?
+      request.session_options[:skip] = true
+      response.headers['Cache-Control'] = "public, max-age=#{Settings.cache_life}"
+    end
+  end
 
   def allow_iframe
     response.headers.delete('X-Frame-Options')

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,6 +22,8 @@ Rails.application.configure do
   # Disable Rails's static asset server (Apache or nginx will already do this).
   config.serve_static_assets = false
 
+  config.static_cache_control = "public, max-age=#{1.year.to_i}"
+
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,1 +1,2 @@
 static_assets_url: 'http://embed.stanford.edu/assets/'
+cache_life: <%= 1.week.to_s %>


### PR DESCRIPTION
This is settable in our rails_config so we can change it whenever we want in the symlinked settings files.

The assets are fingerprinted on deploy, so I'm just setting a far-out expire date.
