### PR TITLE
add "(Restricted)" text to thumbs for location restricted media files

### DIFF
--- a/app/assets/javascripts/modules/media_viewer.js
+++ b/app/assets/javascripts/modules/media_viewer.js
@@ -8,6 +8,15 @@
     var restrictedOverlaySelector = '[data-location-restricted-overlay]';
     var restrictedMessageSelector = '[data-access-restricted-message]';
     var sliderObjectSelector = '[data-slider-object]';
+    var restrictedText = '(Restricted)'
+
+    function restrictedTextMarkup(isLocationRestricted) {
+      if(isLocationRestricted) {
+        return '<span class="sul-embed-thumb-restricted-text">' + restrictedText + '</span> ';
+      } else {
+        return '';
+      }
+    }
 
     function thumbsForSlider() {
       var thumbs = [];
@@ -45,6 +54,7 @@
           '<li class="' + thumbClass + activeClass + '">' +
             thumbnailIcon +
             '<div class="' + labelClass + '">' +
+              restrictedTextMarkup($(mediaDiv).data('location-restricted')) +
               $(mediaDiv).data('file-label') +
             '</div>' +
           '</li>'

--- a/app/assets/stylesheets/modules/thumb_slider.scss
+++ b/app/assets/stylesheets/modules/thumb_slider.scss
@@ -3,6 +3,7 @@
 
 $thumb-background-color: #fff;
 $thumb-slider-border-color: $sul-border-color;
+$restricted-text-color: $color-cardinal-red;
 $thumb-slider-background-color: $sul-background;
 
 .#{$namespace}-thumb-slider-container {
@@ -63,5 +64,9 @@ $thumb-slider-background-color: $sul-background;
 
   img {
     width: 100%;
+  }
+
+  .#{$namespace}-thumb-restricted-text {
+    color: $restricted-text-color;
   }
 }

--- a/spec/features/media_viewer_spec.rb
+++ b/spec/features/media_viewer_spec.rb
@@ -80,4 +80,15 @@ describe 'media viewer', js: true do
       expect(page).to have_css('.sul-embed-thumb-label', text: 'Image of media (1 of 1)')
     end
   end
+
+  context 'a location restricted file within a media object' do
+    it 'displays the restricted text with the appropriate styling' do
+      expect(page).not_to have_css('.sul-embed-thumb-slider', visible: true)
+      page.find('.sul-embed-thumb-slider-open-close').click
+      expect(page).to have_css('.sul-embed-thumb-slider', visible: true)
+
+      expect(page).to have_css('.sul-embed-thumb-restricted-text', text: '(Restricted)', count: 1)
+      expect(page).to have_css('.sul-embed-media-slider-thumb', text: '(Restricted) abc_123.mp4')
+    end
+  end
 end


### PR DESCRIPTION
paired w/ @jkeck to implement this.

note: a change from the mockup is that the restricted text comes first (easier to implement, and consistent with the presentation of the stanford-only icon).

before:
<img width="1447" alt="screen shot 2016-07-08 at 3 15 45 pm" src="https://cloud.githubusercontent.com/assets/7741604/16703025/0a08cd56-451f-11e6-8aa0-35307182b11c.png">

after:
<img width="1454" alt="screen shot 2016-07-08 at 3 10 08 pm" src="https://cloud.githubusercontent.com/assets/7741604/16702959/5ec1c1e6-451e-11e6-80fa-29cbf100cb05.png">

closes #602 
connect to #602 
