### PR TITLE
Adds Download "Object" for Image type purls

### DIFF
--- a/app/assets/stylesheets/mixins.css.scss
+++ b/app/assets/stylesheets/mixins.css.scss
@@ -20,3 +20,8 @@
 @mixin license-image($license) {
   background: url('#{$asset_base}#{$license}') no-repeat left;
 }
+
+@mixin panel-list-style {
+  list-style: none;
+  padding-left: 8px;
+}

--- a/app/assets/stylesheets/modules/popup_panels.css.scss.erb
+++ b/app/assets/stylesheets/modules/popup_panels.css.scss.erb
@@ -113,8 +113,13 @@
   }
 
   ul.#{$namespace}-download-list {
-    list-style: none;
-    padding-left: 8px;
+    @include panel-list-style;
+  }
+
+  ul.#{$namespace}-download-list-full {
+    @include panel-list-style;
+    padding-bottom: 8px;
+    padding-top: 8px;
   }
 
   .#{$namespace}-license-by {

--- a/app/views/pages/sandbox.html.erb
+++ b/app/views/pages/sandbox.html.erb
@@ -132,6 +132,12 @@
         Image with restrictions - bb537hc4022
       </li>
       <li>
+        Image with Book download - dn665vh1697
+      </li>
+      <li>
+        Image with pdf and other downloads - bg262qk2288
+      </li>
+      <li>
         Files - tn629pk3948
       </li>
       <li>

--- a/lib/embed/mimetypes.rb
+++ b/lib/embed/mimetypes.rb
@@ -1,0 +1,38 @@
+module Embed
+  module Mimetypes
+    ##
+    # Creates a pretty human readable mime type
+    # @param [String] mimetype
+    # @return [String]
+    def pretty_mime(mimetype)
+      PrettyMime.new(mimetype).prettify
+    end
+
+    ##
+    # A quick best effort to create a short human readable mimetype
+    class PrettyMime
+      attr_reader :mimetype
+      ##
+      # @param [String] mimetype
+      def initialize(mimetype)
+        @mimetype = mimetype
+      end
+
+      ##
+      # Make the mimetype pretty if it can be looked up
+      # @return [String]
+      def prettify
+        if lookup.nil?
+          @mimetype
+        else
+          lookup.to_s.delete(':')
+        end
+      end
+      
+      private
+      def lookup
+        @lookup ||= Mime::Type.lookup(mimetype).to_sym
+      end
+    end
+  end
+end

--- a/lib/embed/pretty_filesize.rb
+++ b/lib/embed/pretty_filesize.rb
@@ -1,0 +1,17 @@
+module Embed
+  ##
+  # Mixin to provide standardized convenience methods to make filesize's pretty
+  module PrettyFilesize
+    ##
+    # Convert to a standardized pretty filesize
+    def pretty_filesize(size)
+      Filesize.from("#{to_kilobyte(size)} KB").pretty
+    end
+
+    ##
+    # Covert Bytes to Kilobytes
+    def to_kilobyte(size)
+      size.to_f / 1000
+    end
+  end
+end

--- a/lib/embed/viewer/common_viewer.rb
+++ b/lib/embed/viewer/common_viewer.rb
@@ -1,6 +1,11 @@
+require 'embed/mimetypes'
+require 'embed/pretty_filesize'
+
 module Embed
   class Viewer
     class CommonViewer
+      include Embed::Mimetypes
+      include Embed::PrettyFilesize
       def initialize(request)
         @request = request
         @purl_object = request.purl_object
@@ -200,6 +205,14 @@ module Embed
       # @return [String]
       def file_url(title)
         "#{stacks_url}/#{title}"
+      end
+
+      ##
+      # Checks to see if an item is embargoed to the world
+      # @param [Embed::PURL::Resource::ResourceFile]
+      # @return [Boolean]
+      def embargoed_to_world?(file)
+        @purl_object.embargoed? && !file.stanford_only?
       end
 
       ##

