### PR TITLE
access restriction messaging

### DIFF
--- a/app/assets/javascripts/modules/media_viewer.js
+++ b/app/assets/javascripts/modules/media_viewer.js
@@ -5,9 +5,13 @@
 (function( global ) {
   'use strict';
   var Module = (function() {
+    var restrictedOverlaySelector = '[data-location-restricted-overlay]';
+    var restrictedMessageSelector = '[data-access-restricted-message]';
+    var sliderObjectSelector = '[data-slider-object]';
+
     function thumbsForSlider() {
       var thumbs = [];
-      var sliderSelector = '.sul-embed-media [data-slider-object]';
+      var sliderSelector = '.sul-embed-media ' + sliderObjectSelector;
       jQuery(sliderSelector).each(function(index, mediaDiv) {
         var mediaObject = $(mediaDiv).find('audio, video');
         var cssClass;
@@ -77,11 +81,13 @@
             if (!_timedOut(start, 30000) &&
               (!windowReference || !windowReference.closed)) return;
             clearInterval(checkWindow);
-            mediaObject[0].load();
             mediaObject
-              .parent('[data-slider-object]')
-              .find('[data-auth-link]')
+              .parents(sliderObjectSelector)
+              .find('[data-auth-link], ' + restrictedOverlaySelector + ', ' + restrictedMessageSelector)
               .hide();
+            // As best I can tell, .touch() does nothing (and does not exist in jQuery),
+            // but without calling some function after .load() the media fails to load.
+            mediaObject[0].load().touch();
             return;
           }, 500);
         });
@@ -96,18 +102,18 @@
           // present the auth link if it's stanford restricted and the user isn't logged in
           if(jQuery.inArray('stanford_restricted', data.status) > -1) {
             var wrapper = jQuery('<div data-auth-link="true" class="sul-embed-auth-link"></div>');
-            mediaObject.after(
+            mediaObject.parents(sliderObjectSelector).append(
               wrapper.append(authLink(data.service, mediaObject))
             );
           }
 
           // if the user authed successfully for the file, hide the restriction overlays
-          var sliderSelector = '.sul-embed-media [data-slider-object]';
+          var sliderSelector = '.sul-embed-media ' + sliderObjectSelector;
           var parentDiv = mediaObject.closest(sliderSelector);
           var isRestricted = parentDiv.data('stanford-only') || parentDiv.data('location-restricted');
           if(isRestricted && data.status === 'success') {
-            parentDiv.find('[data-location-restricted-overlay]').hide();
-            parentDiv.find('[data-access-restricted-message]').hide();
+            parentDiv.find(restrictedOverlaySelector).hide();
+            parentDiv.find(restrictedMessageSelector).hide();
           }
         });
       });

--- a/app/assets/javascripts/modules/media_viewer.js
+++ b/app/assets/javascripts/modules/media_viewer.js
@@ -88,16 +88,26 @@
     }
 
 
