### PR TITLE
Swap out OSD viewer for thumb when loading errors out.

### DIFF
--- a/app/assets/javascripts/modules/jquery.iiifOsdViewer.js
+++ b/app/assets/javascripts/modules/jquery.iiifOsdViewer.js
@@ -291,6 +291,20 @@
               .height(imgHeight)
               .data('iov-img-url', imgUrl);
 
+            // when an image load errors (i.e. WebAuth challenge)
+            $img.on('error', function(){
+              if($("li", $thumbsList).index($imgItem) == 0) {
+                $leftNav.hide();
+                $rightNav.hide();
+                $thumbsViewport.hide();
+                $('.iov-menu-bar').hide();
+                $listViewOsd
+                  .removeClass('iov-list-view-osd')
+                  .css('text-align', 'center')
+                  .html('<img src="' + getThumbUrl(collection.iiifServer, image.id) + '" />')
+              }
+            });
+
             $imgItem.append($('<a href="javascript:;"></a>').append($img));
             $thumbsList.append($imgItem);
 
@@ -312,6 +326,10 @@
           $listViewOsd.addClass('iov-remove-margin');
           $thumbsViewport.hide();
         }
+      }
+
+      function getThumbUrl(serverUrl, imageId) {
+        return [serverUrl.replace('/iiif', ''), imageId.replace('%252F', '/')].join('/') + '_thumb'
       }
 
       function addImageNavBehavior(){


### PR DESCRIPTION
Begins work on #118 (leaving open for know to discuss alternate approaches that would require changes to the stacks IIIF service).
#### Example SU Only object (bd117rc5047)

![bd117rc5047-static-thumb](https://cloud.githubusercontent.com/assets/96776/5055703/e172eae8-6c1c-11e4-80db-28c7641724ae.png)
#### Example read=none object (bb066bf1599)

![bb066bf1599-static-thumb](https://cloud.githubusercontent.com/assets/96776/5055714/15230ae4-6c1d-11e4-9658-7060c0c5be52.png)
