### PR TITLE
Adds download panel for images

### DIFF
--- a/app/assets/javascripts/image.js
+++ b/app/assets/javascripts/image.js
@@ -1,5 +1,6 @@
 //= require openseadragon/built-openseadragon/openseadragon/openseadragon.min
 //= require modules/css_injection
+//= require modules/download_panel
 //= require modules/jquery.iiifOsdViewer
 //= require modules/common_viewer_behavior
 //= require modules/popup_panels

--- a/app/assets/javascripts/modules/download_panel.js
+++ b/app/assets/javascripts/modules/download_panel.js
@@ -1,0 +1,135 @@
+(function(global) {
+  global.sulEmbedDownloadPanel = (function() {
+     var $downloadOptions = $('.sul-embed-download-options'),
+         $btnDownloadPanel = $('.sul-embed-footer-tool[data-toggle="sul-embed-download-panel"]'),
+         sizes = $downloadOptions.data('download-sizes'),
+         sizeLevelMapping = { full: 0, xlarge: -1, large: -2, medium: -3, small: -4 },
+         djatokaBaseResolution = 92,
+         defaultSize = 400,
+         imageData,
+         fullFileSize,
+         fullWidth,
+         fullHeight,
+         stacksUrl,
+         druid,
+         imageId,
+         levels;
+
+    function init(data) {
+      imageData = data;
+      setProperties();
+      updateDownloadLinks();
+    }
+
+    function updateDownloadLinks() {
+      $.each(sizes, function(index, size) {
+        var dimensions = getDimensionsForSize(size),
+            downloadLink = [stacksUrl, 'image', druid, imageId + '_' + size + '?action=download'].join('/');
+
+        $downloadOptions.find('.sul-embed-download-' + size + '-dimensions').html(dimensions);
+
+        if (size !== 'default') {
+          $downloadOptions.find('.sul-embed-download-' + size + ' a').attr('href', downloadLink);
+        }
+      });
+    }
+
+    function setProperties() {
+      var parts = imageData['image-id'].split('%252F');
+
+      druid = parts[0];
+      imageId = parts[1];
+      fullWidth = parseInt(imageData['iov-width'], 10);
+      fullHeight = parseInt(imageData['iov-height'], 10);
+      fullFileSize = parseInt(imageData['iov-file-size'], 10);
+      stacksUrl = $downloadOptions.data('stacks-url');
+      levels = jp2Levels(fullWidth, fullHeight);
+    }
+
+    function getDimensionsForSize(size) {
+      var levelDelta = 0,
+          dimensions = { width: 0, height: 0 };
+
+      if (size === 'default') {
+        dimensions = getDimensionsForDefaultSize();
+      } else {
+        levelDelta = levels - getLevelForSize(size);
+        dimensions.width = Math.round(fullWidth / Math.pow(2, levelDelta));
+        dimensions.height = Math.round(fullHeight / Math.pow(2, levelDelta));
+      }
+
+      return [dimensions.width, 'x', dimensions.height].join(' ');
+    }
+
+    function getDimensionsForDefaultSize() {
+      var aspectRatio = (fullWidth/fullHeight).toPrecision(2),
+          width = defaultSize,
+          height = 0;
+
+      if (fullHeight > fullWidth) {
+        height = defaultSize;
+        width = Math.round(height * aspectRatio);
+      } else {
+        height = Math.round(width / aspectRatio);
+      }
+
+      return { width: width, height: height };
+    }
+
+    function getLevelForSize(size) {
+      var level = 0;
+
+      if (size !== 'default' && typeof sizeLevelMapping[size] !== 'undefined') {
+        level = levels + sizeLevelMapping[size];
+      }
+
+      return level;
+    }
+
+    function jp2Levels(width, height) {
+      var levels = 1;
+          longestSideDimension = Math.max(width, height);
+
+      while (longestSideDimension >= djatokaBaseResolution) {
+        ++levels;
+        longestSideDimension = Math.round(longestSideDimension / 2);
+      }
+
+      return levels;
+    }
+
+    function formatBytes(bytes) {
+      var k = 1000,
+          sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'],
+          i = Math.floor(Math.log(bytes) / Math.log(k));
+
+       if (bytes === 0) return '0 Byte';
+       return (bytes / Math.pow(k, i)).toPrecision(3) + ' ' + sizes[i];
+    }
+
+    function disableDownloadButton() {
+      $btnDownloadPanel
+        .prop('disabled', true)
+        .text(' No image selected');
+    }
+
+    function enableDownloadButton() {
+      $btnDownloadPanel
+        .prop('disabled', false)
+        .text('');
+    }
+
+
+    return {
+      update: function(data) {
+        enableDownloadButton();
+        init(data);
+      },
+
+      disableDownload: function() {
+        disableDownloadButton();
+      }
+    };
+  }());
+
+})(this);