-    function setupAuthLinks() {
+    function authCheck() {
       jQuery('.sul-embed-media [data-auth-url]').each(function(){
         var mediaObject = jQuery(this);
         var authUrl = mediaObject.data('auth-url');
         jQuery.ajax({url: authUrl, dataType: 'jsonp'}).done(function(data) {
-          if(data.status === 'must_authenticate') {
+          // present the auth link if it's stanford restricted and the user isn't logged in
+          if(jQuery.inArray('stanford_restricted', data.status) > -1) {
             var wrapper = jQuery('<div data-auth-link="true" class="sul-embed-auth-link"></div>');
             mediaObject.after(
               wrapper.append(authLink(data.service, mediaObject))
             );
+          }
+
+          // if the user authed successfully for the file, hide the restriction overlays
+          var sliderSelector = '.sul-embed-media [data-slider-object]';
+          var parentDiv = mediaObject.closest(sliderSelector);
+          var isRestricted = parentDiv.data('stanford-only') || parentDiv.data('location-restricted');
+          if(isRestricted && data.status === 'success') {
+            parentDiv.find('[data-location-restricted-overlay]').hide();
+            parentDiv.find('[data-access-restricted-message]').hide();
           }
         });
       });
@@ -144,7 +154,7 @@
     return {
       init: function() {
         setupThumbSlider();
-        setupAuthLinks();
+        authCheck();
         this.initializeDashPlayer();
       },
 

--- a/app/assets/stylesheets/media.scss
+++ b/app/assets/stylesheets/media.scss
@@ -16,15 +16,44 @@
 
 .#{$namespace}-media-wrapper {
   display: inline-block;
+  position: relative;
+  text-align: center;
 }
 
-.#{$namespace}-media-location-restricted {
-  @include rounded($border-radius-base);
+.#{$namespace}-media-access-restricted-container {
+  left: 0;
   position: absolute;
-  top: 50px;
-  font-size: 25px;
-  padding: 4px;
-  background-color: $gray-54-percent;
+  top: 15%;
+  width: 100%;
+}
+
+.#{$namespace}-media-access-restricted {
+  @include rounded($border-radius-base);
+  background-color: $white-color;
+  margin: 0 auto;
+  opacity: 0.9;
+  padding: 20px 25px;
+  width: 80%;
+
+  .line1 {
+    display: block;
+    font-size: 35px;
+    font-weight: 100;
+  }
+
+  .line2 {
+    display: block;
+    font-size: 24px;
+    font-weight: 100;
+  }
+}
+
+.#{$namespace}-media-location-only-restricted-overlay {
+  color: $color-beige-30;
+  font-size: 20em;
+  position: absolute;
+  top: -10%;
+  width: 100%;
 }
 
 .#{$namespace}-media-slider-thumb {

--- a/app/assets/stylesheets/media.scss
+++ b/app/assets/stylesheets/media.scss
@@ -14,6 +14,19 @@
   }
 }
 
+.#{$namespace}-media-wrapper {
+  display: inline-block;
+}
+
+.#{$namespace}-media-location-restricted {
+  @include rounded($border-radius-base);
+  position: absolute;
+  top: 50px;
+  font-size: 25px;
+  padding: 4px;
+  background-color: $gray-54-percent;
+}
+
 .#{$namespace}-media-slider-thumb {
   height: 75px;
   text-align: left;
@@ -48,4 +61,5 @@
     padding-right: 0;
     text-indent: 17px;
   }
+
 }

--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -202,6 +202,10 @@ module Embed
           @rights.stanford_only_unrestricted_file?(title)
         end
 
+        def location_restricted?
+          @rights.restricted_by_location?(title)
+        end
+
         private
 
         def image_data?

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -48,7 +48,7 @@ module Embed
       <<-HTML.strip_heredoc
         <div data-stanford-only="#{stanford_only}" data-location-restricted="#{location_restricted}" data-file-label="#{label}" data-slider-object="#{file_index}">
           <div class='sul-embed-media-wrapper'>
-            #{location_restricted_message(location_restricted)}
+            #{access_restricted_message(stanford_only, location_restricted)}
             #{yield(block) if block_given?}
           </div>
         </div>
@@ -79,13 +79,26 @@ module Embed
       end
     end
 
-    def location_restricted_message(location_restricted)
-      return unless location_restricted
+    def access_restricted_message(stanford_only, location_restricted)
+      return unless stanford_only || location_restricted
+      # jvine says the -container div is necessary to style the elements so that
+      # sul-embed-media-access-restricted positions correctly
+      # TODO: line1 and line1 spans should be populated by values returned from stacks
       <<-HTML.strip_heredoc
-        <div class='sul-embed-media-location-restricted'>
-          <h3>Limited access for all guests until we fix jsonp</h3>
-          <p>See Access conditions for more information.</p>
+        #{location_only_overlay(stanford_only, location_restricted)}
+        <div class='sul-embed-media-access-restricted-container'>
+          <div class='sul-embed-media-access-restricted'>
+            <span class='line1'>Limited access for non-Stanford guests</span>
+            <span class='line2'>See Access conditions for more information.</span>
+          </div>
         </div>
