### PR TITLE
removes headings in favor of divs

### DIFF
--- a/app/assets/stylesheets/common.css.scss.erb
+++ b/app/assets/stylesheets/common.css.scss.erb
@@ -49,7 +49,7 @@
 
   }
 
-  h2.#{$namespace}-item-count {
+  .#{$namespace}-item-count {
     color: white;
     border-bottom: 0;
     font-size: $font-size-base;

--- a/lib/embed/viewer/common_viewer.rb
+++ b/lib/embed/viewer/common_viewer.rb
@@ -311,7 +311,7 @@ module Embed
       end
 
       def file_count_html(doc)
-        doc.h2(class: 'sul-embed-item-count', 'aria-live' => 'polite') {}
+        doc.div(class: 'sul-embed-item-count', 'aria-live' => 'polite') {}
       end
     end
   end

--- a/spec/features/file_list_accessibility_spec.rb
+++ b/spec/features/file_list_accessibility_spec.rb
@@ -10,7 +10,7 @@ describe 'file list accessibility', js: true do
     expect(page).to have_content 'Preview item 1'
     expect(page).to have_css 'a[aria-expanded="false"]'
     expect(page).to have_css 'div.sul-embed-preview[aria-hidden="true"]', visible: false
-    expect(page).to have_css 'h2.sul-embed-item-count[aria-live="polite"]'
+    expect(page).to have_css 'div.sul-embed-item-count[aria-live="polite"]'
     click_link 'Preview'
     expect(page).to have_css '.sul-embed-preview img[alt]'
     expect(page).to have_content 'Close preview item 1'


### PR DESCRIPTION
Closes #401 

Note: does not remove headings from legacy image viewer