### PR TITLE
Add iframe options to remove unnecessary spacing and allow fullscreen

### DIFF
--- a/lib/embed/viewer/common_viewer.rb
+++ b/lib/embed/viewer/common_viewer.rb
@@ -161,7 +161,7 @@ module Embed
                       end
                       doc.div(class: 'sul-embed-section') do
                         doc.textarea(id: 'sul-embed-iframe-code', 'data-behavior' => 'iframe-code', rows: 4) do
-                          doc.text("<iframe src='#{Settings.embed_iframe_url}?url=#{Settings.purl_url}/#{@purl_object.druid}' height='#{height}px' width='#{width || height}px' frameborder='0'></iframe>")
+                          doc.text("<iframe src='#{Settings.embed_iframe_url}?url=#{Settings.purl_url}/#{@purl_object.druid}' height='#{height}px' width='#{width || height}px' frameborder='0' marginwidth='0' marginheight='0' scrolling='no' allowfullscreen></iframe>")
                         end
                       end
                     end

--- a/spec/features/embed_this_panel_spec.rb
+++ b/spec/features/embed_this_panel_spec.rb
@@ -7,6 +7,17 @@ describe 'embed this panel', js: true do
     stub_purl_response_with_fixture(spec_fixture)
     send_embed_response
   end
+  describe 'embed code' do
+    let(:spec_fixture) { file_purl }
+    it 'should include the allowfullscreen no-scrolling, no-border, and no margin/padding attributes' do
+      page.find('[data-toggle="sul-embed-embed-this-panel"]', match: :first).trigger('click')
+      expect(page.find('.sul-embed-embed-this-panel textarea').value).to match /<iframe.*frameborder='0'.*><\/iframe>/
+      expect(page.find('.sul-embed-embed-this-panel textarea').value).to match /<iframe.*marginwidth='0'.*><\/iframe>/
+      expect(page.find('.sul-embed-embed-this-panel textarea').value).to match /<iframe.*marginheight='0'.*><\/iframe>/
+      expect(page.find('.sul-embed-embed-this-panel textarea').value).to match /<iframe.*scrolling='no'.*><\/iframe>/
+      expect(page.find('.sul-embed-embed-this-panel textarea').value).to match /<iframe.*allowfullscreen.*><\/iframe>/
+    end
+  end
   describe 'file objects' do
     let(:spec_fixture) { file_purl }
     it 'should be present after a user clicks the button' do


### PR DESCRIPTION
This makes the need for scroll bars unnecessary (by removing the margins) and allows fullscreen from an embedded iframe (which is blocked w/o that attribute).

![embed-options](https://cloud.githubusercontent.com/assets/96776/5006491/6fa0a2c8-69f8-11e4-8596-f689bde6d4c6.png)