+      HTML
+    end
+
+    def location_only_overlay(stanford_only, location_restricted)
+      return unless location_restricted && !stanford_only
+      <<-HTML.strip_heredoc
+        <i class="sul-i-file-video-3 sul-embed-media-location-only-restricted-overlay"></i>
       HTML
     end
 

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -47,7 +47,10 @@ module Embed
     def media_wrapper(label:, stanford_only:, location_restricted:, &block)
       <<-HTML.strip_heredoc
         <div data-stanford-only="#{stanford_only}" data-location-restricted="#{location_restricted}" data-file-label="#{label}" data-slider-object="#{file_index}">
-          #{yield(block) if block_given?}
+          <div class='sul-embed-media-wrapper'>
+            #{location_restricted_message(location_restricted)}
+            #{yield(block) if block_given?}
+          </div>
         </div>
       HTML
     end
@@ -74,6 +77,16 @@ module Embed
       purl_document.contents.count do |resource|
         SUPPORTED_MEDIA_TYPES.include?(resource.type.to_sym)
       end
+    end
+
+    def location_restricted_message(location_restricted)
+      return unless location_restricted
+      <<-HTML.strip_heredoc
+        <div class='sul-embed-media-location-restricted'>
+          <h3>Limited access for all guests until we fix jsonp</h3>
+          <p>See Access conditions for more information.</p>
+        </div>
+      HTML
     end
 
     def streaming_settings_for(type)

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -30,7 +30,7 @@ module Embed
     attr_reader :purl_document, :request, :viewer
 
     def media_element(label, file, type)
-      media_wrapper(label: label, stanford_only: file.stanford_only?) do
+      media_wrapper(label: label, stanford_only: file.stanford_only?, location_restricted: file.location_restricted?) do
         <<-HTML.strip_heredoc
           <#{type}
             data-src="#{streaming_url_for(file, :dash)}"
@@ -44,9 +44,9 @@ module Embed
       end
     end
 
-    def media_wrapper(label:, stanford_only:, &block)
+    def media_wrapper(label:, stanford_only:, location_restricted:, &block)
       <<-HTML.strip_heredoc
-        <div data-stanford-only="#{stanford_only}" data-file-label="#{label}" data-slider-object="#{file_index}">
+        <div data-stanford-only="#{stanford_only}" data-location-restricted="#{location_restricted}" data-file-label="#{label}" data-slider-object="#{file_index}">
           #{yield(block) if block_given?}
         </div>
       HTML

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -86,7 +86,7 @@ module Embed
       # TODO: line1 and line1 spans should be populated by values returned from stacks
       <<-HTML.strip_heredoc
         #{location_only_overlay(stanford_only, location_restricted)}
-        <div class='sul-embed-media-access-restricted-container'>
+        <div class='sul-embed-media-access-restricted-container' data-access-restricted-message>
           <div class='sul-embed-media-access-restricted'>
             <span class='line1'>Limited access for non-Stanford guests</span>
             <span class='line2'>See Access conditions for more information.</span>
@@ -98,7 +98,7 @@ module Embed
     def location_only_overlay(stanford_only, location_restricted)
       return unless location_restricted && !stanford_only
       <<-HTML.strip_heredoc
-        <i class="sul-i-file-video-3 sul-embed-media-location-only-restricted-overlay"></i>
+        <i class="sul-i-file-video-3 sul-embed-media-location-only-restricted-overlay" data-location-restricted-overlay></i>
       HTML
     end
 

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -48,7 +48,7 @@ module Embed
       <<-HTML.strip_heredoc
         <div data-stanford-only="#{stanford_only}" data-location-restricted="#{location_restricted}" data-file-label="#{label}" data-slider-object="#{file_index}">
           <div class='sul-embed-media-wrapper'>
-            #{access_restricted_message(stanford_only, location_restricted)}
+            #{access_restricted_overlay(stanford_only, location_restricted)}
             #{yield(block) if block_given?}
           </div>
         </div>
@@ -80,6 +80,20 @@ module Embed
     end
 
     def access_restricted_message(stanford_only, location_restricted)
