### PR TITLE
use iso8601 duration info from videoData to display video duration in parens after the title

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ gem 'config'
 
 gem 'therubyracer'
 
+gem 'iso8601' # to parse durations, since ActiveSupport::Duration doesn't get a parse method till rails 5
+
 group :development, :test do
   gem 'rspec-rails', '~> 3.0.0'
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,7 @@ GEM
       domain_name (~> 0.5)
     i18n (0.7.0)
     is_it_working (1.1.0)
+    iso8601 (0.9.1)
     jasmine-jquery-rails (2.0.3)
     jquery-rails (4.0.5)
       rails-dom-testing (~> 1.0)
@@ -327,6 +328,7 @@ DEPENDENCIES
   guard-rspec
   high_voltage
   is_it_working
+  iso8601
   jasmine-jquery-rails
   jquery-rails
   leaflet-rails

--- a/app/assets/javascripts/modules/media_viewer.js
+++ b/app/assets/javascripts/modules/media_viewer.js
@@ -20,6 +20,14 @@
       }
     }
 
+    function durationMarkup(duration) {
+      if(duration && duration.length > 0) {
+        return ' (' + duration + ')';
+      } else {
+        return '';
+      }
+    }
+
     function thumbsForSlider() {
       var thumbs = [];
       var sliderSelector = '.sul-embed-media ' + sliderObjectSelector;
@@ -58,6 +66,7 @@
             '<div class="' + labelClass + '">' +
               restrictedTextMarkup($(mediaDiv).data('location-restricted')) +
               $(mediaDiv).data('file-label') +
+              durationMarkup($(mediaDiv).data('duration')) +
             '</div>' +
           '</li>'
         );

--- a/app/assets/javascripts/modules/media_viewer.js
+++ b/app/assets/javascripts/modules/media_viewer.js
@@ -11,6 +11,7 @@
     var restrictedMessageSelector = '[data-access-restricted-message]';
     var sliderObjectSelector = '[data-slider-object]';
     var restrictedText = '(Restricted)'
+    var MAX_FILE_LABEL_LENGTH = 45;
 
     function restrictedTextMarkup(isLocationRestricted) {
       if(isLocationRestricted) {
@@ -26,6 +27,17 @@
       } else {
         return '';
       }
+    }
+
+    function maxFileLabelLength(isLocationRestricted) {
+      if(isLocationRestricted)
+        return MAX_FILE_LABEL_LENGTH - restrictedText.length;
+      else
+        return MAX_FILE_LABEL_LENGTH;
+    }
+
+    function truncateWithEllipsis(text, maxLen) {
+      return text.substr(0, maxLen - 1) + (text.length > maxLen ? '&hellip;' : '');
     }
 
     function thumbsForSlider() {
@@ -60,13 +72,16 @@
           thumbnailIcon = '<i class="' + cssClass + '"></i>';
         }
 
+        var isLocationRestricted = $(mediaDiv).data('location-restricted');
+        var fileLabel = $(mediaDiv).data('file-label');
+        var duration = $(mediaDiv).data('duration');
         thumbs.push(
           '<li class="' + thumbClass + activeClass + '">' +
             thumbnailIcon +
             '<div class="' + labelClass + '">' +
-              restrictedTextMarkup($(mediaDiv).data('location-restricted')) +
-              $(mediaDiv).data('file-label') +
-              durationMarkup($(mediaDiv).data('duration')) +
+              restrictedTextMarkup(isLocationRestricted) +
+              truncateWithEllipsis(fileLabel, maxFileLabelLength(isLocationRestricted)) +
+              durationMarkup(duration) +
             '</div>' +
           '</li>'
         );

--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -198,6 +198,14 @@ module Embed
           @file.xpath('./imageData').first.attributes['width'].try(:text) if image_data?
         end
 
+        def video_height
+          @file.xpath('./videoData').first.attributes['height'].try(:text) if video_data?
+        end
+
+        def video_width
+          @file.xpath('./videoData').first.attributes['width'].try(:text) if video_data?
+        end
+
         def location
           @file.xpath('./location[@type="url"]').first.try(:text) if location_data?
         end
@@ -214,6 +222,10 @@ module Embed
 
         def image_data?
           @file.xpath('./imageData').present?
