### PR TITLE
Add a max-height to images in the media-viewer that ensures they are …

### DIFF
--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -52,7 +52,11 @@ module Embed
 
     def previewable_element(label, file)
       media_wrapper(label: label, thumbnail: stacks_square_url(@purl_document.druid, file.title, size: '75')) do
-        "<img src='#{stacks_thumb_url(@purl_document.druid, file.title)}' class='sul-embed-media-thumb' />"
+        "<img
+          src='#{stacks_thumb_url(@purl_document.druid, file.title)}'
+          class='sul-embed-media-thumb #{'sul-embed-many-media' if many_primary_files?}'
+          style='max-height: #{media_element_height}'
+        />"
       end
     end
 

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -147,6 +147,7 @@ describe Embed::MediaTag do
     end
 
     describe '#previewable_element' do
+      before { stub_purl_response_with_fixture(purl) }
       let(:previewable_element) { subject_klass.send(:previewable_element, 'Some Label', file) }
       it 'passes the square thumb url as a data attribute' do
         expect(previewable_element).to match(
@@ -155,9 +156,18 @@ describe Embed::MediaTag do
       end
 
       it 'includes an image element which points to a stacks 400px thumb' do
+        expect(previewable_element).to match(/<img/)
         expect(previewable_element).to match(
-          %r{<img src='https://stacks.*/iiif/.*abc123/full/\!400,400.*' .*/>}
+          %r{src='https://stacks.*/iiif/.*abc123/full/\!400,400.*'}
         )
+      end
+
+      it 'defines a max-height on the image that is equal to the viewer body height' do
+        expect(previewable_element).to match(/style='max-height: 276px'/)
+      end
+
+      it 'includes a class that indicates that there is are many media objects (to make room for the slider control)' do
+        expect(previewable_element).to match(/class='.* sul-embed-many-media/)
       end
     end
   end


### PR DESCRIPTION
…not larger than the body-height of the viewer itself.

Closes #607 

## xv428cw8400 (before)
<img width="547" alt="xv428cw8400-before" src="https://cloud.githubusercontent.com/assets/96776/17120062/af77f43a-527e-11e6-9001-f2c7ded18a19.png">

## xv428cw8400 (after)
<img width="552" alt="xv428cw8400-after" src="https://cloud.githubusercontent.com/assets/96776/17120063/af8bff3e-527e-11e6-93dc-fc96bd09ab81.png">