+      if location_restricted && !stanford_only
+        <<-HTML.strip_heredoc
+          <span class='line1'>Restricted media cannot be played in your location.</span>
+          <span class='line2'>See Access conditions for more information.</span>
+        HTML
+      else
+        <<-HTML.strip_heredoc
+          <span class='line1'>Limited access for<br>non-Stanford guests.</span>
+          <span class='line2'>See Access conditions for more information.</span>
+        HTML
+      end
+    end
+
+    def access_restricted_overlay(stanford_only, location_restricted)
       return unless stanford_only || location_restricted
       # jvine says the -container div is necessary to style the elements so that
       # sul-embed-media-access-restricted positions correctly
@@ -88,8 +102,7 @@ module Embed
         #{location_only_overlay(stanford_only, location_restricted)}
         <div class='sul-embed-media-access-restricted-container' data-access-restricted-message>
           <div class='sul-embed-media-access-restricted'>
-            <span class='line1'>Limited access for non-Stanford guests</span>
-            <span class='line2'>See Access conditions for more information.</span>
+            #{access_restricted_message(stanford_only, location_restricted)}
           </div>
         </div>
       HTML

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -624,6 +624,13 @@ module PURLFixtures
             <file id="abc_123.mp4" mimetype="video/mp4" size="152000000"></file>
           </resource>
         </contentMetadata>
+        <rightsMetadata>
+          <access type="read">
+            <machine>
+              <location>spec</location>
+            </machine>
+          </access>
+        </rightsMetadata>
         <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
           <dc:title>stupid dc title of video</dc:title>
         </oai_dc>
@@ -654,6 +661,12 @@ module PURLFixtures
           <access type="read">
             <machine>
               <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <file>abc_123.mp4</file>
+            <machine>
+              <location>spec</location>
             </machine>
           </access>
           <access type="read">

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -70,13 +70,37 @@ describe Embed::MediaTag do
   describe '#media_wrapper' do
     describe 'data-stanford-only attribute' do
       it 'true for Stanford only files' do
-        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', stanford_only: true))
+        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', stanford_only: true, location_restricted: false))
         expect(media_wrapper).to have_css('[data-stanford-only="true"]')
       end
 
       it 'false for public files' do
-        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', stanford_only: false))
+        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', stanford_only: false, location_restricted: false))
         expect(media_wrapper).to have_css('[data-stanford-only="false"]')
+      end
+    end
+    describe 'data-location-restricted attribute' do
+      context "stanford_only" do
+        it 'true for location restricted files' do
+          media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', stanford_only: true, location_restricted: true))
+          expect(media_wrapper).to have_css('[data-location-restricted="true"]')
+        end
+
+        it 'false for public files' do
+          media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', stanford_only: true, location_restricted: false))
+          expect(media_wrapper).to have_css('[data-location-restricted="false"]')
+        end
+      end
+      context 'not stanford_only' do
+        it 'true for location restricted files' do
+          media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', stanford_only: false, location_restricted: true))
+          expect(media_wrapper).to have_css('[data-location-restricted="true"]')
+        end
+
+        it 'false for public files' do
+          media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', stanford_only: false, location_restricted: false))
+          expect(media_wrapper).to have_css('[data-location-restricted="false"]')
+        end
       end
     end
   end

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -82,7 +82,7 @@ describe Embed::MediaTag do
     describe 'location restriction message' do
       it 'displayed when not in location' do
         media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', stanford_only: false, location_restricted: true))
-        expect(media_wrapper).to have_css('.sul-embed-media-access-restricted .line1', text: 'Limited access for non-Stanford guests')
+        expect(media_wrapper).to have_css('.sul-embed-media-access-restricted .line1', text: 'Restricted media cannot be played in your location')
         expect(media_wrapper).to have_css('.sul-embed-media-access-restricted .line2', text: 'See Access conditions for more information')
       end
       it 'not displayed when in location' do

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -79,8 +79,19 @@ describe Embed::MediaTag do
         expect(media_wrapper).to have_css('[data-stanford-only="false"]')
       end
     end