+        end
+
+        def video_data?
+          @file.xpath('./videoData').present?
         end
 
         def location_data?

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -36,7 +36,7 @@ module Embed
     attr_reader :purl_document, :request, :viewer
 
     def media_element(label, file, type)
-      media_wrapper(label: label, stanford_only: file.stanford_only?, location_restricted: file.location_restricted?) do
+      media_wrapper(label: label, file: file) do
         <<-HTML.strip_heredoc
           <#{type}
             id="sul-embed-media-#{file_index}"
@@ -61,15 +61,15 @@ module Embed
       end
     end
 
-    def media_wrapper(label:, thumbnail: '', stanford_only: nil, location_restricted: nil, &block)
+    def media_wrapper(label:, thumbnail: '', file: nil, &block)
       <<-HTML.strip_heredoc
-        <div data-stanford-only="#{stanford_only}"
-             data-location-restricted="#{location_restricted}"
+        <div data-stanford-only="#{file.try(:stanford_only?)}"
+             data-location-restricted="#{file.try(:location_restricted?)}"
              data-file-label="#{label}"
              data-slider-object="#{file_index}"
              data-thumbnail-url="#{thumbnail}">
           <div class='sul-embed-media-wrapper'>
-            #{access_restricted_overlay(stanford_only, location_restricted)}
+            #{access_restricted_overlay(file.try(:stanford_only?), file.try(:location_restricted?))}
             #{yield(block) if block_given?}
           </div>
         </div>

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -67,7 +67,8 @@ module Embed
              data-location-restricted="#{file.try(:location_restricted?)}"
              data-file-label="#{label}"
              data-slider-object="#{file_index}"
-             data-thumbnail-url="#{thumbnail}">
+             data-thumbnail-url="#{thumbnail}"
+             data-duration="#{file.try(:video_duration).try(:to_s)}">
           <div class='sul-embed-media-wrapper'>
             #{access_restricted_overlay(file.try(:stanford_only?), file.try(:location_restricted?))}
             #{yield(block) if block_given?}

--- a/spec/features/media_viewer_spec.rb
+++ b/spec/features/media_viewer_spec.rb
@@ -89,4 +89,22 @@ describe 'media viewer', js: true do
       expect(page).to have_css('.sul-embed-media-slider-thumb', text: '(Restricted) abc_123.mp4')
     end
   end
+
+  context 'duration related info' do
+    it 'displays available duration in parens after the title' do
+      page.find('.sul-embed-thumb-slider-open-close').click
+      expect(page).to have_css('.sul-embed-media-slider-thumb', text: 'abc_123.mp4 (1:02:03)')
+    end
+    it 'displays no duration info after title when there is no duration we can interpret' do
+      page.find('.sul-embed-thumb-slider-open-close').click
+      expect(page).to have_css('.sul-embed-media-slider-thumb', text: /^Second Video$/)
+    end
+    context 'invalid duration format' do
+      let(:purl) { invalid_video_duration_purl }
+      it 'displays as if there were no duration in the purl xml' do
+        page.find('.sul-embed-thumb-slider-open-close').click
+        expect(page).to have_css('.sul-embed-media-slider-thumb', text: 'abc_123.mp4')
+      end
+    end
+  end
 end

--- a/spec/features/media_viewer_spec.rb
+++ b/spec/features/media_viewer_spec.rb
@@ -107,4 +107,16 @@ describe 'media viewer', js: true do
       end
     end
   end
+
+  context 'graceful display of long titles' do
+    let(:purl) { long_label_purl }
+    it 'truncates at 45 characters of combined restriction and title text' do
+      page.find('.sul-embed-thumb-slider-open-close').click
+      expect(page).to have_css('.sul-embed-media-slider-thumb', text: /^\(Restricted\) The First Video Has An Overly Lo… \(1:02:03\)$/)
+    end
+    it 'displays the whole title if it is under the length limit' do
+      page.find('.sul-embed-thumb-slider-open-close').click
+      expect(page).to have_css('.sul-embed-media-slider-thumb', text: /^2nd Video Has A Long Title, But Not Too Long$/)
+    end
+  end
 end

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -217,13 +217,13 @@ module PURLFixtures
           <resource id="media1" sequence="1" type="video">
             <label>mp4-normal</label>
             <file id="JessieSaysNo.mp4" mimetype="video/mp4" size="190916">
