### PR TITLE
stacks streaming url update

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,5 +11,5 @@ geo_external_url: 'https://earthworks.stanford.edu/catalog/stanford-'
 geo_wms_url: 'https://geowebservices.stanford.edu/geoserver/wms/'
 was_thumbs_url: 'https://thumbnail-service-example'
 streaming_url_suffixes:
-  hls: 'playlist.m3u8'
-  dash: 'manifest.mpd'
+  hls: '.m3u8'
+  dash: '.mpd'

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -40,7 +40,7 @@ module Embed
 
     def streaming_url_for(file, type)
       suffix = Settings.streaming_url_suffixes[type]
-      "#{Settings.stacks_url}/media/#{purl_document.druid}/#{file.title}/#{suffix}"
+      "#{Settings.stacks_url}/media/#{purl_document.druid}/#{file.title}/stream#{suffix}"
     end
   end
 end

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -46,12 +46,12 @@ describe Embed::MediaTag do
 
     describe '#streaming_url_for' do
       it 'appends the generated stream URL with the appropriate suffix' do
-        expect(subject.send(:streaming_url_for, file, :hls)).to match(%r{.*/playlist.m3u8$})
-        expect(subject.send(:streaming_url_for, file, :dash)).to match(%r{.*/manifest.mpd$})
+        expect(subject.send(:streaming_url_for, file, :hls)).to match(%r{.*/stream.m3u8$})
+        expect(subject.send(:streaming_url_for, file, :dash)).to match(%r{.*/stream.mpd$})
       end
 
       it 'has the appropriate Media Stacks URL with druid and filename' do
-        expect(subject.send(:streaming_url_for, file, :hls)).to match(%r{stacks\.stanford\.edu/media/druid/abc123\.mp4/playlist.m3u8})
+        expect(subject.send(:streaming_url_for, file, :hls)).to match(%r{stacks\.stanford\.edu/media/druid/abc123\.mp4/stream.m3u8})
       end
     end
   end


### PR DESCRIPTION
We changed the url for media streaming in the stacks app;  this re-synch sul-embed with the latest media stacks code.