+    describe 'location restriction message' do
+      it 'displayed when not in location' do
+        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', stanford_only: false, location_restricted: true))
+        expect(media_wrapper).to have_css('.sul-embed-media-location-restricted', text: 'See Access conditions for more information')
+      end
+      it 'not displayed when in location' do
+        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', stanford_only: false, location_restricted: false))
+        expect(media_wrapper).not_to have_css('.sul-embed-media-location-restricted')
+      end
+    end
+    # TODO:  not sure if we're going to keep data-location-restricted as an attrib or just use element
     describe 'data-location-restricted attribute' do
-      context "stanford_only" do
+      context 'stanford_only' do
         it 'true for location restricted files' do
           media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', stanford_only: true, location_restricted: true))
           expect(media_wrapper).to have_css('[data-location-restricted="true"]')

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -82,11 +82,14 @@ describe Embed::MediaTag do
     describe 'location restriction message' do
       it 'displayed when not in location' do
         media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', stanford_only: false, location_restricted: true))
-        expect(media_wrapper).to have_css('.sul-embed-media-location-restricted', text: 'See Access conditions for more information')
+        expect(media_wrapper).to have_css('.sul-embed-media-access-restricted .line1', text: 'Limited access for non-Stanford guests')
+        expect(media_wrapper).to have_css('.sul-embed-media-access-restricted .line2', text: 'See Access conditions for more information')
       end
       it 'not displayed when in location' do
         media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', stanford_only: false, location_restricted: false))
-        expect(media_wrapper).not_to have_css('.sul-embed-media-location-restricted')
+        expect(media_wrapper).not_to have_css('.sul-embed-media-access-restricted')
+        expect(media_wrapper).not_to have_css('.sul-embed-media-access-restricted .line1', text: 'Limited access for non-Stanford guests')
+        expect(media_wrapper).not_to have_css('.sul-embed-media-access-restricted .line2', text: 'See Access conditions for more information')
       end
     end
     # TODO:  not sure if we're going to keep data-location-restricted as an attrib or just use element

--- a/spec/models/embed/purl_spec.rb
+++ b/spec/models/embed/purl_spec.rb
@@ -177,6 +177,24 @@ describe Embed::PURL do
             expect(last_file).to_not be_stanford_only
           end
         end
+        describe 'location_restricted?' do
+          it 'should identify location restricted objects' do
+            stub_purl_response_with_fixture(single_video_purl)
+            expect(Embed::PURL.new('12345').contents.first.files.all?(&:location_restricted?)).to be true
+          end
+          it 'should identify world accessible objects as not stanford only' do
+            stub_purl_response_with_fixture(file_purl)
+            expect(Embed::PURL.new('12345').contents.first.files.all?(&:location_restricted?)).to be false
+          end
+          it 'should identify file-level location_restricted rights' do
+            stub_purl_response_with_fixture(video_purl)
+            contents = Embed::PURL.new('12345').contents
+            first_file = contents.first.files.first
+            last_file = contents.last.files.first
+            expect(first_file).to be_location_restricted
+            expect(last_file).to_not be_location_restricted
+          end
+        end
       end
       describe 'image data' do
         before { stub_purl_response_with_fixture(image_purl) }


### PR DESCRIPTION
resolves issue #587
resolves issue #589

this branch should implement the messaging overlays for access restrictions (location based and stanford user based).

this depends on sul-dlss/digital_stacks_rails#61.

clumped with @ndushay, @jkeck, and @jvine to implement this.

could we get @tingulfsen to do code review?  and @jvine to review styling?

code has been deployed to embed-dev and stacks-test.
<img width="1459" alt="screen shot 2016-06-27 at 4 18 31 pm" src="https://cloud.githubusercontent.com/assets/7741604/16399008/af5ad2a8-3c83-11e6-906f-dd54fef089af.png">
<img width="1446" alt="screen shot 2016-06-27 at 4 24 38 pm" src="https://cloud.githubusercontent.com/assets/7741604/16399009/af5b7e7e-3c83-11e6-8ea9-98f6e993aa57.png">

connected to #587
connected to #589