### PR TITLE
Move render logic for image viewer controls to a single place

### DIFF
--- a/app/assets/javascripts/image_x.js
+++ b/app/assets/javascripts/image_x.js
@@ -14,6 +14,7 @@
 //= require modules/manifest_store
 //= require modules/layout_store
 //= require modules/canvas_store
+//= require modules/image_controls
 //= require modules/image_x_viewer
 
 CssInjection.injectFontIcons();

--- a/app/assets/javascripts/modules/image_controls.js
+++ b/app/assets/javascripts/modules/image_controls.js
@@ -1,0 +1,96 @@
+/*global PubSub */
+
+(function(global) {
+  'use strict';
+
+  // Handles the display of the image controls in image viewer
+  var ImageControls = (function() {
+    var $imageControls;
+    var $fullscreen;
+    var $pagedMode;
+    var $individualsMode;
+    var $overviewPerspective;
+
+    return {
+      render: function(layout, canvas) {
+        layout = typeof layout !== 'undefined' ?  layout : {};
+        canvas = typeof canvas !== 'undefined' ?  canvas : {};
+
+        // Fullscreen
+        if (layout.fullscreen) {
+          $fullscreen.removeAttr('disabled');
+        } else {
+          $fullscreen.attr('disabled', '');
+        }
+
+        // Modes
+        if (layout.individuals) {
+          $individualsMode.removeClass('sul-embed-hidden');
+        }
+        if (layout.paged) {
+          $pagedMode.removeClass('sul-embed-hidden');
+        }
+
+        // Perspective
+        if (layout.overviewPerspectiveAvailable) {
+          $overviewPerspective.removeClass('sul-embed-hidden');
+        }
+
+        if (canvas.perspective === 'overview') {
+          $individualsMode.removeClass('active');
+          $pagedMode.removeClass('active');
+          $overviewPerspective.addClass('active');
+        } else {
+          $overviewPerspective.removeClass('active');
+          if (canvas.viewingMode === 'individuals') {
+            $pagedMode.removeClass('active');
+            $individualsMode.addClass('active');
+          } else {
+            $individualsMode.removeClass('active');
+            $pagedMode.addClass('active');
+          }
+        }
+      },
+      init: function($el) {
+        $imageControls = $el;
+        $fullscreen = $el.find('[data-sul-view-fullscreen]');
+        $pagedMode = $el.find('[data-sul-view-mode="paged"]');
+        $individualsMode = $el.find('[data-sul-view-mode="individuals"]');
+        $overviewPerspective = $el.find('[data-sul-view-perspective]');
+        
+        // Handle control events here, but unfortunately we cannot handle the 
+        // fullscreen through PubSub because of browser security restrictions
+        $pagedMode.on('click', function() {
+          var mode = $(this).data().sulViewMode;
+          PubSub.publish('updateMode', mode);
+        });
+        
+        $individualsMode.on('click', function() {
+          var mode = $(this).data().sulViewMode;
+          PubSub.publish('updateMode', mode);
+        });
+        
+        $overviewPerspective.on('click', function() {
+          PubSub.publish('updatePerspective', 'overview');
+        });
+
+        return this;
+      },
+      _paged: function() {
+        return $pagedMode;
+      },
+      _individuals: function() {
+        return $individualsMode;
+      },
+      _fullscreen: function() {
+        return $fullscreen;
+      },
+      _overview: function() {
+        return $overviewPerspective;
+      }
+    };
+  })();
+  
+
+  global.ImageControls = ImageControls;
+})(this);

