### PR TITLE
Adding css to sul-embed-container to help mobile responsive behavior.

### DIFF
--- a/app/assets/stylesheets/common.scss.erb
+++ b/app/assets/stylesheets/common.scss.erb
@@ -9,11 +9,14 @@
 
 .#{$namespace}-container {
   background: $white-color;
+  border: 1px solid $color-pantone-405;
   color: $sul-font-color;
   font-family: 'Source Sans Pro', 'Arial Unicode MS', Helvetica, sans-serif;
   font-size: $font-size-base;
   overflow-y: hidden;
-  border: 1px solid $color-pantone-405;
+  width: 1px;
+  min-width: 99%;
+  *width: 99%;
 
   * {
     padding: 0;


### PR DESCRIPTION
Closes #634 (fwiw, it looks like the login link issue was resolved when we stopped redirecting through stacks to wowza).

See http://stackoverflow.com/questions/23083462/how-to-get-an-iframe-to-be-responsive-in-ios-safari for explanation.

_Note: The video element itself is not responsive, but @jmartin-sul and I have been looking at ways to handle this natively with videojs._

## bd786fy6312 (before)
![bd786fy6312-before](https://cloud.githubusercontent.com/assets/96776/17564752/7311564a-5ee9-11e6-912f-9a48c70a0ae2.png)

## bd786fy6312 (after)
![bd786fy6312-after](https://cloud.githubusercontent.com/assets/96776/17564751/730f304a-5ee9-11e6-9ac1-7d5f71af8cc2.png)
