### PR TITLE
Update media viewer with configurable streaming endpoint to generate...

### DIFF
--- a/app/assets/stylesheets/media.scss
+++ b/app/assets/stylesheets/media.scss
@@ -1,1 +1,7 @@
 @import 'common';
+
+.sul-embed-media {
+  text-align: center;
+
+  audio { width: 100%; }
+}

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,3 +10,7 @@ squash_disable: <%= (Rails.env.development? || Rails.env.test?) %>
 geo_external_url: 'https://earthworks.stanford.edu/catalog/stanford-'
 geo_wms_url: 'https://geowebservices.stanford.edu/geoserver/wms/'
 was_thumbs_url: 'https://thumbnail-service-example'
+streaming_service:
+  host: 'streaming-server.stanford.edu'
+  port: '1935'
+  application: 'media_infrastructure'

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -1,0 +1,60 @@
+module Embed
+  # Utility class to handle generating HTML media tags
+  class MediaTag
+    SUPORTED_MEDIA_TYPES = [:audio, :video].freeze
+    ENABLED_STREAMING_TYPES = [:hls].freeze
+    STREAMING_URL_SCHEMA = {
+      hls: { protocol: 'http', suffix: 'playlist.m3u8' },
+      mdash: { protocol: 'http', suffix: 'manifest.mpd' }
+    }.freeze
+
+    def initialize(ng_doc, viewer)
+      @ng_document = ng_doc
+      @viewer = viewer
+      @purl_document = viewer.purl_object
+      build_markup
+    end
+
+    private
+
+    attr_reader :ng_document, :purl_document, :request, :viewer
+
+    def build_markup
+      purl_document.contents.each do |resource|
+        next unless SUPORTED_MEDIA_TYPES.include?(resource.type.to_sym)
+        resource.files.each do |file|
+          ng_document.send(resource.type.to_sym, controls: 'controls', height: "#{viewer.body_height}px") do
+            enabled_streaming_sources(file)
+          end
+        end
+      end
+    end
+
+    def enabled_streaming_sources(file)
+      ENABLED_STREAMING_TYPES.each do |streaming_type|
+        ng_document.source(
+          src: streaming_url_for(file, streaming_type),
+          type: file.mimetype
+        )
+      end
+    end
+
+    def streaming_url_for(file, type)
+      protocol = STREAMING_URL_SCHEMA[type][:protocol]
+      suffix = STREAMING_URL_SCHEMA[type][:suffix]
+      "#{protocol}://#{streaming_base_url}/#{streaming_url_file_segment(file)}/#{suffix}"
+    end
+
+    def streaming_url_file_segment(file)
+      "#{::File.extname(file.title).delete('.')}:#{file.title}"
+    end
+
+    def streaming_base_url
+      "#{streaming_config.host}:#{streaming_config.port}/#{streaming_config.application}"
+    end
+
+    def streaming_config
+      Settings.streaming_service
+    end
+  end
+end

--- a/lib/embed/viewer/common_viewer.rb
+++ b/lib/embed/viewer/common_viewer.rb
@@ -6,6 +6,8 @@ module Embed
     class CommonViewer
       include Embed::Mimetypes
       include Embed::PrettyFilesize
+
+      attr_reader :purl_object
       def initialize(request)
         @request = request
         @purl_object = request.purl_object

--- a/lib/embed/viewer/common_viewer.rb
+++ b/lib/embed/viewer/common_viewer.rb
@@ -249,6 +249,18 @@ module Embed
         (is_a?(Embed::Viewer::ImageX) || is_a?(Embed::Viewer::Geo)) && !@request.hide_download?
       end
 
+      # Set a specific height for the body. We need to subtract
+      # the header and footer heights from the consumer
+      # requested maxheight, otherwise we set a default
+      # which can be set by the specific viewers.
+      def body_height
+        if @request.maxheight
+          @request.maxheight.to_i - (header_height + footer_height)
+        else
+          default_body_height
+        end
+      end
+
       private
 
       def tooltip_text(file)
@@ -312,18 +324,6 @@ module Embed
           40
         else
           63
-        end
-      end
-
-      # Set a specific height for the body. We need to subtract
-      # the header and footer heights from the consumer
-      # requested maxheight, otherwise we set a default
-      # which can be set by the specific viewers.
-      def body_height
-        if @request.maxheight
-          @request.maxheight.to_i - (header_height + footer_height)
-        else
-          default_body_height
         end
       end
 

--- a/lib/embed/viewer/media.rb
+++ b/lib/embed/viewer/media.rb
@@ -1,3 +1,4 @@
+require 'embed/media_tag'
 module Embed
   class Viewer
     class Media < CommonViewer
@@ -8,7 +9,7 @@ module Embed
             'style' => "max-height: #{body_height}px",
             'data-sul-embed-theme' => asset_url('media.css').to_s
           ) do
-            doc.video
+            Embed::MediaTag.new(doc, self)
             doc.script { doc.text ";jQuery.getScript(\"#{asset_url('media.js')}\");" }
           end
         end.to_html

