### PR TITLE
Add Stanford S icon to Stanford only files in multiple-media filmstrip

### DIFF
--- a/app/assets/javascripts/modules/media_viewer.js
+++ b/app/assets/javascripts/modules/media_viewer.js
@@ -23,10 +23,16 @@
         }
 
         var thumbClass = 'sul-embed-slider-thumb sul-embed-media-slider-thumb ';
+        var labelClass = 'sul-embed-thumb-label';
+
+        if ($(mediaDiv).data('stanford-only')) {
+          labelClass += ' sul-embed-thumb-stanford-only';
+        }
+
         thumbs.push(
           '<li class="' + thumbClass + activeClass + '">' +
             '<i class="' + cssClass + '"></i>' +
-            '<div class="sul-embed-thumb-label">' +
+            '<div class="' + labelClass + '">' +
               $(mediaDiv).data('file-label') +
             '</div>' +
           '</li>'

--- a/app/assets/stylesheets/media.scss
+++ b/app/assets/stylesheets/media.scss
@@ -40,4 +40,11 @@
     width: 100px;
     word-wrap: break-word;
   }
+
+  .#{$namespace}-thumb-stanford-only {
+    @include stanford-only;
+    background-position: left 4px;
+    padding-right: 0;
+    text-indent: 17px;
+  }
 }

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -30,7 +30,7 @@ module Embed
     attr_reader :purl_document, :request, :viewer
 
     def media_element(label, file, type)
-      media_wrapper(label) do
+      media_wrapper(label: label, stanford_only: file.stanford_only?) do
         <<-HTML.strip_heredoc
           <#{type}
             data-src="#{streaming_url_for(file, :dash)}"
@@ -44,10 +44,10 @@ module Embed
       end
     end
 
-    def media_wrapper(label, &block)
+    def media_wrapper(label:, stanford_only:, &block)
       <<-HTML.strip_heredoc
-        <div data-file-label="#{label}" data-slider-object="#{file_index}">
-          #{yield(block)}
+        <div data-stanford-only="#{stanford_only}" data-file-label="#{label}" data-slider-object="#{file_index}">
+          #{yield(block) if block_given?}
         </div>
       HTML
     end

--- a/spec/features/media_viewer_spec.rb
+++ b/spec/features/media_viewer_spec.rb
@@ -52,5 +52,15 @@ describe 'media viewer', js: true do
         expect(page).to have_css('.sul-embed-slider-thumb', count: 2)
       end
     end
+
+    it 'has the class indicating Stanford only for stanford restricted files' do
+      expect(page).not_to have_css('.sul-embed-thumb-slider', visible: true)
+      page.find('.sul-embed-thumb-slider-open-close').click
+      expect(page).to have_css('.sul-embed-thumb-slider', visible: true)
+
+      expect(page).to have_css('.sul-embed-thumb-stanford-only', count: 1)
+      expect(page).to have_css('.sul-embed-thumb-stanford-only', text: 'Second Video')
+      expect(page).not_to have_css('.sul-embed-thumb-stanford-only', text: 'abc_123.mp4')
+    end
   end
 end

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -650,6 +650,19 @@ module PURLFixtures
             <file id="abc_123_script.pdf" mimetype="application/pdf" size="557708"></file>
           </resource>
         </contentMetadata>
+        <rightsMetadata>
+          <access type="read">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <file>abc_321.mp4</file>
+            <machine>
+              <group>Stanford</group>
+            </machine>
+          </access>
+        </rightsMetadata>
         <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
           <dc:title>stupid dc title of video</dc:title>
         </oai_dc>

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -67,6 +67,20 @@ describe Embed::MediaTag do
     end
   end
 
+  describe '#media_wrapper' do
+    describe 'data-stanford-only attribute' do
+      it 'true for Stanford only files' do
+        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', stanford_only: true))
+        expect(media_wrapper).to have_css('[data-stanford-only="true"]')
+      end
+
+      it 'false for public files' do
+        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', stanford_only: false))
+        expect(media_wrapper).to have_css('[data-stanford-only="false"]')
+      end
+    end
+  end
+
   describe 'private methods' do
     let(:file) { double('File', title: 'abc123.mp4') }
     describe '#enabled_streaming_sources' do


### PR DESCRIPTION
Closes #588 

<img width="770" alt="stanford-only-media-filmstrip" src="https://cloud.githubusercontent.com/assets/96776/15977056/5f2a040a-2f0b-11e6-91c7-813b45527a76.png">
