### PR TITLE
Quick fix basemap

### DIFF
--- a/app/assets/javascripts/modules/geo_viewer.js
+++ b/app/assets/javascripts/modules/geo_viewer.js
@@ -15,17 +15,13 @@
 
         map = L.map('sul-embed-geo-map').fitBounds(dataAttributes.boundingBox);
 
-        L.tileLayer(
-            'https://otile{s}-s.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png', {
-              attribution: '&copy; <a href="http://openstreetmap.org">OpenStr' +
-                'eetMap</a> contributors, Tiles Courtesy of <a href="http://w' +
-                'ww.mapquest.com/" target="_blank">MapQuest</a> <img src="//d' +
-                'eveloper.mapquest.com/content/osm/mq_logo.png" alt="">',
-              maxZoom: 18,
-              worldCopyJump: true,
-              subdomains: '1234'
-            }
-        ).addTo(map);
+        L.tileLayer('https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
+          maxZoom: 19,
+          attribution: '&copy; <a href="http://www.openstreetmap.org/copyrigh' +
+            't">OpenStreetMap</a>, Tiles courtesy of <a href="http://hot.open' +
+            'streetmap.org/" target="_blank">Humanitarian OpenStreetMap Team<' +
+            '/a>',
+        }).addTo(map);
         
         Module.addVisualizationLayer();
         map.invalidateSize();

--- a/spec/features/geo_viewer_spec.rb
+++ b/spec/features/geo_viewer_spec.rb
@@ -19,12 +19,12 @@ describe 'geo viewer public', js: true do
       expect(page).to have_css('.leaflet-control-zoom-out', count: 1, visible: true)
 
       within '.leaflet-control-attribution.leaflet-control' do
-        expect(page).to have_content(' contributors, Tiles Courtesy of ')
+        expect(page).to have_content(' OpenStreetMap, Tiles courtesy of ')
       end
     end
 
-    it 'shows the Mapquest Tile' do
-      expect(page).to have_css("img[src*='mqcdn.com']", minimum: 6)
+    it 'shows the OpenStreetMap tiles' do
+      expect(page).to have_css("img[src*='openstreetmap.fr']", minimum: 6)
     end
 
     it 'shows the wms tiles' do


### PR DESCRIPTION
Fixes an issue where the MapQuest tiles were no longer provided. This fix was applied in EarthWorks earlier in the week but forgot about embed Sorry 😢 

Went with the Humanitarian OpenStreetMap Team basemap which the geo team decided on last week.

## Before
![screen shot 2016-07-14 at 3 01 24 pm](https://cloud.githubusercontent.com/assets/1656824/16852042/4410f014-49d4-11e6-96a8-37dd4d015ef3.png)

## After

![screen shot 2016-07-14 at 3 04 36 pm](https://cloud.githubusercontent.com/assets/1656824/16852050/4be37032-49d4-11e6-8b13-046ee3986b84.png)

_Note_ this was deployed to production off the previously released commit:

`Branch fix-on-prod (at e9cae94) deployed as release 20160714185956 by pjreed`