### PR TITLE
turn off jQuery animations during test suite

### DIFF
--- a/app/views/pages/sandbox.html.erb
+++ b/app/views/pages/sandbox.html.erb
@@ -196,6 +196,10 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
   <script>
     $(function() {
+      // Turn off jQuery animations on test suite
+      if ('<%= Rails.env %>' === 'test') {
+        if (window.jQuery) { jQuery.fx.off = true; }
+      }
         $('.btn-render').on('click', function() {
             embed.render();
         });


### PR DESCRIPTION
I'm hoping that this will reduce the number of false test failures. This is some quick data run 3 times locally on each branch.

branch | test time (s) | failures
--------- | ----------- | ----------
`js-tests-fix` | 25.27, 22.28, 25.21 | 0, 0, 0
`master` | 29.1, 28.96, **46.63** | 0, 0, **2**

Not an exhaustive study, but I think this may solve some of the issues we were seeing.

http://cabeca.github.io/blog/2013/06/16/waiting-for-completed-ajax-in-capybara-and-other-tricks/