### PR TITLE
Updates style of was seed viewer

### DIFF
--- a/app/assets/stylesheets/file.css.scss
+++ b/app/assets/stylesheets/file.css.scss
@@ -68,7 +68,7 @@
 }
 
 .#{$namespace}-file-list {
-  background-color: $color-beige-10;
+  background-color: $sul-background;
   padding: 10px;
 }
 

--- a/app/assets/stylesheets/sul_variables.css.scss.erb
+++ b/app/assets/stylesheets/sul_variables.css.scss.erb
@@ -42,7 +42,7 @@ $tooltip-opacity: .9 !default;
 $zindex-tooltip: 1070;
 
 
-$sul-background: $color-beige-30;
+$sul-background: $color-beige-10;
 $sul-border-color: $color-pantone-405;
 $sul-button-bg: white;
 $sul-button-border-color: $color-beige-30;

--- a/app/assets/stylesheets/was_seed.scss
+++ b/app/assets/stylesheets/was_seed.scss
@@ -1,24 +1,40 @@
+@import 'sul_variables';
 @import 'common';
 @import 'vendor/tooltip';
 @import 'modules/slider';
+@import 'modules/shadows';
 
 .#{$namespace}-body {
-  height: 260px;
+  background-color: $sul-background;
+  height: 280px;
   padding: 0;
  }
  
 .#{$namespace}-was-thumb-list {
   list-style: none;
+  padding: 10px;
  }
 
 .#{$namespace}-was-thumb-item {
   cursor: pointer;
   float: left;
   height: 100%;
-  margin: 10px;
-  width: 200px;
+  margin-bottom: 10px;
+  width: 220px;
+
+  &:hover {
+    @include shadow(2);
+    background-color: $color-beige-05;
+    transition: all 0.2s ease-in-out;
+  }
+
+  &.active {
+    @include shadow(2);
+    background-color: $white-color;
+  }
 }
 
-.#{$namespace}-was-thumb-item-date {
+.#{$namespace}-was-thumb-item-div {
+  margin: 10px;
   text-align: center;
 }

--- a/lib/embed/viewer/was_seed.rb
+++ b/lib/embed/viewer/was_seed.rb
@@ -15,10 +15,9 @@ module Embed
                   doc.li(class: 'sul-embed-was-thumb-item') do
                     doc.div(class: 'sul-embed-was-thumb-item-div') do
                       doc.img(src: thumb_record['thumbnail_uri'])
-                      doc.a(href: thumb_record['memento_uri'], target: '_blank') do
-                        doc.div(class: 'sul-embed-was-thumb-item-date') do
-                          doc.text(format_memento_datetime(thumb_record['memento_datetime']))
-                        end
+                      doc.a(class: 'sul-embed-was-thumb-item-date',
+                            href: thumb_record['memento_uri']) do
+                        doc.text(format_memento_datetime(thumb_record['memento_datetime']))
                       end
                     end
                   end


### PR DESCRIPTION
Closes #341 - Do not open links in new window
Closes #340 - Add more affordance to was links

Also provides visual design changes to be more consistent with file viewer

![embed-was](https://cloud.githubusercontent.com/assets/1656824/9317084/1ff67eba-44ee-11e5-90e1-2a4d75be5950.gif)
