### PR TITLE
[WIP] set video element height and width from PURL XML videoData info (if possible)

### DIFF
--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -198,6 +198,14 @@ module Embed
           @file.xpath('./imageData').first.attributes['width'].try(:text) if image_data?
         end
 
+        def video_height
+          @file.xpath('./videoData').first.attributes['height'].try(:text) if video_data?
+        end
+
+        def video_width
+          @file.xpath('./videoData').first.attributes['width'].try(:text) if video_data?
+        end
+
         def location
           @file.xpath('./location[@type="url"]').first.try(:text) if location_data?
         end
@@ -214,6 +222,10 @@ module Embed
 
         def image_data?
           @file.xpath('./imageData').present?
+        end
+
+        def video_data?
+          @file.xpath('./videoData').present?
         end
 
         def location_data?

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -86,13 +86,22 @@ module Embed
       end.join
     end
 
+    def usable_body_height
+      many_primary_files? ? viewer.body_height.to_i - MEDIA_INDEX_CONTROL_HEIGHT : viewer.body_height.to_i
+    end
+
     def media_element_height(file)
-      elt_base_height = (file.video_height || viewer.body_height).to_i
-      many_primary_files? ? elt_base_height - MEDIA_INDEX_CONTROL_HEIGHT : elt_base_height
+      return usable_body_height unless file.video_height && (file.video_height.to_i < usable_body_height)
+      file.video_height.to_i
     end
 
     def media_element_width(file)
-      file.video_width.to_i if file.video_width
+      return unless file.video_width
+
+      # if there's a width specified, scale it by the same factor as the actual
+      # display height vs the specified height, so correct aspect ratio is maintained
+      height_scale_factor = media_element_height(file) / file.video_height.to_d
+      (file.video_width.to_i * height_scale_factor).to_i
     end
 
     def media_element_height_attr(file)

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -44,7 +44,8 @@ module Embed
             data-auth-url="#{authentication_url(file)}"
             controls='controls'
             class="#{'sul-embed-many-media' if many_primary_files?}"
-            height="#{media_element_height}">
+            #{media_element_height_attr(file)}
+            #{media_element_width_attr(file)}>
             #{enabled_streaming_sources(file)}
           </#{type}>
         HTML
@@ -56,7 +57,7 @@ module Embed
         "<img
           src='#{stacks_thumb_url(@purl_document.druid, file.title)}'
           class='sul-embed-media-thumb #{'sul-embed-many-media' if many_primary_files?}'
-          style='max-height: #{media_element_height}'
+          style='max-height: #{media_element_height(file)}'
         />"
       end
     end
@@ -85,9 +86,21 @@ module Embed
       end.join
     end
 
-    def media_element_height
-      return "#{viewer.body_height}px" unless many_primary_files?
-      "#{viewer.body_height.to_i - MEDIA_INDEX_CONTROL_HEIGHT}px"
+    def media_element_height(file)
+      elt_base_height = (file.video_height || viewer.body_height).to_i
+      many_primary_files? ? "#{elt_base_height - MEDIA_INDEX_CONTROL_HEIGHT}px" : "#{elt_base_height}px"
+    end
+
+    def media_element_width(file)
+      "#{file.video_width.to_i}px" if file.video_width
+    end
+
+    def media_element_height_attr(file)
+      %(height="#{media_element_height(file)}") if media_element_height(file)
+    end
+
+    def media_element_width_attr(file)
+      %(width="#{media_element_width(file)}") if media_element_width(file)
     end
 
     def many_primary_files?

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -45,7 +45,11 @@ module Embed
             controls='controls'
             class="#{'sul-embed-many-media' if many_primary_files?}"
             #{media_element_height_attr(file)}
-            #{media_element_width_attr(file)}>
+            #{media_element_width_attr(file)}
+            data-height="#{media_element_height(file)}"
+            data-width="#{media_element_width(file)}"
+            data-viewer-body-height="#{viewer.body_height}"
+            data-usable-body-height="#{usable_body_height}">
             #{enabled_streaming_sources(file)}
           </#{type}>
         HTML

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -57,7 +57,7 @@ module Embed
         "<img
           src='#{stacks_thumb_url(@purl_document.druid, file.title)}'
           class='sul-embed-media-thumb #{'sul-embed-many-media' if many_primary_files?}'
-          style='max-height: #{media_element_height(file)}'
+          style='max-height: #{media_element_height(file)}px'
         />"
       end
     end
@@ -88,19 +88,19 @@ module Embed
 
     def media_element_height(file)
       elt_base_height = (file.video_height || viewer.body_height).to_i
-      many_primary_files? ? "#{elt_base_height - MEDIA_INDEX_CONTROL_HEIGHT}px" : "#{elt_base_height}px"
+      many_primary_files? ? elt_base_height - MEDIA_INDEX_CONTROL_HEIGHT : elt_base_height
     end
 
     def media_element_width(file)
-      "#{file.video_width.to_i}px" if file.video_width
+      file.video_width.to_i if file.video_width
     end
 
     def media_element_height_attr(file)
-      %(height="#{media_element_height(file)}") if media_element_height(file)
+      %(height="#{media_element_height(file)}px") if media_element_height(file)
     end
 
     def media_element_width_attr(file)
-      %(width="#{media_element_width(file)}") if media_element_width(file)
+      %(width="#{media_element_width(file)}px") if media_element_width(file)
     end
 
     def many_primary_files?

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -234,6 +234,33 @@ module PURLFixtures
       </publicObject>
     XML
   end
