### PR TITLE
re-add spec expect statements for visibility of download panel

### DIFF
--- a/spec/features/download_panel_spec.rb
+++ b/spec/features/download_panel_spec.rb
@@ -11,7 +11,9 @@ describe 'download panel', js: true do
       click_button 'Embed'
     end
     it 'should be present after a user clicks the button' do
+      expect(page).to have_css('.sul-embed-download-panel', visible: false)
       toggle_download_panel
+      expect(page).to have_css('.sul-embed-download-panel', visible: true)
       expect(page).to have_css('.sul-embed-panel-item-label', text: '')
       expect(page).to have_css('.sul-embed-download-list-item', visible: true, count: 6)
     end

--- a/spec/features/media_viewer_spec.rb
+++ b/spec/features/media_viewer_spec.rb
@@ -22,8 +22,9 @@ describe 'media viewer', js: true do
     end
 
     it 'renders a download panel' do
+      expect(page).to have_css('.sul-embed-download-panel', visible: false)
       toggle_download_panel
-
+      expect(page).to have_css('.sul-embed-download-panel', visible: true)
       expect(page).to have_css('ul.sul-embed-download-list', count: 1)
       expect(page).to have_css('.sul-embed-download-list li a', visible: true, count: 2, text: /^Download/)
     end


### PR DESCRIPTION
@jkeck   This is more in keeping with what I was trying to say for the earlier add download_panel PR #537 , especially  for download_panel_spec  feature -- it matches the spec description nicely.  But I am totally ok with you closing this w/o a merge if you think it's a stupid thing to test, or test this way.