--- a/lib/embed/viewer/file.rb
+++ b/lib/embed/viewer/file.rb
@@ -65,14 +65,6 @@ module Embed
         end
       end
 
-      def pretty_filesize(size)
-        Filesize.from("#{to_kilobyte(size)} KB").pretty
-      end
-
-      def to_kilobyte(size)
-        size.to_f / 1000
-      end
-
       def default_body_height
         400 - (header_height + footer_height)
       end
@@ -174,14 +166,6 @@ module Embed
             end
           end
         end
-      end
-
-      ##
-      # Checks to see if an item is embargoed to the world
-      # @param [Embed::PURL::Resource::ResourceFile]
-      # @return [Boolean]
-      def embargoed_to_world?(file)
-        @purl_object.embargoed? && !file.stanford_only?
       end
 
       def file_search_logic

--- a/lib/embed/viewer/image_x.rb
+++ b/lib/embed/viewer/image_x.rb
@@ -57,9 +57,50 @@ module Embed
                 end
               end
               doc.ul(class: 'sul-embed-download-list') {}
+              @purl_object.contents.each do |resource|
+                if resource.type == 'object'
+                  doc.ul(class: 'sul-embed-download-list-full') do
+                    resource.files.each do |file|
+                      unless embargoed_to_world?(file)
+                        doc.li do
+                          doc.div(class: "#{'sul-embed-stanford-only' if file.stanford_only?}") do
+                            doc.a(href: file_url(file.title), download: nil) do
+                              if file.size.blank?
+                                doc.text full_download_title(file)
+                              else
+                                doc.text full_download_title(file) +
+                                  " #{pretty_filesize(file.size)}"
+                              end
+                            end
+                          end
+                        end
+                      end
+                    end
+                  end
+                end
+              end
             end
           end
         end.to_html
+      end
+
+      ##
+      # Title to display for the full download
+      def full_download_title(file)
+        "Download \"#{truncate(@purl_object.title).tr('"', '\'')}\" " +
+          "(as #{pretty_mime(file.mimetype)})"
+      end
+
+      ##
+      # Truncate a string
+      # @param [String] str
+      # @param [Integer] length
+      def truncate(str, length = 20)
+        if str && str.length > length
+          str.slice(0, length - 1) + ' ...'
+        else
+          str
+        end
       end
     end
   end

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -461,4 +461,128 @@ module PURLFixtures
       </publicObject>
     XML
   end
