### PR TITLE
Use asset-url in sass files.

### DIFF
--- a/app/assets/stylesheets/common.css.scss
+++ b/app/assets/stylesheets/common.css.scss
@@ -105,6 +105,6 @@
 
 .#{$namespace}-stanford-only a{
     padding-right: 20px;
-    background: url(#{$asset_url}stanford_s.png) no-repeat right;
-    background: url(#{$asset_url}stanford_s.svg) no-repeat right, none;
+    background: asset-url('#{$asset_url}stanford_s.png') no-repeat right;
+    background: asset-url('#{$asset_url}stanford_s.svg') no-repeat right, none;
 }

--- a/app/assets/stylesheets/mixins.css.scss
+++ b/app/assets/stylesheets/mixins.css.scss
@@ -9,8 +9,8 @@
 }
 
 @mixin license-images($license, $asset-url) {
-  background: url(#{$asset-url}#{$license}.png) no-repeat left;
-  background: url(#{$asset-url}#{$license}.svg) no-repeat left;
+  background: asset-url('#{$asset-url}#{$license}.png') no-repeat left;
+  background: asset-url('#{$asset-url}#{$license}.svg') no-repeat left;
   display: inline-block;
   height: 15px;
   margin-right: 6px;


### PR DESCRIPTION
This puts the asset fingerprint the the path so that the reference will be correct under production.