--- a/lib/embed/viewer/media.rb
+++ b/lib/embed/viewer/media.rb
@@ -18,6 +18,12 @@ module Embed
         return [] unless ::Settings.enable_media_viewer?
         [:media]
       end
+
+      private
+
+      def default_body_height
+        400 - (header_height + footer_height)
+      end
     end
   end
 end

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -619,9 +619,30 @@ module PURLFixtures
           <objectLabel>Title of the video</objectLabel>
         </identityMetadata>
         <contentMetadata type="media">
+          <resource sequence="1" id="abc123_1" type="video">
+            <file id="abc_123.mp4" mimetype="video/mp4"></file>
+          </resource>
         </contentMetadata>
         <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
           <dc:title>stupid dc title of video</dc:title>
+        </oai_dc>
+      </publicObject>
+    XML
+  end
+
+  def audio_purl
+    <<-XML
+      <publicObject>
+        <identityMetadata>
+          <objectLabel>Title of the video</objectLabel>
+        </identityMetadata>
+        <contentMetadata type="media">
+          <resource sequence="1" id="abc123_1" type="audio">
+            <file id="abc_123.mp3" mimetype="audio/mpeg"></file>
+          </resource>
+        </contentMetadata>
+        <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+          <dc:title>DC title of audio</dc:title>
         </oai_dc>
       </publicObject>
     XML

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+describe Embed::MediaTag do
+  include PURLFixtures
+
+  let(:purl) { video_purl }
+  let(:viewer) do
+    double(
+      'MediaViewer',
+      purl_object: Embed::PURL.new('ignored'),
+      body_height: '300'
+    )
+  end
+  let(:document) { double('Nokogiri HTML Builder') }
+  subject { described_class.new(document, viewer) }
+
+  before { stub_purl_response_with_fixture(purl) }
+
+  describe 'media tags' do
+    context 'video' do
+      it 'renders a video tag in the provided document' do
+        expect(document).to receive(:video)
+        subject
+      end
+    end
+
+    context 'audio' do
+      let(:purl) { audio_purl }
+
+      it 'renders an audo tag in the provided document' do
+        expect(document).to receive(:audio)
+        subject
+      end
+    end
+  end
+
+  describe 'private methods' do
+    before { expect(document).to receive(:video) }
+    let(:file) { double('File', title: 'abc123.mp4', mimetype: 'video/mp4') }
+    describe '#enabled_streaming_sources' do
+      it 'adds a source element for every enabled type' do
+        expect(document).to receive(:source).with(hash_including(:src, type: 'video/mp4'))
+        subject.send(:enabled_streaming_sources, file)
+      end
+    end
+
+    describe '#streaming_url_for' do
+      it 'wraps the generated stream URL with the protocol and suffix' do
+        expect(subject.send(:streaming_url_for, file, :hls)).to match(%r{http://.*/playlist.m3u8})
+        expect(subject.send(:streaming_url_for, file, :mdash)).to match(%r{http://.*/manifest.mpd})
+      end
+    end
+
+    describe '#streaming_url_file_segment' do
+      it 'is the filename with the extension appended with a ":"' do
+        expect(subject.send(:streaming_url_file_segment, file)).to eq 'mp4:abc123.mp4'
+      end
+    end
+  end
+end

--- a/spec/lib/embed/viewer/common_viewer_spec.rb
+++ b/spec/lib/embed/viewer/common_viewer_spec.rb
@@ -155,4 +155,16 @@ describe Embed::Viewer::CommonViewer do
       expect(geo_hide_viewer.show_download?).to be_falsey
     end
   end
+
+  describe '#body_height' do
+    it 'is the default_body_height when no maxheight is provided' do
+      expect(file_viewer).to receive(:default_body_height).and_return(200)
+      expect(file_viewer.body_height).to eq 200
+    end
+
+    it 'subtracts the header and footer height' do
+      expect(request).to receive(:maxheight).at_least(:once).and_return(200)
+      expect(file_viewer.body_height).to be < 200
+    end
+  end
 end

--- a/spec/lib/embed/viewer/media_spec.rb
+++ b/spec/lib/embed/viewer/media_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Embed::Viewer::Media do
+  include PURLFixtures
+
   let(:request) { Embed::Request.new(url: 'https://purl.stanford.edu/ignored') }
   let(:media_viewer) { Embed::Viewer::Media.new(request) }
 
@@ -17,7 +19,8 @@ describe Embed::Viewer::Media do
   end
 
   describe '#body_html' do
-    it 'includes some dummy content' do
+    before { stub_purl_response_with_fixture(video_purl) }
+    it 'implements the MediaTag class appropriately and gets a video tag' do
       allow(request).to receive(:rails_request).and_return(double(host_with_port: ''))
       stub_request(request)
       body_html = Capybara.string(media_viewer.body_html)


### PR DESCRIPTION
...`<source>` elements.

<img width="513" alt="configured-media" src="https://cloud.githubusercontent.com/assets/96776/14335481/7f013dd0-fc10-11e5-8ff2-d08a30cc83e3.png">

Closes #526