+  def image_with_pdf_purl
+    <<-XML
+      <publicObject id="druid:bb112fp0199" published="2014-04-10T16:06:21-07:00">
+        <identityMetadata>
+          <sourceId source="sul">M1711_Series3_Box104_Folder19</sourceId>
+          <objectId>druid:bb112fp0199</objectId>
+          <objectCreator>DOR</objectCreator>
+          <objectLabel>Writings - "How to Test a Good Trumpet," The Instrumentalist 31(8):57-58 (reprint, 2 pp.)</objectLabel>
+          <objectType>item</objectType>
+          <adminPolicy>druid:wg541jt7173</adminPolicy>
+          <otherId name="uuid">b655a82e-fc3d-11e1-b443-0016034322e2</otherId>
+          <tag>Project : Musical Acoustics Research Library</tag>
+          <tag>Process : Content Type : Book (flipbook, ltr)</tag>
+          <tag>Project : Musical Acoustics Research Library</tag>
+        </identityMetadata>
+        <contentMetadata type="book" objectId="bb112fp0199">
+          <resource type="page" sequence="1" id="bb112fp0199_1">
+            <label>Page 1</label>
+            <file id="bb112fp0199_06_0001.pdf" mimetype="application/pdf" size="2365677">
+          </file>
+            <file id="bb112fp0199_00_0001.jp2" mimetype="image/jp2" size="3117394">
+              <imageData width="3629" height="4556"/>
+            </file>
+          </resource>
+          <resource type="page" sequence="2" id="bb112fp0199_2">
+            <label>Page 2</label>
+            <file id="bb112fp0199_06_0002.pdf" mimetype="application/pdf" size="2398016">
+          </file>
+            <file id="bb112fp0199_00_0002.jp2" mimetype="image/jp2" size="3117384">
+              <imageData width="3629" height="4556"/>
+            </file>
+          </resource>
+          <resource type="object" sequence="3" id="bb112fp0199_3">
+            <label>Object 1</label>
+            <file id="bb112fp0199_31_0000.pdf" mimetype="application/pdf" size="4761613">
+          </file>
+          </resource>
+        </contentMetadata>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <use>
+            <human type="useAndReproduction">Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Special Collections Public Services Librarian at speccollref@stanford.edu.</human>
+            <human type="creativeCommons"/>
+            <machine type="creativeCommons"/>
+          </use>
+        </rightsMetadata>
+        <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+          <dc:title>Writings - "How to Test a Good Trumpet," The Instrumentalist 31(8):57-58 (reprint, 2 pp.)</dc:title>
+          <dc:relation type="collection">Musical Acoustics Research Library collection, 1956-2007</dc:relation>
+        </oai_dc:dc>
+      </publicObject>
+    XML
+  end
+  def image_with_pdf_restricted_purl
+    <<-XML
+      <publicObject id="druid:bb112fp0199" published="2014-04-10T16:06:21-07:00">
+        <identityMetadata>
+          <sourceId source="sul">M1711_Series3_Box104_Folder19</sourceId>
+          <objectId>druid:bb112fp0199</objectId>
+          <objectCreator>DOR</objectCreator>
+          <objectLabel>Writings - "How to Test a Good Trumpet," The Instrumentalist 31(8):57-58 (reprint, 2 pp.)</objectLabel>
+          <objectType>item</objectType>
+          <adminPolicy>druid:wg541jt7173</adminPolicy>
+          <otherId name="uuid">b655a82e-fc3d-11e1-b443-0016034322e2</otherId>
+          <tag>Project : Musical Acoustics Research Library</tag>
+          <tag>Process : Content Type : Book (flipbook, ltr)</tag>
+          <tag>Project : Musical Acoustics Research Library</tag>
+        </identityMetadata>
+        <contentMetadata type="book" objectId="bb112fp0199">
+          <resource type="page" sequence="1" id="bb112fp0199_1">
+            <label>Page 1</label>
+            <file id="bb112fp0199_06_0001.pdf" mimetype="application/pdf" size="2365677">
+          </file>
+            <file id="bb112fp0199_00_0001.jp2" mimetype="image/jp2" size="3117394">
+              <imageData width="3629" height="4556"/>
+            </file>
+          </resource>
+          <resource type="page" sequence="2" id="bb112fp0199_2">
+            <label>Page 2</label>
+            <file id="bb112fp0199_06_0002.pdf" mimetype="application/pdf" size="2398016">
+          </file>
+            <file id="bb112fp0199_00_0002.jp2" mimetype="image/jp2" size="3117384">
+              <imageData width="3629" height="4556"/>
+            </file>
+          </resource>
+          <resource type="object" sequence="3" id="bb112fp0199_3">
+            <label>Object 1</label>
+            <file id="bb112fp0199_31_0000.pdf" mimetype="application/pdf">
+          </file>
+          </resource>
+        </contentMetadata>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <group>Stanford</group>
+            </machine>
+          </access>
+          <use>
+            <human type="useAndReproduction">Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Special Collections Public Services Librarian at speccollref@stanford.edu.</human>
+            <human type="creativeCommons"/>
+            <machine type="creativeCommons"/>
+          </use>
+        </rightsMetadata>
+        <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+          <dc:title>Yolo</dc:title>
+          <dc:relation type="collection">Musical Acoustics Research Library collection, 1956-2007</dc:relation>
+        </oai_dc:dc>
+      </publicObject>
+    XML
+  end
 end