-              <videoData height="288" width="352"/>
+              <videoData duration="P0DT1H2M3S" height="288" width="352"/>
             </file>
           </resource>
           <resource id="media2" sequence="2" type="video">
             <label>mp4-slow</label>
             <file id="JessieSaysNo-Slow.mp4" mimetype="video/mp4" size="738559">
-              <videoData height="288" width="352"/>
+              <videoData duration="P0DT1H2M3S" height="288" width="352"/>
             </file>
           </resource>
         </contentMetadata>
@@ -692,6 +692,34 @@ module PURLFixtures
               <group>Stanford</group>
             </machine>
           </access>
+        </rightsMetadata>
+        <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+          <dc:title>stupid dc title of video</dc:title>
+        </oai_dc>
+      </publicObject>
+    XML
+  end
+
+  def invalid_video_duration_purl
+    <<-XML
+      <publicObject>
+        <identityMetadata>
+          <objectLabel>Title of the video</objectLabel>
+        </identityMetadata>
+        <contentMetadata type="media">
+          <resource sequence="1" id="abc123_1" type="video">
+            <file id="abc_123.mp4" mimetype="video/mp4" size="152000000">
+              <videoData duration="PDDTMMS"/>
+            </file>
+          </resource>
+          <resource sequence="2" id="abc321_1" type="video">
+            <file id="abc_321.mp4" mimetype="video/mp4" size="152000000">
+              <videoData duration="PDDTMMS"/>
+            </file>
+          </resource>
+        </contentMetadata>
+        <rightsMetadata>
+          #{access_read_world}
         </rightsMetadata>
         <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
           <dc:title>stupid dc title of video</dc:title>

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -667,11 +667,15 @@ module PURLFixtures
         </identityMetadata>
         <contentMetadata type="media">
           <resource sequence="1" id="abc123_1" type="video">
-            <file id="abc_123.mp4" mimetype="video/mp4" size="152000000"></file>
+            <file id="abc_123.mp4" mimetype="video/mp4" size="152000000">
+              <videoData duration="P0DT1H2M3S" height="288" width="352"/>
+            </file>
           </resource>
           <resource sequence="2" id="abc321_1" type="video">
             <label>Second Video</label>
-            <file id="abc_321.mp4" mimetype="video/mp4" size="666000000"></file>
+            <file id="abc_321.mp4" mimetype="video/mp4" size="666000000">
+              <videoData duration="-P1W" height="288" width="352"/>
+            </file>
           </resource>
           <resource sequence="3" id="bb051hp9404_2" type="file">
             <label>Transcript</label>

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -732,6 +732,44 @@ module PURLFixtures
     XML
   end
 
+  def long_label_purl
+    <<-XML
+      <publicObject>
+        <identityMetadata>
+          <objectLabel>Title of the video</objectLabel>
+        </identityMetadata>
+        <contentMetadata type="media">
+          <resource sequence="1" id="abc123_1" type="video">
+            <label>The First Video Has An Overly Long Title, With More Words Than Can Practically Be Displayed</label>
+            <file id="abc_123.mp4" mimetype="video/mp4" size="152000000">
+              <videoData duration="P0DT1H2M3S" height="288" width="352"/>
+            </file>
+          </resource>
+          <resource sequence="2" id="abc321_1" type="video">
+            <label>2nd Video Has A Long Title, But Not Too Long</label>
+            <file id="abc_321.mp4" mimetype="video/mp4" size="666000000"></file>
+          </resource>
+          <resource sequence="3" id="bb051hp9404_2" type="file">
+            <label>Transcript</label>
+            <file id="abc_123_script.pdf" mimetype="application/pdf" size="557708"></file>
+          </resource>
+        </contentMetadata>
+        <rightsMetadata>
+          #{access_read_world}
+          <access type="read">
+            <file>abc_123.mp4</file>
+            <machine>
+              <location>spec</location>
+            </machine>
+          </access>
+        </rightsMetadata>
+        <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+          <dc:title>stupid dc title of video</dc:title>
+        </oai_dc>
+      </publicObject>
+    XML
+  end
+
   def video_purl_with_image
     <<-XML
       <publicObject>

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -103,6 +103,18 @@ describe Embed::MediaTag do
         expect(media_wrapper).not_to have_css('.sul-embed-media-access-restricted .line2', text: 'See Access conditions for more information')
       end
     end