--- a/app/assets/javascripts/modules/jquery.iiifOsdViewer.js
+++ b/app/assets/javascripts/modules/jquery.iiifOsdViewer.js
@@ -52,13 +52,17 @@
           config.totalImages += collection.images.length || 0;
         });
 
+        $.subscribe('iov-jump-to-list-view', jumpTo('list'));
+        $.subscribe('iov-list-view-load', updateDownloadPanel());
+        $.subscribe('iov-gallery-view-load', disableDownload());
+        $.subscribe('iov-horizontal-view-load', disableDownload());
+
         addMenuBar();
         attachEvents();
         initializeViews();
         views[config.currentView].load();
         $selectViews.val(config.currentView);
       }
-
 
       function addMenuBar() {
         if (config.totalImages > 1) {
@@ -96,6 +100,22 @@
           views[view].jumpToImg(hashCode);
           $selectViews.val(view);
           config.currentView = view;
+        }
+      }
+
+      function updateDownloadPanel() {
+        return function(_, hashCode) {
+          var $imgItem = $('.iov-list-view-id-' + hashCode);
+
+          if ($imgItem.length) {
+            sulEmbedDownloadPanel.update($imgItem.data());
+          }
+        }
+      }
+
+      function disableDownload() {
+        return function(_) {
+          sulEmbedDownloadPanel.disableDownload();
         }
       }
 
@@ -160,8 +180,6 @@
         return (document.fullscreenElement || document.mozFullScreenElement || document.webkitFullscreenElement);
       }
 
-      $.subscribe('iov-jump-to-list-view', jumpTo('list'));
-
     });
 
     function hashCode(str) {
@@ -218,7 +236,13 @@
 
             $imgItem
               .addClass('iov-list-view-id-' + hashCode(image.id))
-              .data('iiif-info-url', infoUrl);
+              .data({
+                'iov-list-view-id': hashCode(image.id),
+                'image-id': image.id,
+                'iov-height': image.height,
+                'iov-width': image.width,
+                'iiif-info-url': infoUrl
+              });
 
             $thumbsList.append($imgItem.append('<a href="javascript:;"><img src="' + imgUrl + '"></a> '));
 
@@ -228,6 +252,8 @@
               $self.addClass('iov-list-view-thumb-selected');
               $self.siblings().removeClass('iov-list-view-thumb-selected');
               updateView($self);
+
+              $.publish('iov-list-view-load', $imgItem.data('iov-list-view-id'));
             });
           });
         });
@@ -366,6 +392,7 @@
         },
 
         load: function() {
+          $.publish('iov-gallery-view-load');
           $galleryView.show();
         },
 
@@ -455,6 +482,7 @@
         },
 
         load: function() {
+          $.publish('iov-horizontal-view-load');
           $horizontalView.show();
           loadHorizontalViewImages();
         },

--- a/app/assets/stylesheets/modules/popup_panels.css.scss
+++ b/app/assets/stylesheets/modules/popup_panels.css.scss
@@ -61,6 +61,12 @@
           }
         }
       }
+
+      &.#{$namespace}-download-panel {
+        .#{$namespace}-download-options {
+          margin: 20px 10px;
+        }
+      }
     }
   }
 

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -23,4 +23,7 @@ module Constants
     'video/quicktime' => 'fa-file-video-o',
     'video/x-msvideo' => 'fa-file-video-o'
   }
+  IMAGE_DOWNLOAD_SIZES = [
+    'default', 'small', 'medium', 'large', 'xlarge', 'full'
+  ]
 end

--- a/lib/embed/viewer/common_viewer.rb
+++ b/lib/embed/viewer/common_viewer.rb
@@ -28,7 +28,7 @@ module Embed
       end
 
       def to_html
-        "<div class='sul-embed-container' id='sul-embed-object' style='display:none; #{container_styles}'>" << header_html << body_html << metadata_html << embed_this_html << footer_html << '</div>'
+        "<div class='sul-embed-container' id='sul-embed-object' style='display:none; #{container_styles}'>" << header_html << body_html << metadata_html << embed_this_html << download_html << footer_html << '</div>'
       end
 
       def header_html
