### PR TITLE
Change data-toggle attribute to include sul-embed namespace.

### DIFF
--- a/app/assets/javascripts/modules/download_panel.js
+++ b/app/assets/javascripts/modules/download_panel.js
@@ -1,7 +1,7 @@
 (function(global) {
   global.sulEmbedDownloadPanel = (function() {
      var $downloadOptions = $('.sul-embed-download-options'),
-         $btnDownloadPanel = $('.sul-embed-footer-tool[data-toggle="sul-embed-download-panel"]'),
+         $btnDownloadPanel = $('.sul-embed-footer-tool[data-sul-embed-toggle="sul-embed-download-panel"]'),
          sizes = $downloadOptions.data('download-sizes'),
          sizeLevelMapping = { full: 0, xlarge: -1, large: -2, medium: -3, small: -4 },
          djatokaBaseResolution = 92,

--- a/app/assets/javascripts/modules/popup_panels.js
+++ b/app/assets/javascripts/modules/popup_panels.js
@@ -10,9 +10,9 @@
       },
       setupListeners: function() {
         var _this = this;
-        $("[data-toggle]").on("click", function() {
+        $("[data-sul-embed-toggle]").on("click", function() {
           clickTarget = $(this);
-          toggleElements = $("." + clickTarget.data("toggle"));
+          toggleElements = $("." + clickTarget.data("sul-embed-toggle"));
           _this.hideAllOtherPanels();
           _this.toggleAriaAttributes();
           _this.setMaxHeight();
@@ -20,9 +20,9 @@
         });
       },
       hideAllOtherPanels: function() {
-        $("[data-toggle]").each(function(){
-          if(clickTarget.data("toggle") != $(this).data('toggle')) {
-            $("." + $(this).data("toggle") + ':visible').hide();
+        $("[data-sul-embed-toggle]").each(function(){
+          if(clickTarget.data("sul-embed-toggle") != $(this).data('sul-embed-toggle')) {
+            $("." + $(this).data("sul-embed-toggle") + ':visible').hide();
           }
         });
       },

--- a/lib/embed/viewer/common_viewer.rb
+++ b/lib/embed/viewer/common_viewer.rb
@@ -47,13 +47,13 @@ module Embed
           doc.div(class: 'sul-embed-footer') do
             doc.div(class: 'sul-embed-footer-toolbar') do
               unless @request.hide_metadata?
-                doc.button(class: 'sul-embed-footer-tool sul-embed-btn sul-embed-btn-xs sul-embed-btn-default fa fa-info-circle', 'aria-expanded' => 'false', 'data-toggle' => 'sul-embed-metadata-panel')
+                doc.button(class: 'sul-embed-footer-tool sul-embed-btn sul-embed-btn-xs sul-embed-btn-default fa fa-info-circle', 'aria-expanded' => 'false', 'data-sul-embed-toggle' => 'sul-embed-metadata-panel')
               end
               unless @request.hide_embed_this?
-                doc.button(class: 'sul-embed-footer-tool sul-embed-btn sul-embed-btn-xs sul-embed-btn-default fa fa-code', 'aria-expanded' => 'false', 'data-toggle' => 'sul-embed-embed-this-panel')
+                doc.button(class: 'sul-embed-footer-tool sul-embed-btn sul-embed-btn-xs sul-embed-btn-default fa fa-code', 'aria-expanded' => 'false', 'data-sul-embed-toggle' => 'sul-embed-embed-this-panel')
               end
               if self.is_a?(Embed::Viewer::Image) && !@request.hide_download?
-                doc.button(class: 'sul-embed-footer-tool sul-embed-btn sul-embed-btn-xs sul-embed-btn-default fa fa-download', 'aria-expanded' => 'false', 'data-toggle' => 'sul-embed-download-panel')
+                doc.button(class: 'sul-embed-footer-tool sul-embed-btn sul-embed-btn-xs sul-embed-btn-default fa fa-download', 'aria-expanded' => 'false', 'data-sul-embed-toggle' => 'sul-embed-download-panel')
               end
             end
             doc.div(class: 'sul-embed-purl-link') do
@@ -72,7 +72,7 @@ module Embed
             doc.div(class: 'sul-embed-panel-container') do
               doc.div(class: 'sul-embed-panel sul-embed-metadata-panel', style: 'display:none;', :'aria-hidden' => 'true') do
                 doc.div(class: 'sul-embed-panel-header') do
-                  doc.button(class: 'sul-embed-close', 'data-toggle' => 'sul-embed-metadata-panel') do
+                  doc.button(class: 'sul-embed-close', 'data-sul-embed-toggle' => 'sul-embed-metadata-panel') do
                     doc.span('aria-hidden' => true, class: 'fa fa-close') {}
                     doc.span(class: 'sul-embed-sr-only') { doc.text "Close" }
                   end
@@ -113,7 +113,7 @@ module Embed
             doc.div(class: 'sul-embed-panel-container') do
               doc.div(class: 'sul-embed-panel sul-embed-embed-this-panel', style: 'display:none;', :'aria-hidden' => 'true') do
                 doc.div(class: 'sul-embed-panel-header') do
-                  doc.button(class: 'sul-embed-close', 'data-toggle' => 'sul-embed-embed-this-panel') do
+                  doc.button(class: 'sul-embed-close', 'data-sul-embed-toggle' => 'sul-embed-embed-this-panel') do
                     doc.span('aria-hidden' => true, class: 'fa fa-close') {}
                     doc.span(class: 'sul-embed-sr-only') { doc.text "Close" }
                   end

--- a/lib/embed/viewer/image.rb
+++ b/lib/embed/viewer/image.rb
@@ -28,7 +28,7 @@ module Embed
           doc.div(class: 'sul-embed-panel-container') do
             doc.div(class: 'sul-embed-panel sul-embed-download-panel', style: 'display:none;', :'aria-hidden' => 'true') do
               doc.div(class: 'sul-embed-panel-header') do
-                doc.button(class: 'sul-embed-close', 'data-toggle' => 'sul-embed-download-panel') do
+                doc.button(class: 'sul-embed-close', 'data-sul-embed-toggle' => 'sul-embed-download-panel') do
                   doc.span('aria-hidden' => true, class: 'fa fa-close') {}
                   doc.span(class: 'sul-embed-sr-only') { doc.text "Close" }
                 end

--- a/spec/features/download_panel_spec.rb
+++ b/spec/features/download_panel_spec.rb
@@ -11,9 +11,9 @@ describe 'download panel', js: true do
 
     it 'should be present after a user clicks the button' do
       expect(page).to have_css('.sul-embed-download-panel', visible: false)
-      page.find('button[data-toggle="sul-embed-download-panel"]', visible: true)
+      page.find('button[data-sul-embed-toggle="sul-embed-download-panel"]', visible: true)
 
-      page.find('[data-toggle="sul-embed-download-panel"]', match: :first).click
+      page.find('[data-sul-embed-toggle="sul-embed-download-panel"]', match: :first).click
       expect(page).to have_css('.sul-embed-download-panel', visible: true)
 
       expect(page).to have_css('.sul-embed-panel-item-label', text: '')      
@@ -34,12 +34,12 @@ describe 'download panel', js: true do
       check("Hide download?")
       click_button 'Embed'
 
-      expect(page).to_not have_css('button[data-toggle="sul-embed-download-panel"]')
+      expect(page).to_not have_css('button[data-sul-embed-toggle="sul-embed-download-panel"]')
     end
     it 'when not selected should display the button' do
       click_button 'Embed'
 
-      expect(page).to have_css('button[data-toggle="sul-embed-download-panel"]')
+      expect(page).to have_css('button[data-sul-embed-toggle="sul-embed-download-panel"]')
     end
   end
 end

--- a/spec/features/embed_this_panel_spec.rb
+++ b/spec/features/embed_this_panel_spec.rb
@@ -10,7 +10,7 @@ describe 'embed this panel', js: true do
   describe 'embed code' do
     let(:spec_fixture) { file_purl }
     it 'should include the allowfullscreen no-scrolling, no-border, and no margin/padding attributes' do
-      page.find('[data-toggle="sul-embed-embed-this-panel"]', match: :first).trigger('click')
+      page.find('[data-sul-embed-toggle="sul-embed-embed-this-panel"]', match: :first).trigger('click')
       expect(page.find('.sul-embed-embed-this-panel textarea').value).to match /<iframe.*frameborder='0'.*><\/iframe>/
       expect(page.find('.sul-embed-embed-this-panel textarea').value).to match /<iframe.*marginwidth='0'.*><\/iframe>/
       expect(page.find('.sul-embed-embed-this-panel textarea').value).to match /<iframe.*marginheight='0'.*><\/iframe>/
@@ -22,13 +22,13 @@ describe 'embed this panel', js: true do
     let(:spec_fixture) { file_purl }
     it 'should be present after a user clicks the button' do
       expect(page).to have_css('.sul-embed-embed-this-panel', visible: false)
-      page.find('[data-toggle="sul-embed-embed-this-panel"]', match: :first).trigger('click')
+      page.find('[data-sul-embed-toggle="sul-embed-embed-this-panel"]', match: :first).trigger('click')
       expect(page).to have_css('.sul-embed-embed-this-panel', visible: true)
-      page.find('[data-toggle="sul-embed-embed-this-panel"]', match: :first).trigger('click')
+      page.find('[data-sul-embed-toggle="sul-embed-embed-this-panel"]', match: :first).trigger('click')
       expect(page).to have_css('.sul-embed-embed-this-panel', visible: false)
     end
     it 'should have the form elements for updating the embed code' do
-      page.find('[data-toggle="sul-embed-embed-this-panel"]', match: :first).trigger('click')
+      page.find('[data-sul-embed-toggle="sul-embed-embed-this-panel"]', match: :first).trigger('click')
       expect(page).to have_css('.sul-embed-options-label', text: 'SELECT OPTIONS:')
       expect(page).to have_css('input#sul-embed-embed-title[type="checkbox"]')
       expect(page).to have_css('input#sul-embed-embed-search[type="checkbox"]')
@@ -36,7 +36,7 @@ describe 'embed this panel', js: true do
       expect(page).to have_css('textarea#sul-embed-iframe-code')
     end
     it 'should update the textarea when the checkboxes are selected' do
-      page.find('[data-toggle="sul-embed-embed-this-panel"]', match: :first).trigger('click')
+      page.find('[data-sul-embed-toggle="sul-embed-embed-this-panel"]', match: :first).trigger('click')
       expect(page.find('.sul-embed-embed-this-panel textarea').value).to match /src='\S+\/iframe\?url=http:\/\/purl\.stanford\.edu\/ab123cd4567'/
       page.find("input#sul-embed-embed-search[type='checkbox']").trigger('click')
       expect(page.find('.sul-embed-embed-this-panel textarea').value).to match /src='\S+\/iframe\?url=http:\/\/purl\.stanford\.edu\/ab123cd4567&hide_search=true'/
@@ -47,7 +47,7 @@ describe 'embed this panel', js: true do
   describe 'image objects' do
     let(:spec_fixture) { image_purl }
     it 'should include the form elements for downloading an image' do
-      page.find('[data-toggle="sul-embed-embed-this-panel"]', match: :first).trigger('click')
+      page.find('[data-sul-embed-toggle="sul-embed-embed-this-panel"]', match: :first).trigger('click')
       expect(page).to have_css('input#sul-embed-embed-download[type="checkbox"]')
     end
   end

--- a/spec/features/metadata_panel_spec.rb
+++ b/spec/features/metadata_panel_spec.rb
@@ -7,15 +7,15 @@ describe 'metadata panel', js: true do
     stub_purl_response_with_fixture(file_purl)
     send_embed_response
     expect(page).to have_css('.sul-embed-metadata-panel', visible: false)
-    page.find('[data-toggle="sul-embed-metadata-panel"]', match: :first).click
+    page.find('[data-sul-embed-toggle="sul-embed-metadata-panel"]', match: :first).click
     expect(page).to have_css('.sul-embed-metadata-panel', visible: true)
-    page.find('[data-toggle="sul-embed-metadata-panel"]', match: :first).click
+    page.find('[data-sul-embed-toggle="sul-embed-metadata-panel"]', match: :first).click
     expect(page).to have_css('.sul-embed-metadata-panel', visible: false)
   end
   it 'should have use and reproduction and license text' do
     stub_purl_response_with_fixture(file_purl)
     send_embed_response
-    page.find('[data-toggle="sul-embed-metadata-panel"]', match: :first).click
+    page.find('[data-sul-embed-toggle="sul-embed-metadata-panel"]', match: :first).click
     expect(page).to have_css('dt', text: 'USE AND REPRODUCTION')
     expect(page).to have_css('dt', text: 'LICENSE')
     within '.sul-embed-metadata-panel' do

--- a/spec/lib/embed/viewer/common_viewer_spec.rb
+++ b/spec/lib/embed/viewer/common_viewer_spec.rb
@@ -65,7 +65,7 @@ describe Embed::Viewer::CommonViewer do
       stub_request(request)
       html = Capybara.string(file_viewer.metadata_html)
       expect(html).to_not have_css '.sul-embed-metadata-container'
-      expect(html).to_not have_css '[data-toggle="sul-embed-metadata-panel"]'
+      expect(html).to_not have_css '[data-sul-embed-toggle="sul-embed-metadata-panel"]'
     end
   end
   describe 'footer_html' do


### PR DESCRIPTION
`data-toggle` is a commonly used data attribute in bootstrap.  We don't want to attach our events to their elements.
