### PR TITLE
Rescue error when an unembeddable object is requested (i.e. has no contentMetadata type)

### DIFF
--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -23,6 +23,10 @@ class EmbedController < ApplicationController
     render body: e.to_s, status: 400
   end
 
+  rescue_from Embed::PURL::ResourceNotEmbeddable do |e|
+    render body: e.to_s, status: 400
+  end
+
   rescue_from Embed::Request::InvalidURLScheme do |e|
     render body: e.to_s, status: 404
   end

--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -45,6 +45,12 @@ class EmbedController < ApplicationController
     {}
   end
 
+  # Setting a cookies method on the controller so that squash can properly report errors
+  # Cookies do not exsist natively in Rails-API and we don't need them.
+  def cookies
+    []
+  end
+
   private
 
   def set_cache

--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -12,7 +12,10 @@ module Embed
     end
 
     def type
-      @type ||= ng_xml.xpath('//contentMetadata').first.attributes['type'].try(:value)
+      @type ||= begin
+        contentMetadata = ng_xml.xpath('//contentMetadata').first
+        contentMetadata.attributes['type'].try(:value) if contentMetadata.present?
+      end
     end
 
     def contents

--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -116,6 +116,11 @@ module Embed
         super
       end
     end
+    class ResourceNotEmbeddable < StandardError
+      def initialize(msg = "The requested PURL resource was not embeddable.")
+        super
+      end
+    end
     class Resource
       def initialize(resource, rights)
         @resource = resource

--- a/lib/embed/viewer.rb
+++ b/lib/embed/viewer.rb
@@ -7,6 +7,7 @@ module Embed
     delegate :height, :width, to: :viewer
     def initialize(request)
       @request = request
+      raise Embed::PURL::ResourceNotEmbeddable unless request.purl_object.type.present?
     end
     def viewer
       @viewer ||= registered_or_default_viewer.new(@request)

--- a/spec/controllers/embed_controller_spec.rb
+++ b/spec/controllers/embed_controller_spec.rb
@@ -6,6 +6,10 @@ describe EmbedController do
       get :get
       expect(response.status).to eq(400)
     end
+    it 'has a 400 status when a PURL that is not embeddable is requested' do
+      get :get, url: 'http://purl.stanford.edu/tz959sb6952'
+      expect(response.status).to eq(400)
+    end
     it 'has a 404 status code without matched url scheme params' do
       get :get, url: 'http://www.example.com'
       expect(response.status).to eq(404)


### PR DESCRIPTION
This creates an error class that gets called when an object w/o contentMetadata (e.g. a collection) is embedded.

This error is rescued in the embed controller and returns a 400.