--- a/spec/lib/embed/mimetypes_spec.rb
+++ b/spec/lib/embed/mimetypes_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe Embed::Mimetypes do
+  let(:dummy_class) { Class.new { include Embed::Mimetypes }.new }
+  describe '.pretty_mime' do
+    it 'for a known mimetype' do
+      expect(dummy_class.pretty_mime('application/pdf')).to eq 'pdf'
+    end
+    it 'for an unknown mimetype' do
+      expect(dummy_class.pretty_mime('text/yolo')).to eq 'text/yolo'
+    end
+  end
+end

--- a/spec/lib/embed/pretty_filesize_spec.rb
+++ b/spec/lib/embed/pretty_filesize_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+describe Embed::PrettyFilesize do
+  let(:dummy_class) { Class.new { include Embed::PrettyFilesize }.new }
+  describe '.pretty_file_size' do
+    it 'should return the correct size' do
+      expect(dummy_class.pretty_filesize(123_45)).to eq '12.35 kB'
+    end
+  end
+end

--- a/spec/lib/embed/viewer/file_spec.rb
+++ b/spec/lib/embed/viewer/file_spec.rb
@@ -33,11 +33,6 @@ describe Embed::Viewer::File do
       expect(viewer.send(:body_height)).to eq 407
     end
   end
-  describe 'pretty_file_size' do
-    it 'should return the correct size' do
-      expect(file_viewer.pretty_filesize(123_45)).to eq '12.35 kB'
-    end
-  end
   describe 'header tools' do
     it 'should include the search in the header tools' do
       stub_request(request)

--- a/spec/lib/embed/viewer/image_x_spec.rb
+++ b/spec/lib/embed/viewer/image_x_spec.rb
@@ -29,5 +29,20 @@ describe Embed::Viewer::ImageX do
       expect(html).to have_css('.sul-embed-image-x-buttons button', count: 4, visible: false)
       expect(html).to have_css('#sul-embed-image-x[data-world-restriction=false]', visible: false)
     end
+    it 'full download should be present' do
+      expect(request).to receive(:hide_title?).at_least(:once).and_return(false)
+      stub_purl_response_and_request(image_with_pdf_purl, request)
+      expect(image_x_viewer).to receive(:asset_host).at_least(:twice).and_return('http://example.com/')
+      html = Capybara.string(image_x_viewer.to_html)
+      expect(html).to have_css '.sul-embed-download-list-full', visible: false
+      expect(html).to have_css 'ul li div a', visible: false, text: 'Download "Writings - \'How to  ..." (as pdf) 4.76 MB'
+    end
+    it 'full download restricted' do
+      expect(request).to receive(:hide_title?).at_least(:once).and_return(false)
+      stub_purl_response_and_request(image_with_pdf_restricted_purl, request)
+      expect(image_x_viewer).to receive(:asset_host).at_least(:twice).and_return('http://example.com/')
+      html = Capybara.string(image_x_viewer.to_html)
+      expect(html).to have_css 'ul li div.sul-embed-stanford-only a', visible: false, text: 'Download "Yolo" (as pdf)'
+    end
   end
 end


### PR DESCRIPTION
Closes #14 
Closes #310 

## bh538xp9013
<img width="600" alt="screen shot 2015-10-13 at 8 52 54 am" src="https://cloud.githubusercontent.com/assets/1656824/10460165/067d0820-7188-11e5-871f-0a9433e29d77.png">

## dn665vh1697 (with restricted download)
<img width="592" alt="screen shot 2015-10-13 at 9 06 50 am" src="https://cloud.githubusercontent.com/assets/1656824/10460578/c7500614-7189-11e5-8676-01d640f36328.png">

## bg262qk2288 (multi file)
Note: other download links are not showing due to incorrect manifest/stacks info. Should be resolved with stacks/purl upgrade
<img width="598" alt="screen shot 2015-10-13 at 8 55 37 am" src="https://cloud.githubusercontent.com/assets/1656824/10460210/3f30b4f0-7188-11e5-8636-5eb5d08e5a56.png">
