### PR TITLE
update Capistrano to fix deploy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,20 +42,19 @@ GEM
     bundler-audit (0.3.1)
       bundler (~> 1.2)
       thor (~> 0.18)
-    capistrano (3.3.5)
-      capistrano-stats (~> 1.1.0)
+    capistrano (3.4.0)
       i18n
       rake (>= 10.0.0)
       sshkit (~> 1.3)
     capistrano-bundle_audit (0.0.3)
       bundler-audit
       capistrano (~> 3.0)
-    capistrano-bundler (1.1.2)
-      capistrano (~> 3.0)
+    capistrano-bundler (1.1.4)
+      capistrano (~> 3.1)
       sshkit (~> 1.2)
     capistrano-one_time_key (0.0.1)
       capistrano (~> 3.0)
-    capistrano-rails (1.1.1)
+    capistrano-rails (1.1.3)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
     capistrano-releaseboard (0.0.1)
@@ -63,7 +62,6 @@ GEM
     capistrano-rvm (0.1.1)
       capistrano (~> 3.0)
       sshkit (~> 1.2)
-    capistrano-stats (1.1.1)
     capybara (2.3.0)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -78,7 +76,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1.1)
-    colorize (0.7.5)
+    colorize (0.7.7)
     coveralls (0.8.1)
       json (~> 1.8)
       rest-client (>= 1.6.8, < 2)
@@ -214,7 +212,7 @@ GEM
       squash_ruby
     squash_ruby (1.4.0)
       json
-    sshkit (1.6.1)
+    sshkit (1.7.1)
       colorize (>= 0.7.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
-# config valid only for Capistrano 3.3
-lock '3.3.5'
+# config valid only for Capistrano 3.4.0
+lock '3.4.0'
 
 set :application, 'embed'
 set :repo_url, 'https://github.com/sul-dlss/sul-embed.git'


### PR DESCRIPTION
Deploys were running into an issue where they would fail reporting: 

```
'assets_manifest_backup’ is not a directory
```

This PR fixes the issue. Tested successfully on dev