+    describe 'duration' do
+      it 'sets the duration when the resource file has duration' do
+        resource_file = double(Embed::PURL::Resource::ResourceFile, video_duration: Embed::PURL::Duration.new('PT0H1M2S'))
+        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', file: resource_file))
+        expect(media_wrapper).to have_css('[data-duration="1:02"]')
+      end
+      it 'leaves the duration empty when the resource file is missing duration' do
+        resource_file = double(Embed::PURL::Resource::ResourceFile)
+        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', file: resource_file))
+        expect(media_wrapper).to have_css('[data-duration=""]')
+      end
+    end
     # TODO:  not sure if we're going to keep data-location-restricted as an attrib or just use element
     describe 'data-location-restricted attribute' do
       context 'stanford_only' do

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -77,23 +77,27 @@ describe Embed::MediaTag do
   describe '#media_wrapper' do
     describe 'data-stanford-only attribute' do
       it 'true for Stanford only files' do
-        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', stanford_only: true, location_restricted: false))
+        resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: true, location_restricted?: false)
+        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', file: resource_file))
         expect(media_wrapper).to have_css('[data-stanford-only="true"]')
       end
 
       it 'false for public files' do
-        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', stanford_only: false, location_restricted: false))
+        resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: false, location_restricted?: false)
+        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', file: resource_file))
         expect(media_wrapper).to have_css('[data-stanford-only="false"]')
       end
     end
     describe 'location restriction message' do
       it 'displayed when not in location' do
-        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', stanford_only: false, location_restricted: true))
+        resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: false, location_restricted?: true)
+        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', file: resource_file))
         expect(media_wrapper).to have_css('.sul-embed-media-access-restricted .line1', text: 'Restricted media cannot be played in your location')
         expect(media_wrapper).to have_css('.sul-embed-media-access-restricted .line2', text: 'See Access conditions for more information')
       end
       it 'not displayed when in location' do
-        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', stanford_only: false, location_restricted: false))
+        resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: false, location_restricted?: false)
+        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', file: resource_file))
         expect(media_wrapper).not_to have_css('.sul-embed-media-access-restricted')
         expect(media_wrapper).not_to have_css('.sul-embed-media-access-restricted .line1', text: 'Limited access for non-Stanford guests')
         expect(media_wrapper).not_to have_css('.sul-embed-media-access-restricted .line2', text: 'See Access conditions for more information')
@@ -103,23 +107,27 @@ describe Embed::MediaTag do
     describe 'data-location-restricted attribute' do
       context 'stanford_only' do
         it 'true for location restricted files' do
-          media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', stanford_only: true, location_restricted: true))
+          resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: true, location_restricted?: true)
+          media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', file: resource_file))
           expect(media_wrapper).to have_css('[data-location-restricted="true"]')
         end
 
         it 'false for public files' do
-          media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', stanford_only: true, location_restricted: false))
+          resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: true, location_restricted?: false)
+          media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', file: resource_file))
           expect(media_wrapper).to have_css('[data-location-restricted="false"]')
         end
       end
       context 'not stanford_only' do
         it 'true for location restricted files' do
-          media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', stanford_only: false, location_restricted: true))
+          resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: false, location_restricted?: true)
+          media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', file: resource_file))
           expect(media_wrapper).to have_css('[data-location-restricted="true"]')
         end
 
         it 'false for public files' do
-          media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', stanford_only: false, location_restricted: false))
+          resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: false, location_restricted?: false)
+          media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', file: resource_file))
           expect(media_wrapper).to have_css('[data-location-restricted="false"]')
         end
       end

--- a/spec/models/embed/purl_spec.rb
+++ b/spec/models/embed/purl_spec.rb
@@ -231,12 +231,40 @@ describe Embed::PURL do
         end
       end
       describe 'video_data' do
-        before { stub_purl_response_with_fixture(multi_media_purl) }
-        let(:video) { Embed::PURL.new('12345').contents.first.files.first }
-        it 'should get the height and width for the video object' do
-          expect(video.video_height).to eq '288'
-          expect(video.video_width).to eq '352'
+        context 'valid videoData' do
+          before { stub_purl_response_with_fixture(multi_media_purl) }
+          let(:video) { Embed::PURL.new('12345').contents.first.files.first }
+          it 'should get the height and width for the video object' do
+            expect(video.video_height).to eq '288'
+            expect(video.video_width).to eq '352'
+          end
+          it 'should get the duration for the video object' do
+            expect(video.video_duration.to_s).to eq '1:02:03'
+          end
         end