@@ -48,6 +48,9 @@ module Embed
               end
               unless @request.hide_embed_this?
                 doc.button(class: 'sul-embed-footer-tool sul-embed-btn sul-embed-btn-xs sul-embed-btn-default fa fa-share-alt', 'data-toggle' => 'sul-embed-embed-this-panel')
+              end
+              if self.is_a?(Embed::Viewer::Image)
+                doc.button(class: 'sul-embed-footer-tool sul-embed-btn sul-embed-btn-xs sul-embed-btn-default fa fa-download', 'data-toggle' => 'sul-embed-download-panel')
               end
             end
             doc.div(class: 'sul-embed-purl-link') do
@@ -158,6 +161,10 @@ module Embed
         else
           ''
         end
+      end
+
+      def download_html
+        ''
       end
 
       private

--- a/lib/embed/viewer/image.rb
+++ b/lib/embed/viewer/image.rb
@@ -15,6 +15,48 @@ module Embed
         end.to_html
       end
 
+      def download_html
+        sizes = Constants::IMAGE_DOWNLOAD_SIZES
+
+        Nokogiri::HTML::Builder.new do |doc|
+          doc.div(class: 'sul-embed-panel-container') do
+            doc.div(class: 'sul-embed-panel sul-embed-download-panel', style: 'display:none;') do
+              doc.div(class: 'sul-embed-panel-header') do
+                doc.button(class: 'sul-embed-close', 'data-toggle' => 'sul-embed-download-panel') do
+                  doc.span('aria-hidden' => true, class: 'fa fa-close') {}
+                  doc.span(class: 'sul-embed-sr-only') { doc.text "Close" }
+                end
+                doc.div(class: 'sul-embed-panel-title') do
+                  doc.text "Download image"
+                end
+              end
+              doc.table(class: 'sul-embed-download-options', :'data-download-sizes' => "#{sizes.to_json}", :'data-stacks-url' => "#{Settings.stacks_url}") do
+	              sizes.each do |size|
+                  doc.tr do
+                    doc.td(:class => "sul-embed-download-size-type sul-embed-download-#{size}") do
+                      if (size != 'default')
+                        doc.a(href: 'javascript:;') {
+                          doc.text "#{size} ("
+                          doc.span(class: "sul-embed-download-#{size}-dimensions")
+                          doc.text ")"
+                        }
+                      else
+                        doc.span() {
+                          doc.text "#{size} ("
+                          doc.span(class: "sul-embed-download-#{size}-dimensions")
+                          doc.text ")"
+                        }
+                      end
+                    end
+                    doc.td(class: "sul-embed-download-file-size sul-embed-download-#{size}-size")
+                  end
+                end
+              end
+            end
+          end
+        end.to_html
+      end
+
       def image_id(image)
         ::File.basename(image.title, ::File.extname(image.title))
       end

--- a/spec/features/download_panel_spec.rb
+++ b/spec/features/download_panel_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe 'download panel', js: true do
+  include PURLFixtures
+  let(:request) { Embed::Request.new( {url: 'http://purl.stanford.edu/ab123cd4567'}) }
+  before do
+    stub_purl_response_with_fixture(image_purl)
+    send_embed_response
+  end
+
+  it 'should be present after a user clicks the button' do
+    expect(page).to have_css('.sul-embed-download-panel', visible: false)
+    page.find('button[data-toggle="sul-embed-download-panel"]', visible: true)
+
+    skip 'verify image viewer plugin is correctly initialized'
+    page.find('[data-toggle="sul-embed-download-panel"]', match: :first).click
+    expect(page).to have_css('.sul-embed-download-panel', visible: true)
+  end
+
+end


### PR DESCRIPTION
Closes #68 
- Adds download panel with dynamic size calculation and updated links
- Download panel button is disabled for gallery and horizontal view, and enabled for list view

![image](https://cloud.githubusercontent.com/assets/302258/4948681/b8ecd52c-65f8-11e4-84c9-03a51d36cbc2.png)
![image](https://cloud.githubusercontent.com/assets/302258/4948792/7000d0ea-65fb-11e4-9555-af9aade32184.png)
![image](https://cloud.githubusercontent.com/assets/302258/4948691/d71e14d4-65f8-11e4-811c-85790043592e.png)
![image](https://cloud.githubusercontent.com/assets/302258/4948692/e49762dc-65f8-11e4-8281-b6d20207ea70.png)

Note:
- File download sizes are not displayed because we have only jp2 size (not the derived jpeg size from jp2)
- We do not have support direct download links for thumb (= default) in digital-stacks. Currently, default link is disabled. 
- Few tests are pending for download panel
