### PR TITLE
adds WMS layer preview for public layers

### DIFF
--- a/app/assets/javascripts/modules/geo_viewer.js
+++ b/app/assets/javascripts/modules/geo_viewer.js
@@ -2,11 +2,18 @@
 (function( global ) {
   'use strict';
   var Module = (function() {
+    var dataAttributes;
+    var map;
+    
+    var isDefined = function(object) {
+       return typeof object !== 'undefined';
+    };
+
     return {
       init: function() {
-        var boundingBox = jQuery('#sul-embed-geo-map').data().boundingBox;
+        dataAttributes = jQuery('#sul-embed-geo-map').data();
 
-        var map = L.map('sul-embed-geo-map').fitBounds(boundingBox);
+        map = L.map('sul-embed-geo-map').fitBounds(dataAttributes.boundingBox);
 
         L.tileLayer(
             'https://otile{s}-s.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png', {
@@ -19,8 +26,25 @@
               subdomains: '1234'
             }
         ).addTo(map);
-        L.rectangle(boundingBox, {color: "#0000FF", weight: 4}).addTo(map)
+        
+        Module.addVisualizationLayer();
         map.invalidateSize();
+      },
+      addVisualizationLayer: function() {
+        var hasWmsUrl = isDefined(dataAttributes.wmsUrl);
+        var hasLayers = isDefined(dataAttributes.layers);
+
+        if (hasWmsUrl && hasLayers) {
+          L.tileLayer.wms(dataAttributes.wmsUrl, {
+              layers: dataAttributes.layers,
+              format: 'image/png',
+              transparent: true,
+              tiled: true
+          }).addTo(map);
+        } else {
+          L.rectangle(dataAttributes.boundingBox, {color: '#0000FF', weight: 4})
+            .addTo(map);
+        }
       }
     };
   })();

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,3 +6,4 @@ squash_api_host: 'http://squash-host.example.com'
 squash_api_key: 'abc123'
 squash_disable: <%= (Rails.env.development? || Rails.env.test?) %>
 geo_external_url: 'http://earthworks.stanford.edu/catalog/stanford-'
+geo_wms_url: 'https://geowebservices.stanford.edu/geoserver/wms/'

--- a/lib/embed/viewer/geo.rb
+++ b/lib/embed/viewer/geo.rb
@@ -9,7 +9,7 @@ module Embed
       def body_html
         Nokogiri::HTML::Builder.new do |doc|
           doc.div(class: 'sul-embed-body sul-embed-geo', 'style' => "max-height: #{body_height}px", 'data-sul-embed-theme' => "#{asset_url('geo.css')}") do
-            doc.div(id: 'sul-embed-geo-map', 'style' => "height: #{body_height}px", 'data-bounding-box' => @purl_object.bounding_box) {}
+            doc.div(map_element_options) {}
             doc.script { doc.text ";jQuery.getScript(\"#{asset_url('geo.js')}\");" }
           end
         end.to_html
@@ -46,6 +46,22 @@ module Embed
             end
           end
         end.to_html
+      end
+
+      ##
+      # Options for the map element tag
+      # @return [Hash]
+      def map_element_options
+        options = {
+          id: 'sul-embed-geo-map',
+          style: "height: #{body_height}px",
+          'data-bounding-box' => @purl_object.bounding_box,
+        }
+        if @purl_object.public?
+          options['data-wms-url'] = Settings.geo_wms_url
+          options['data-layers'] = "druid:#{@purl_object.druid}"
+        end
+        options
       end
       
       def default_body_height

--- a/spec/features/geo_viewer_spec.rb
+++ b/spec/features/geo_viewer_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
+include PURLFixtures
 
-describe 'geo viewer', js: true do
-  include PURLFixtures
+describe 'geo viewer public', js: true do
   before do
-    stub_purl_response_with_fixture(geo_purl)
+    stub_purl_response_with_fixture(geo_purl_public)
     visit_sandbox
     fill_in_default_sandbox_form
     click_button 'Embed'
@@ -27,12 +27,8 @@ describe 'geo viewer', js: true do
       expect(page).to have_css("img[src*='mqcdn.com']", minimum: 6)
     end
 
-    it 'shows the bounding box' do
-      # This is a hack, but there is no other way (that we know of) to
-      # find this svg element on the page.
-      # We also need to explicitly wait for the JS to run.
-      find ".leaflet-overlay-pane"
-      expect(Nokogiri::HTML.parse(page.body).css('path').length).to eq 1
+    it 'shows the wms tiles' do
+      expect(page).to have_css("img[src*='stanford.edu']", minimum: 4)
     end
 
     it 'download toolbar/panel is present with download links' do
@@ -42,6 +38,25 @@ describe 'geo viewer', js: true do
           expect(page).to have_css 'li', count: 1, text: 'data.zip'
         end
       end
+    end
+  end
+end
+
+describe 'geo viewer restricted', js: true do
+  before do
+    stub_purl_response_with_fixture(geo_purl_restricted)
+    visit_sandbox
+    fill_in_default_sandbox_form
+    click_button 'Embed'
+  end
+  describe 'loads viewer' do
+    it 'shows the bounding box' do
+      # This is a hack, but there is no other way (that we know of) to
+      # find this svg element on the page.
+      # We also need to explicitly wait for the JS to run.
+      expect(page).to have_css('.sul-embed-geo', count: 1, visible: true)
+      find '.leaflet-overlay-pane'
+      expect(Nokogiri::HTML.parse(page.body).css('path').length).to eq 1
     end
   end
 end

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -265,7 +265,7 @@ module PURLFixtures
       </publicObject>
     XML
   end
-  def geo_purl
+  def geo_purl_public
      <<-XML
       <publicObject>
         <identityMetadata>
@@ -299,6 +299,57 @@ module PURLFixtures
               <world/>
             </machine>
           </access>
+        </rightsMetadata>
+      </publicObject>
+    XML
+  end
+  def geo_purl_restricted
+    <<-XML
+      <publicObject id="druid:fp756wn9369" published="2015-02-04T20:03:27-08:00">
+        <identityMetadata>
+          <sourceId source="branner">rr_1100kgrdu.shp</sourceId>
+          <objectId>druid:fp756wn9369</objectId>
+        </identityMetadata>
+        <contentMetadata objectId="fp756wn9369" type="geo">
+          <resource id="fp756wn9369_1" sequence="1" type="object">
+            <label>Data</label>
+            <file id="data.zip" mimetype="application/zip" size="127368" role="master">
+              <geoData>
+                <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://purl.stanford.edu/fp756wn9369">
+                  <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">application/x-esri-shapefile; format=Shapefile</dc:format>
+                  <dc:type xmlns:dc="http://purl.org/dc/elements/1.1/">Dataset#Polygon</dc:type>
+                  <gml:boundedBy xmlns:gml="http://www.opengis.net/gml/3.2/">
+                    <gml:Envelope gml:srsName="EPSG:4326">
+                      <gml:lowerCorner>-123.387626 38.298673</gml:lowerCorner>
+                      <gml:upperCorner>-122.528843 39.399103</gml:upperCorner>
+                    </gml:Envelope>
+                  </gml:boundedBy>
+                </rdf:Description>
+              </geoData>
+            </file>
+          </resource>
+        </contentMetadata>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <group>Stanford</group>
+            </machine>
+          </access>
+          <use>
+            <human type="useAndReproduction">
+              These data are licensed by Stanford Libraries and are available to Stanford University affiliates only. Affiliates are limited to current faculty, staff and students. These data may not be reproduced or used for any purpose without permission. For more information please contact brannerlibrary@stanford.edu.
+            </human>
+            <human type="creativeCommons"/>
+            <machine type="creativeCommons"/>
+          </use>
+          <copyright>
+            <human>Copyright ownership resides with the originator.</human>
+          </copyright>
         </rightsMetadata>
       </publicObject>
     XML

--- a/spec/javascripts/geo/geo_viewer_spec.js
+++ b/spec/javascripts/geo/geo_viewer_spec.js
@@ -1,0 +1,19 @@
+//= require jquery
+//= require modules/geo_viewer
+
+'use strict';
+
+describe('geo_viewer.js', function() {
+  describe('loads and makes available modules', function() {
+    it('GeoViewer is defined', function() {
+      expect(GeoViewer).toBeDefined();
+    });
+  });
+  describe('#init', function() {
+    fixture.set('<div id="sul-embed-geo-map" data-bounding-box=\'[["38.298673' +
+      '", "-123.387626"], ["39.399103", "-122.528843"]]\'></div>');
+    it('initializes map', function() {
+      GeoViewer.init();
+    });
+  });
+});

--- a/spec/lib/embed/viewer/geo_spec.rb
+++ b/spec/lib/embed/viewer/geo_spec.rb
@@ -23,8 +23,8 @@ describe Embed::Viewer::Geo do
   end
 
   describe '.body_html' do
-    it 'should return geo html body' do
-      stub_purl_response_and_request(geo_purl, request)         
+    it 'should return geo html body for public resources' do
+      stub_purl_response_and_request(geo_purl_public, request)
       expect(geo_viewer).to receive(:asset_host).at_least(:twice).and_return('http://example.com/')
 
       html = Capybara.string(geo_viewer.to_html)
@@ -33,6 +33,8 @@ describe Embed::Viewer::Geo do
       expect(html).to have_css '#sul-embed-geo-map', visible: false
       expect(html).to have_css('#sul-embed-geo-map[style="height: 400px"]', visible: false)
       expect(html).to have_css('#sul-embed-geo-map[data-bounding-box=\'[["38.298673", "-123.387626"], ["39.399103", "-122.528843"]]\']', visible: false)
+      expect(html).to have_css('#sul-embed-geo-map[data-wms-url="https://geowebservices.stanford.edu/geoserver/wms/"]', visible: false)
+      expect(html).to have_css('#sul-embed-geo-map[data-layers="druid:12345"]', visible: false)
     end
   end
   describe '.external_url' do
@@ -51,7 +53,7 @@ describe Embed::Viewer::Geo do
       expect(geo_viewer.download_html).to eq ''
     end
     it 'generates a file list when file has resources' do
-      stub_purl_response_and_request(geo_purl, request)
+      stub_purl_response_and_request(geo_purl_public, request)
       html = Capybara.string(geo_viewer.download_html)
       expect(html).to have_css 'li', visible: false, count: 1
       expect(html).to have_css 'a[href="https://stacks.stanford.edu/file/druid:12345/data.zip"]', visible: false
@@ -60,6 +62,27 @@ describe Embed::Viewer::Geo do
       stub_purl_response_and_request(stanford_restricted_file_purl, request)
       html = Capybara.string(geo_viewer.download_html)
       expect(html).to have_css 'li.sul-embed-stanford-only', visible: false
+    end
+  end
+  describe '#map_element_options' do
+    it 'for public content' do
+      stub_purl_response_and_request(geo_purl_public, request)
+      expect(geo_viewer.map_element_options).to be_an Hash
+      expect(geo_viewer.map_element_options).to include style: 'height: 400px'
+      expect(geo_viewer.map_element_options).to include id: 'sul-embed-geo-map'
+      expect(geo_viewer.map_element_options).to include 'data-bounding-box' => [['38.298673', '-123.387626'], ['39.399103', '-122.528843']]
+      expect(geo_viewer.map_element_options).to include 'data-wms-url' => 'https://geowebservices.stanford.edu/geoserver/wms/'
+      expect(geo_viewer.map_element_options).to include 'data-layers' => 'druid:12345'
+    end
+
+    it 'for restricted content' do
+      stub_purl_response_and_request(geo_purl_restricted, request)
+      expect(geo_viewer.map_element_options).to be_an Hash
+      expect(geo_viewer.map_element_options).to include style: 'height: 400px'
+      expect(geo_viewer.map_element_options).to include id: 'sul-embed-geo-map'
+      expect(geo_viewer.map_element_options).to include 'data-bounding-box' => [['38.298673', '-123.387626'], ['39.399103', '-122.528843']]
+      expect(geo_viewer.map_element_options).to_not include 'data-layers'
+      expect(geo_viewer.map_element_options).to_not include 'data-wms-url'
     end
   end
 end

--- a/spec/models/embed/envelope_spec.rb
+++ b/spec/models/embed/envelope_spec.rb
@@ -11,7 +11,7 @@ describe Embed::Envelope do
   end
   describe '#to_bounding_box' do
     let(:envelope) do
-      Embed::Envelope.new(Nokogiri::XML(geo_purl).
+      Embed::Envelope.new(Nokogiri::XML(geo_purl_public).
         at_xpath('//gml:Envelope','gml'=>'http://www.opengis.net/gml/3.2/'))
     end
     let(:no_envelope) { Embed::Envelope.new(nil) }

--- a/spec/models/embed/purl_spec.rb
+++ b/spec/models/embed/purl_spec.rb
@@ -45,7 +45,7 @@ describe Embed::PURL do
     end
   end
   describe '#bounding_box' do
-    before { stub_purl_response_with_fixture(geo_purl) }
+    before { stub_purl_response_with_fixture(geo_purl_public) }
     it 'creates an Envelope and calls #to_bounding_box on it' do
       expect_any_instance_of(Embed::Envelope).to receive(:to_bounding_box)
       Embed::PURL.new('12345').bounding_box
@@ -53,7 +53,7 @@ describe Embed::PURL do
   end
   describe '#envelope' do
     it 'selects the envelope element' do
-      stub_purl_response_with_fixture(geo_purl)
+      stub_purl_response_with_fixture(geo_purl_public)
       expect(Embed::PURL.new('12345').envelope).to be_an Nokogiri::XML::Element
     end
     it 'without an envelope present' do


### PR DESCRIPTION
## For a public layer cz128vq0535

<img width="589" alt="screen shot 2015-07-13 at 4 22 23 pm" src="https://cloud.githubusercontent.com/assets/1656824/8663065/61a84534-297b-11e5-9072-f1c1efa9f2e2.png">

Restricted layers stay the same