+        context 'duration in an invalid format' do
+          before { stub_purl_response_with_fixture(invalid_video_duration_purl) }
+          let(:video) { Embed::PURL.new('12345').contents.first.files.first }
+          it 'should return nil and log an error' do
+            expect(Rails.logger).to receive(:warn).with("ResourceFile\#video_duration ISO8601::Errors::UnknownPattern: 'PDDTMMS'")
+            expect(video.video_duration).to be_nil
+          end
+        end
+      end
+    end
+    describe 'PURL::Duration' do
+      it '#to_s should return the appropriate human-readable string for the given iso8601 duration string' do
+        expect(Embed::PURL::Duration.new('P0DT1H2M3S').to_s).to eq '1:02:03'
+        expect(Embed::PURL::Duration.new('PT2M3S').to_s).to     eq '2:03'
+        expect(Embed::PURL::Duration.new('PT10S').to_s).to      eq '0:10'
+        expect(Embed::PURL::Duration.new('P5DT1H2M3S').to_s).to eq '5:01:02:03'
+        expect(Embed::PURL::Duration.new('P9D').to_s).to        eq '9:00:00:00'
+      end
+      it '#to_s should return nil and log the appropriate error for an unsupported Duration specification' do
+        expect(Rails.logger).to receive(:warn).with('Embed::PURL::Duration does not support specifying durations in weeks')
+        expect(Rails.logger).to receive(:warn).with('Embed::PURL::Duration does not support specifying negative durations')
+        expect(Embed::PURL::Duration.new('P10W').to_s).to be_nil
+        expect(Embed::PURL::Duration.new('-PT10S').to_s).to be_nil
       end
     end
   end

--- a/spec/models/embed/purl_spec.rb
+++ b/spec/models/embed/purl_spec.rb
@@ -230,6 +230,14 @@ describe Embed::PURL do
           expect(file.location).to eq 'http://stacks.stanford.edu/file/druid:abc123/Title_of_the_PDF.pdf'
         end
       end
+      describe 'video_data' do
+        before { stub_purl_response_with_fixture(multi_media_purl) }
+        let(:video) { Embed::PURL.new('12345').contents.first.files.first }
+        it 'should get the height and width for the video object' do
+          expect(video.video_height).to eq '288'
+          expect(video.video_width).to eq '352'
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
this adds a new [dependency](https://github.com/arnau/ISO8601) because:
* ruby's time libraries don't parse ISO 8601 durations
* ActiveSupport's Duration class does, but not until rails 5
* arnau's library seems well tested, and a better fit than the other options i looked at:
  * https://github.com/peleteiro/ruby-duration
  * https://github.com/janko-m/as-duration (just reimplements that AS4 duration)

AFAICT, nothing off the shelf provides for nice human readable printing of a duration object in the way you'd expect a media timer to do it.  as the mockup implies, this will print durations such that:
* all fields after the first non-zero field are included
* all fields after the first included field are zero padded

e.g.:
`P0DT1H2M3S` => `1:02:03` (i.e. 0 days, 1 hour, 2 minutes, 3 seconds)
`PT10S` => `0:10` (i.e. 10 seconds)
`P9D` => `9:00:00:00` (i.e. 9 days)

before:
<img width="1439" alt="screen shot 2016-08-11 at 2 32 44 pm" src="https://cloud.githubusercontent.com/assets/7741604/17605713/a6e2def2-5fd0-11e6-9132-5f27d4c4d2e1.png">

after (title on last object pushes duration out of view; @jkeck and i were inclined to say we can live with that, but also wanted input from @jvine to see if there was a better solution or a placement that'd keep that from happening):
<img width="1450" alt="screen shot 2016-08-11 at 2 33 24 pm" src="https://cloud.githubusercontent.com/assets/7741604/17605720/ada32cf6-5fd0-11e6-98db-3d4c9d9ae31b.png">



see also: https://en.wikipedia.org/wiki/ISO_8601#Durations (it turns out the actual ISO doc costs 138 swiss francs)

closes issue #636 
closes issue #574 
connect to sul-dlss/sul-embed#636 
connect to sul-dlss/sul-embed#574 