### PR TITLE
Replaces embed panel button icon

### DIFF
--- a/app/assets/stylesheets/common.css.scss
+++ b/app/assets/stylesheets/common.css.scss
@@ -44,7 +44,7 @@
       width: 100%;
       margin-top: 4px;
     }
-    
+
     h2.#{$namespace}-item-count {
       color: white;
       border-bottom: 0;
@@ -79,6 +79,11 @@
         border-color: $sul-botton-hover-border-color;
       }
     }
+
+    .#{$namespace}-btn.fa-code {
+      font-weight: bold;
+    }
+
     .#{$namespace}-purl-link {
       font-size: .9em;
       position: absolute;

--- a/lib/embed/viewer/common_viewer.rb
+++ b/lib/embed/viewer/common_viewer.rb
@@ -50,7 +50,7 @@ module Embed
                 doc.button(class: 'sul-embed-footer-tool sul-embed-btn sul-embed-btn-xs sul-embed-btn-default fa fa-info-circle', 'aria-expanded' => 'false', 'data-toggle' => 'sul-embed-metadata-panel')
               end
               unless @request.hide_embed_this?
-                doc.button(class: 'sul-embed-footer-tool sul-embed-btn sul-embed-btn-xs sul-embed-btn-default fa fa-share-alt', 'aria-expanded' => 'false', 'data-toggle' => 'sul-embed-embed-this-panel')
+                doc.button(class: 'sul-embed-footer-tool sul-embed-btn sul-embed-btn-xs sul-embed-btn-default fa fa-code', 'aria-expanded' => 'false', 'data-toggle' => 'sul-embed-embed-this-panel')
               end
               if self.is_a?(Embed::Viewer::Image) && !@request.hide_download?
                 doc.button(class: 'sul-embed-footer-tool sul-embed-btn sul-embed-btn-xs sul-embed-btn-default fa fa-download', 'aria-expanded' => 'false', 'data-toggle' => 'sul-embed-download-panel')


### PR DESCRIPTION
Adblock blocks `fa-share-alt` ![image](https://cloud.githubusercontent.com/assets/302258/5117822/a658ee8a-700e-11e4-8733-8931a5f552b0.png) icon class, and hides embed functionality. 

Replaced the icon with `fa-code` ![image](https://cloud.githubusercontent.com/assets/302258/5117832/bdf1ae56-700e-11e4-9d18-9ffb60fa95a4.png)

![image](https://cloud.githubusercontent.com/assets/302258/5117895/75a7105e-700f-11e4-8dc9-28c7a59f2aa8.png)
