### PR TITLE
refactor envelope specs

### DIFF
--- a/app/models/embed/envelope.rb
+++ b/app/models/embed/envelope.rb
@@ -7,8 +7,10 @@ module Embed
     end
 
     ##
+    # Creates a bounding box as a 2D Array if an envelope is present (eg. 
+    # [[min_lng, min_lat], [max_lng, max_lat]])
     # @return [Array]
-    def to_bounding_box 
+    def to_bounding_box
       [[west, south], [east, north]] if @envelope.present?
     end
 

--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -61,9 +61,11 @@ module Embed
     end
     
     def bounding_box 
-      Envelope.new(
-        ng_xml.xpath('//gml:Envelope', 'gml'=>'http://www.opengis.net/gml/3.2/').first
-      ).to_bounding_box
+      Embed::Envelope.new(envelope).to_bounding_box
+    end
+
+    def envelope
+      ng_xml.at_xpath('//gml:Envelope', 'gml'=>'http://www.opengis.net/gml/3.2/')
     end
 
     private

--- a/spec/models/embed/envelope_spec.rb
+++ b/spec/models/embed/envelope_spec.rb
@@ -10,19 +10,17 @@ describe Embed::Envelope do
     end
   end
   describe '#to_bounding_box' do
-    let(:envelope) { 
+    let(:envelope) do
       Embed::Envelope.new(Nokogiri::XML(geo_purl).
-        xpath('//gml:Envelope','gml'=>'http://www.opengis.net/gml/3.2/').first)
-    }
-    let(:no_envelope) {
-      Embed::Envelope.new(nil)
-    }
+        at_xpath('//gml:Envelope','gml'=>'http://www.opengis.net/gml/3.2/'))
+    end
+    let(:no_envelope) { Embed::Envelope.new(nil) }
     it 'returns nil if @envelope is falsy' do
       expect(no_envelope.to_bounding_box).to be_nil
     end
     it 'returns a 2D array when @envelope is a gml envelope' do
       expect(envelope.to_bounding_box.length).to eq 2
-      expect(envelope.to_bounding_box).to eq [["38.298673", "-123.387626"], ["39.399103", "-122.528843"]]
+      expect(envelope.to_bounding_box).to eq [['38.298673', '-123.387626'], ['39.399103', '-122.528843']]
     end
   end
 end

--- a/spec/models/embed/envelope_spec.rb
+++ b/spec/models/embed/envelope_spec.rb
@@ -2,34 +2,27 @@ require "rails_helper"
 
 describe Embed::Envelope do
   include PURLFixtures
-  describe 'to_bounding_box' do
-    it 'should extract a simple array from the xml' do
-      stub_purl_response_with_fixture(geo_purl)
-      @envelope_ng = Embed::PURL.new('1234').ng_xml.xpath('//gml:Envelope', 'gml'=>'http://www.opengis.net/gml/3.2/').first
-      expect(Embed::Envelope.new(@envelope_ng).to_bounding_box()).to eq [["38.298673","-123.387626"],[ "39.399103", "-122.528843"]] 
-    end
-    it 'should return nil if there is no envelope present' do
-      stub_purl_response_with_fixture(image_purl)
-      @envelope_nil = Embed::PURL.new('1234').ng_xml.xpath('//gml:Envelope', 'gml'=>'http://www.opengis.net/gml/3.2/').first
-      expect(Embed::Envelope.new(@envelope_nil).to_bounding_box()).to eq nil 
+  describe '#initialize' do
+    let(:envelope_object) { Embed::Envelope.new('test') }
+    it 'creates an Envelope object' do
+      expect(envelope_object).to be_an Embed::Envelope
+      expect(envelope_object.instance_variable_get(:@envelope)).to eq 'test'
     end
   end
-  describe 'lower_corner' do
-    before do
-      stub_purl_response_with_fixture(geo_purl)
-      @envelope_ng = Embed::PURL.new('1234').ng_xml.xpath('//gml:Envelope', 'gml'=>'http://www.opengis.net/gml/3.2/').first
+  describe '#to_bounding_box' do
+    let(:envelope) { 
+      Embed::Envelope.new(Nokogiri::XML(geo_purl).
+        xpath('//gml:Envelope','gml'=>'http://www.opengis.net/gml/3.2/').first)
+    }
+    let(:no_envelope) {
+      Embed::Envelope.new(nil)
+    }
+    it 'returns nil if @envelope is falsy' do
+      expect(no_envelope.to_bounding_box).to be_nil
     end
-    it 'should give the lower_corner value as array of 2 strings' do
-      expect(Embed::Envelope.new(@envelope_ng).send(:lower_corner)).to eq ["-123.387626", "38.298673"] 
-    end
-  end
-  describe 'should give the upper_corner value as array of 2 strings' do
-    before do
-      stub_purl_response_with_fixture(geo_purl)
-      @envelope_ng = Embed::PURL.new('1234').ng_xml.xpath('//gml:Envelope', 'gml'=>'http://www.opengis.net/gml/3.2/').first
-    end
-    it 'should extract a simple array from the xml' do
-      expect(Embed::Envelope.new(@envelope_ng).send(:upper_corner)).to eq ["-122.528843", "39.399103"] 
+    it 'returns a 2D array when @envelope is a gml envelope' do
+      expect(envelope.to_bounding_box.length).to eq 2
+      expect(envelope.to_bounding_box).to eq [["38.298673", "-123.387626"], ["39.399103", "-122.528843"]]
     end
   end
 end

--- a/spec/models/embed/purl_spec.rb
+++ b/spec/models/embed/purl_spec.rb
@@ -44,6 +44,23 @@ describe Embed::PURL do
       expect(Embed::PURL.new('12345').all_resource_files.count).to eq 4
     end
   end
+  describe '#bounding_box' do
+    before { stub_purl_response_with_fixture(geo_purl) }
+    it 'creates an Envelope and calls #to_bounding_box on it' do
+      expect_any_instance_of(Embed::Envelope).to receive(:to_bounding_box)
+      Embed::PURL.new('12345').bounding_box
+    end
+  end
+  describe '#envelope' do
+    it 'selects the envelope element' do
+      stub_purl_response_with_fixture(geo_purl)
+      expect(Embed::PURL.new('12345').envelope).to be_an Nokogiri::XML::Element
+    end
+    it 'without an envelope present' do
+      stub_purl_response_with_fixture(image_purl)
+      expect(Embed::PURL.new('12345').envelope).to be_nil
+    end
+  end
   describe 'licence' do
     it 'should return cc license if present' do
       stub_purl_response_with_fixture(file_purl)


### PR DESCRIPTION
@aeschylus @aalsum 

A quick refactor of the envelope spec. This refactor:
 - isolates and tests only the public methods on the `Envelope` class.
 - isolates tests within `PURL` that deal with `bounding_box`