### PR TITLE
add left/right mouse buttons that fade out

### DIFF
--- a/app/assets/javascripts/modules/image_x_viewer.js
+++ b/app/assets/javascripts/modules/image_x_viewer.js
@@ -94,6 +94,35 @@
       $itemCount.text(numImages + text);
     };
 
+    var _addLeftRightControls = function() {
+      var $leftControl = $('<div class="sul-embed-image-x-side-control sul-em' +
+        'bed-image-x-side-control-left"><div class=sul-i-arrow-left-8></div><' +
+        '/div>');
+      var $rightControl = $('<div class="sul-embed-image-x-side-control sul-e' +
+        'mbed-image-x-side-control-right"><div class=sul-i-arrow-right-8></di' +
+        'v></div>');
+      $el.append($leftControl, $rightControl);
+      $leftControl.on('click', function() {
+        thumbSliderSly.prev();
+      });
+      $rightControl.on('click', function() {
+        thumbSliderSly.next();
+      });
+      var timeout;
+      // Show controls for 2 seconds when mouse stops moving
+      $el.on('mousemove', function() {
+        $leftControl.stop();
+        $rightControl.stop();
+        $leftControl.fadeIn(200);
+        $rightControl.fadeIn(200);
+        clearTimeout(timeout);
+        timeout = setTimeout(function() {
+          $leftControl.fadeOut(2000);
+          $rightControl.fadeOut(2000);
+        }, 1000);
+      });
+    };
+
     var _setupButtonListeners = function() {
       $embedHeader.find('[data-sul-view-mode]').on('click', function() {
         var mode = $(this).data().sulViewMode;
@@ -332,6 +361,7 @@
 
         _setupButtonListeners();
         _listenForActions();
+        _addLeftRightControls();
 
         _extractDruid();
 

--- a/app/assets/stylesheets/image_x.scss
+++ b/app/assets/stylesheets/image_x.scss
@@ -104,3 +104,32 @@ $image-thumb-slider-background-color: $sul-background;
   white-space: nowrap;
   width: 100%;
 }
+
+.#{$namespace}-image-x-side-control {
+  bottom: 0;
+  color: #ffffff;
+  cursor: pointer;
+  font-size: 2em;
+  left: 0;
+  position: absolute;
+  text-align: center;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+  top: 0;
+  width: 10%;
+  z-index: 100;
+
+  &.#{$namespace}-image-x-side-control-right {
+    left: auto;
+    right: 0;
+
+    div {
+      right: 50%;
+    }
+  }
+
+  div {
+    display: inline-block;
+    position: absolute;
+    top: 50%;
+  }
+}


### PR DESCRIPTION
Closes #432 , left/right are visible during mouse moves and then fadeout

<img width="595" alt="screen shot 2015-09-21 at 2 22 04 pm" src="https://cloud.githubusercontent.com/assets/1656824/10002340/27b71c60-606c-11e5-939d-aec61f0e7fe9.png">
