### PR TITLE
closes #371

### DIFF
--- a/app/assets/javascripts/modules/image_x_viewer.js
+++ b/app/assets/javascripts/modules/image_x_viewer.js
@@ -60,7 +60,7 @@
     var _enableBottomPanel = function() {
       $thumbSliderContainer.slideDown();
     };
-    
+
     var _closeThumbSlider = function() {
       PubSub.publish('thumbSliderToggle');
       $thumbOpenClose.addClass('sul-i-rotate-180');

--- a/app/assets/javascripts/vendor/manifestor.js
+++ b/app/assets/javascripts/vendor/manifestor.js
@@ -3142,9 +3142,10 @@ var manifestor = function(options) {
     selectPerspective: selectPerspective,
     selectViewingMode: selectViewingMode,
     updateThumbSize: updateThumbSize,
-    refreshState: refreshState
+    refreshState: refreshState,
+    getState: canvasState,
+    setState: canvasState
   };
-
 };
 
 module.exports = manifestor;


### PR DESCRIPTION
Just refreshes manifestor so that the new methods are available. You can now call getState and setState on the canvasStore to refresh the UI when the state change event is sent out.