--- a/app/assets/javascripts/modules/image_x_viewer.js
+++ b/app/assets/javascripts/modules/image_x_viewer.js
@@ -1,4 +1,4 @@
-/*global Sly, LayoutStore, ManifestStore, PubSub, CanvasStore, key, sulEmbedDownloadPanel */
+/*global Sly, LayoutStore, ManifestStore, PubSub, CanvasStore, key, sulEmbedDownloadPanel, ImageControls */
 
 (function( global ) {
   'use strict';
@@ -14,6 +14,7 @@
     var $thumbSliderContainer;
     var thumbSliderSly;
     var $embedHeader;
+    var imageControls;
 
     var _listenForActions = function() {
       PubSub.subscribe('manifestStateUpdated', function() {
@@ -50,28 +51,19 @@
         }
       });
       PubSub.subscribe('disableFullscreen', function() {
-        $embedHeader.find('[data-sul-view-fullscreen]')
-          .attr('disabled', '');
+        imageControls.render(layoutStore.getState(), canvasStore.getState());
       });
       PubSub.subscribe('enableFullscreen', function() {
-        $embedHeader.find('[data-sul-view-fullscreen]')
-          .removeAttr('disabled');
+        imageControls.render(layoutStore.getState(), canvasStore.getState());
       });
-      PubSub.subscribe('disableMode', function(_, mode) {
-        $embedHeader.find('[data-sul-view-mode="' + mode + '"]')
-          .addClass('sul-embed-hidden');
+      PubSub.subscribe('disableMode', function() {
+        imageControls.render(layoutStore.getState(), canvasStore.getState());
       });
-      PubSub.subscribe('disableOverviewPerspective', function() {
-        $embedHeader.find('[data-sul-view-perspective]')
-          .addClass('sub-embed-hidden');
-      });
-      PubSub.subscribe('enableMode', function(_, mode) {
-        $embedHeader.find('[data-sul-view-mode="' + mode + '"]')
-          .removeClass('sul-embed-hidden');
+      PubSub.subscribe('enableMode', function() {
+        imageControls.render(layoutStore.getState(), canvasStore.getState());
       });
       PubSub.subscribe('enableOverviewPerspective', function() {
-        $embedHeader.find('[data-sul-view-perspective]')
-          .removeClass('sul-embed-hidden');
+        imageControls.render(layoutStore.getState(), canvasStore.getState());
       });
       /**
        * Enable the bottomPanel in detail perspective and update Sly thumb
@@ -165,14 +157,6 @@
     };
 
     var _setupButtonListeners = function() {
-      $embedHeader.find('[data-sul-view-mode]').on('click', function() {
-        var mode = $(this).data().sulViewMode;
-        PubSub.publish('updateMode', mode);
-      });
-      $embedHeader.find('[data-sul-view-perspective]').on('click', function() {
-        var perspective = $(this).data().sulViewPerspective;
-        PubSub.publish('updatePerspective', perspective);
-      });
       $embedHeader.find('[data-sul-view-fullscreen="fullscreen"]')
         .on('click', function() {
           canvasStore.osd.setFullScreen(true);
@@ -399,8 +383,8 @@
         // Access data attributes
         dataAttributes = $el.data();
         $embedHeader = $el.parent().parent();
-
         _setupButtonListeners();
+        imageControls = ImageControls.init($embedHeader);
         _listenForActions();
 
         _extractDruid();

--- a/app/assets/javascripts/modules/layout_store.js
+++ b/app/assets/javascripts/modules/layout_store.js
@@ -20,8 +20,6 @@
         bottomPanelEnabled: true,
         bottomPanelOpen: true,
         fullscreen: true,
-        modeIndividualsAvailable: false,
-        modePagedAvailable: false,
         overviewPerspectiveAvailable: false,
         keyboardNavMode: null
         // currentFocus: null,

--- a/spec/javascripts/fixtures/image_controls.html
+++ b/spec/javascripts/fixtures/image_controls.html
@@ -1,0 +1,10 @@
+<div class="sul-embed-image-x-buttons">
+  <button class="sul-embed-btn sul-embed-btn-default sul-embed-btn-toolbar sul-i-layout-none sul-embed-hidden" data-sul-view-mode="individuals">
+  </button>
+  <button class="sul-embed-btn sul-embed-btn-default sul-embed-btn-toolbar sul-i-layout-4 sul-embed-hidden" data-sul-view-mode="paged">
+  </button>
+  <button class="sul-embed-btn sul-embed-btn-default sul-embed-btn-toolbar sul-i-view-module-1 sul-embed-hidden" data-sul-view-perspective="overview">
+  </button>
+  <button class="sul-embed-btn sul-embed-btn-default sul-embed-btn-toolbar sul-i-expand-1 sul-embed-hidden" data-sul-view-fullscreen="fullscreen">
+  </button>
+</div>

--- a/spec/javascripts/image_controls/image_controls_spec.js
+++ b/spec/javascripts/image_controls/image_controls_spec.js
@@ -1,0 +1,71 @@
+/*global ImageControls */
+//= require modules/image_controls
+
+'use strict';
+
+describe('ImageControls', function() {
+  var imageControls;
+
+  beforeEach(function() {
+    fixture.load('image_controls.html');
+    imageControls = ImageControls.init($('.sul-embed-image-x-buttons'));
+
+  });
+  describe('init', function() {
+  });
+  describe('render', function() {
+    describe('paged button', function(){
+      it('is visible when turned on', function() {
+        imageControls.render({paged: true});
+        expect(imageControls._paged()).not.toHaveClass('sul-embed-hidden');
+      });
+      it('is active when canvas viewingMode is paged', function() {
+        imageControls.render({}, {viewingMode: 'paged'});
+        expect(imageControls._paged()).toHaveClass('active');
+      });
+    });
+    describe('individuals button', function() {
+      it('is visible when turned on', function() {
+        imageControls.render({individuals: true});
+        expect(imageControls._individuals()).not
+          .toHaveClass('sul-embed-hidden');
+      });
+      it('is active when canvas viewingMode is individuals', function() {
+        imageControls.render({}, {viewingMode: 'individuals'});
+        expect(imageControls._individuals()).toHaveClass('active');
+      });
+    });
+    describe('overview button', function() {
+      it('is visible when turned on', function() {
+        imageControls.render({overviewPerspectiveAvailable: true});
+        expect(imageControls._overview()).not.toHaveClass('sul-embed-hidden');
+      });
+      it('is active when canvas perspective is overview', function() {
+        imageControls.render({}, {perspective: 'overview'});
+        expect(imageControls._overview()).toHaveClass('active');
+      });
+      it('other controls are not active', function() {
+        //paged
+        imageControls._paged().addClass('active');
+        expect(imageControls._paged()).toHaveClass('active');
+        imageControls.render({}, {perspective: 'overview'});
+        expect(imageControls._paged()).not.toHaveClass('active');
+        //individuals
+        imageControls._individuals().addClass('active');
+        expect(imageControls._individuals()).toHaveClass('active');
+        imageControls.render({}, {perspective: 'overview'});
+        expect(imageControls._individuals()).not.toHaveClass('active');
+      });
+    });
+    describe('fullscreen button', function(){
+      it('when enabled', function() {
+        imageControls.render({fullscreen: true});
+        expect(imageControls._fullscreen()).not.toBeDisabled();
+      });
+      it('when disabled', function() {
+        imageControls.render({fullscreen: false});
+        expect(imageControls._fullscreen()).toBeDisabled();
+      });
+    });
+  });
+});

--- a/spec/javascripts/layout_store/layout_store_spec.js
+++ b/spec/javascripts/layout_store/layout_store_spec.js
@@ -29,8 +29,6 @@ describe('LayoutStore', function() {
         bottomPanelEnabled: true,
         bottomPanelOpen: true,
         fullscreen: true,
-        modeIndividualsAvailable: false,
-        modePagedAvailable: false,
         overviewPerspectiveAvailable: false,
         keyboardNavMode: null
       });      

--- a/spec/teaspoon_env.rb
+++ b/spec/teaspoon_env.rb
@@ -196,4 +196,7 @@ Teaspoon.configure do |config|
   config.suite :layout_store do |suite|
     suite.matcher = '{spec/javascripts/layout_store}/**/*_spec.{js,js.coffee,coffee}'
   end
+  config.suite :image_controls do |suite|
+    suite.matcher = '{spec/javascripts/image_controls}/**/*_spec.{js,js.coffee,coffee}'
+  end
 end


### PR DESCRIPTION
This commit aims to move image control behavior more inline with the Flux/React way of doing things. This is a prerequisite for some of the accessibility work.