### PR TITLE
adds some more affordance to was seed link

### DIFF
--- a/app/assets/stylesheets/was_seed.scss
+++ b/app/assets/stylesheets/was_seed.scss
@@ -27,6 +27,11 @@
   &.active {
     @include shadow(2);
     background-color: $white-color;
+    
+    a {
+      font-size: 1.2em;
+      font-weight: 400;
+    }
   }
 }
 


### PR DESCRIPTION
Adds more visibility to selected was_seed link @aalsum 

## Before
<img width="626" alt="screen shot 2015-08-28 at 2 08 28 pm" src="https://cloud.githubusercontent.com/assets/1656824/9557128/53eadc2c-4d8e-11e5-8cca-da3b151f6c8e.png">

## After
<img width="629" alt="screen shot 2015-08-28 at 2 08 15 pm" src="https://cloud.githubusercontent.com/assets/1656824/9557122/4b18c118-4d8e-11e5-9c78-fd6a01ba8f61.png">