### PR TITLE
Set explicit line height to media thumb icons to prevent css clash.

### DIFF
--- a/app/assets/stylesheets/media.scss
+++ b/app/assets/stylesheets/media.scss
@@ -26,6 +26,7 @@
     color: $color-pantone-401;
     float: left;
     font-size: 75px;
+    line-height: 1;
     margin-left: -6px;
   }
 


### PR DESCRIPTION
Connects to #586.

This makes it less embarrassingly wrong, but there is still some sort of css clash going on around the icons and border that should be investigated.

## xv428cw8400 (before)
<img width="413" alt="xv428cw8400-before" src="https://cloud.githubusercontent.com/assets/96776/15972786/2ec91744-2ef5-11e6-833f-468f092dec5a.png">

## xv428cw8400 (after)
<img width="491" alt="xv428cw8400-after" src="https://cloud.githubusercontent.com/assets/96776/15972785/2eb917cc-2ef5-11e6-82a0-07e821efc3f2.png">