+  def multi_media_purl_large_format
+    <<-XML
+      <publicObject>
+        <identityMetadata>
+          <objectLabel>Multiple Videos in same contentMetadata</objectLabel>
+        </identityMetadata>
+        <contentMetadata type="media">
+          <resource id="media1" sequence="1" type="video">
+            <label>mp4-normal</label>
+            <file id="JessieSaysNo.mp4" mimetype="video/mp4" size="190916">
+              <videoData height="1080" width="1920"/>
+            </file>
+          </resource>
+          <resource id="media2" sequence="2" type="video">
+            <label>mp4-slow</label>
+            <file id="JessieSaysNo-Slow.mp4" mimetype="video/mp4" size="738559">
+              <videoData height="1080" width="1920"/>
+            </file>
+          </resource>
+        </contentMetadata>
+        <rightsMetadata>
+          #{access_discover_world}
+          #{access_read_world}
+        </rightsMetadata>
+      </publicObject>
+    XML
+  end
   def multi_resource_multi_media_purl
     <<-XML
       <publicObject>

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -41,14 +41,15 @@ describe Embed::MediaTag do
 
     context 'single video' do
       let(:purl) { single_video_purl }
-      it 'includes a height attribute equal to the body height' do
+      it 'includes a default height attribute equal to the body height' do
         expect(subject).to have_css("video[height='#{viewer.body_height}px']")
       end
     end
 
     context 'multiple videos' do
-      it 'includes a height attribute equal to the body height minus some px to make way for the thumb slider' do
+      it 'includes a default height attribute equal to the body height minus some px to make way for the thumb slider' do
         expect(subject).to have_css('video[height="276px"]')
+        expect(subject).not_to have_css('video[width]')
       end
     end
 
@@ -62,6 +63,14 @@ describe Embed::MediaTag do
     context 'video' do
       it 'renders a video tag in the provided document' do
         expect(subject).to have_css('video')
+      end
+    end
+
+    context 'video dimensions' do
+      let(:purl) { multi_media_purl }
+      it 'are taken from the purl if available, and height is adjusted for the thumb slider' do
+        expect(subject).to have_css('video[height="264px"]')
+        expect(subject).to have_css('video[width="352px"]')
       end
     end
 
@@ -143,8 +152,12 @@ describe Embed::MediaTag do
     end
 
     describe '#previewable_element' do
-      before { stub_purl_response_with_fixture(purl) }
+      before do
+        stub_purl_response_with_fixture(purl)
+        allow(file).to receive(:video_height)
+      end
       let(:previewable_element) { subject_klass.send(:previewable_element, 'Some Label', file) }
+
       it 'passes the square thumb url as a data attribute' do
         expect(previewable_element).to match(
           %r{data-thumbnail-url="https://stacks.*/iiif/.*abc123/square/75,75.*"}

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -66,11 +66,21 @@ describe Embed::MediaTag do
       end
     end
 
-    context 'video dimensions' do
+    context 'with small video dimensions' do
       let(:purl) { multi_media_purl }
       it 'are taken from the purl if available, and height is adjusted for the thumb slider' do
-        expect(subject).to have_css('video[height="264px"]')
-        expect(subject).to have_css('video[width="352px"]')
+        expect(subject).to have_css('video[height="276px"]')
+        expect(subject).to have_css('video[width="337px"]')
+      end
+    end
+
+    context 'with large video dimensions' do
+      let(:purl) { multi_media_purl_large_format }
+      it 'are taken from the purl if available, and height is adjusted for the thumb slider' do
+        expected_height = viewer.body_height.to_i - Embed::MediaTag::MEDIA_INDEX_CONTROL_HEIGHT
+        expect(subject).to have_css("video[height='#{expected_height}px']")
+        expected_width = (1920 * (expected_height / 1080.to_d)).to_i
+        expect(subject).to have_css("video[width='#{expected_width}px']")
       end
     end
 

--- a/spec/models/embed/purl_spec.rb
+++ b/spec/models/embed/purl_spec.rb
@@ -230,6 +230,14 @@ describe Embed::PURL do
           expect(file.location).to eq 'http://stacks.stanford.edu/file/druid:abc123/Title_of_the_PDF.pdf'
         end
       end
+      describe 'video_data' do
+        before { stub_purl_response_with_fixture(multi_media_purl) }
+        let(:video) { Embed::PURL.new('12345').contents.first.files.first }
+        it 'should get the height and width for the video object' do
+          expect(video.video_height).to eq '288'
+          expect(video.video_width).to eq '352'
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
if there's no videoData in the PURL XML, the height defaults to what it would've been before this PR (viewer body height, minus thumb slider height if there's a slider), and the width attribute is omitted.

before (note lack of width, old default height):
<img width="1250" alt="screen shot 2016-08-03 at 3 01 52 pm" src="https://cloud.githubusercontent.com/assets/7741604/17383605/ad3f2224-598b-11e6-814f-3ace2e4a8a0c.png">


after (note presence of width from object's PURL XML videoData; and height, which is the videoData height of 288, minus the 24 pixel height of the thumb slider):
<img width="1255" alt="screen shot 2016-08-03 at 3 00 32 pm" src="https://cloud.githubusercontent.com/assets/7741604/17383582/913b827a-598b-11e6-8bf7-080b74abfefa.png">

closes #626 
connect to #626 