### PR TITLE
Replace drop shadow around .sul-embed-container with a simple border.

### DIFF
--- a/app/assets/stylesheets/common.scss.erb
+++ b/app/assets/stylesheets/common.scss.erb
@@ -13,7 +13,7 @@
   font-family: 'Source Sans Pro', 'Arial Unicode MS', Helvetica, sans-serif;
   font-size: $font-size-base;
   overflow-y: hidden;
-  @include shadow(3);
+  border: 1px solid #5f574F;
 
   * {
     padding: 0;

--- a/app/assets/stylesheets/common.scss.erb
+++ b/app/assets/stylesheets/common.scss.erb
@@ -13,7 +13,7 @@
   font-family: 'Source Sans Pro', 'Arial Unicode MS', Helvetica, sans-serif;
   font-size: $font-size-base;
   overflow-y: hidden;
-  border: 1px solid #5f574F;
+  border: 1px solid $color-pantone-405;
 
   * {
     padding: 0;
@@ -93,7 +93,7 @@
       padding-top: 2px;
       padding-bottom: 2px;
       line-height: 1;
-      color: #5F574F;
+      color: $color-pantone-405;
       background-color: #fff;
       text-align: center;
       vertical-align: middle;


### PR DESCRIPTION
Fixes #604 

Before:

![before](https://cloud.githubusercontent.com/assets/3740294/16889877/864ea1a4-4a9e-11e6-9f45-fd6063030b2c.png)

After:

![after](https://cloud.githubusercontent.com/assets/3740294/16889882/98418c6e-4a9e-11e6-896b-c0053e4dca88.png)

I've just verified that this seems to work fine with #609