### PR TITLE
Improve handling of embed customization parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Viewers can customize the embed panel.  To do this, the viewer should override #
 
     def embed_this_html
       return '' if @request.hide_embed_this?
-      Embed::EmbedThisPanel.new(druid: @purl_object.druid, height: height, width: width, purl_object_title: @purl_object.title) do
+      Embed::EmbedThisPanel.new(druid: @purl_object.druid, height: height, width: width, request: @request, purl_object_title: @purl_object.title) do
         "Panel Content Goes Here"
       end.to_html
     end

--- a/app/assets/javascripts/modules/embed_this.js
+++ b/app/assets/javascripts/modules/embed_this.js
@@ -16,10 +16,10 @@
             textarea = $('textarea', formContainer);
         $('input[type="checkbox"], input[type="text"]', formContainer).on('change', function(){
           var checked   = $(this).is(':checked'),
-              inputType = $(this).attr('type');
+              inputType = $(this).attr('type'),
               src       = textarea.text().match(/src='(\S+)'/)[1],
               urlAttr   = '&' + $(this).data('embed-attr') + '=true';
-          if(inputType == 'checkbox'){
+          if(inputType === 'checkbox'){
             if(checked) {
               textarea.text(textarea.text().replace(urlAttr, ''));
             }else{

--- a/lib/embed/embed_this_panel.rb
+++ b/lib/embed/embed_this_panel.rb
@@ -24,7 +24,7 @@ module Embed
               <div class='sul-embed-embed-this-form'>
                 <span class='sul-embed-options-label'>Select options:</span>
                 <div class='sul-embed-section sul-embed-embed-title-section'>
-                  <input type='checkbox' id='sul-embed-embed-title' data-embed-attr='hide_title' checked=true />
+                  <input type='checkbox' id='sul-embed-embed-title' data-embed-attr='hide_title' #{'checked' unless request.hide_title?} />
                   <label for='sul-embed-embed-title'>
                     title
                     <span class='sul-embed-embed-title'> (#{purl_object_title})</span>
@@ -32,7 +32,7 @@ module Embed
                 </div>
                 #{panel_content}
                 <div class='sul-embed-section'>
-                  <input type='checkbox' id='sul-embed-embed' data-embed-attr='hide_embed' checked=true />
+                  <input type='checkbox' id='sul-embed-embed' data-embed-attr='hide_embed' #{'checked' unless request.hide_embed_this?} />
                   <label for='sul-embed-embed'>embed</label>
                 </div>
                 <div>

--- a/lib/embed/embed_this_panel.rb
+++ b/lib/embed/embed_this_panel.rb
@@ -1,9 +1,10 @@
 module Embed
   class EmbedThisPanel
-    def initialize(druid:, height:, width:, purl_object_title:)
+    def initialize(druid:, height:, width:, request:, purl_object_title:)
       @druid = druid
       @height = height
       @width = width
+      @request = request
       @purl_object_title = purl_object_title
       @panel_content = yield if block_given?
     end
@@ -49,22 +50,22 @@ module Embed
       HTML
     end
 
-    def self.iframe_html(druid:, height:, width:)
+    def self.iframe_html(druid:, height:, width:, request:)
       width_style = if width
                       "#{width}px"
                     else
                       '100%'
                     end
-      src = "#{Settings.embed_iframe_url}?url=#{Settings.purl_url}/#{druid}&maxheight=#{height}&maxwidth=#{width}"
+      src = "#{Settings.embed_iframe_url}?url=#{Settings.purl_url}/#{druid}&#{request.as_url_params.to_query}"
       "<iframe src='#{src}' height='#{height}px' width='#{width_style}' frameborder='0' marginwidth='0' marginheight='0' scrolling='no' allowfullscreen />"
     end
 
     private
 
-    attr_reader :druid, :height, :width, :purl_object_title, :panel_content
+    attr_reader :druid, :height, :width, :request, :purl_object_title, :panel_content
 
     def iframe_html
-      self.class.iframe_html(druid: druid, height: height, width: width)
+      self.class.iframe_html(druid: druid, height: height, width: width, request: request)
     end
   end
 end

--- a/lib/embed/request.rb
+++ b/lib/embed/request.rb
@@ -40,12 +40,32 @@ module Embed
       params[:hide_download] && params[:hide_download] == 'true'
     end
 
+    def hide_search?
+      params[:hide_search] && params[:hide_search] == 'true'
+    end
+
+    def min_files_to_search
+      params[:min_files_to_search]
+    end
+
     def object_druid
       url[/\w*$/]
     end
 
     def purl_object
       @purl_object ||= PURL.new(object_druid)
+    end
+
+    def as_url_params
+      params.slice(
+        :maxheight,
+        :maxwidth,
+        :hide_title,
+        :hide_embed,
+        :hide_search,
+        :hide_download,
+        :min_files_to_search
+      )
     end
 
     private

--- a/lib/embed/response.rb
+++ b/lib/embed/response.rb
@@ -29,7 +29,8 @@ module Embed
       @html ||= Embed::EmbedThisPanel.iframe_html(
         druid: @request.purl_object.druid,
         height: viewer.height,
-        width: viewer.width
+        width: viewer.width,
+        request: @request
       )
     end
 

--- a/lib/embed/viewer/common_viewer.rb
+++ b/lib/embed/viewer/common_viewer.rb
@@ -117,7 +117,7 @@ module Embed
       #  override this method, passing a block to EmbedThisPanel
       def embed_this_html
         return '' if @request.hide_embed_this?
-        Embed::EmbedThisPanel.new(druid: @purl_object.druid, height: height, width: width, purl_object_title: @purl_object.title).to_html
+        Embed::EmbedThisPanel.new(druid: @purl_object.druid, height: height, width: width, request: @request, purl_object_title: @purl_object.title).to_html
       end
 
       def download_html

--- a/lib/embed/viewer/file.rb
+++ b/lib/embed/viewer/file.rb
@@ -169,7 +169,7 @@ module Embed
 
       def embed_this_html
         return '' if @request.hide_embed_this?
-        Embed::EmbedThisPanel.new(druid: @purl_object.druid, height: height, width: width, purl_object_title: @purl_object.title) do
+        Embed::EmbedThisPanel.new(druid: @purl_object.druid, height: height, width: width, request: @request, purl_object_title: @purl_object.title) do
           Nokogiri::HTML::Builder.new do |doc|
             doc.div(class: 'sul-embed-section') do
               doc.input(type: 'checkbox', id: 'sul-embed-embed-search', 'data-embed-attr': 'hide_search', checked: true)
@@ -197,7 +197,7 @@ module Embed
       end
 
       def min_files_to_search
-        (@request.params[:min_files_to_search] || 10).to_i
+        (@request.min_files_to_search || 10).to_i
       end
 
       def file_search_html(doc)

--- a/lib/embed/viewer/file.rb
+++ b/lib/embed/viewer/file.rb
@@ -172,11 +172,13 @@ module Embed
         Embed::EmbedThisPanel.new(druid: @purl_object.druid, height: height, width: width, request: @request, purl_object_title: @purl_object.title) do
           Nokogiri::HTML::Builder.new do |doc|
             doc.div(class: 'sul-embed-section') do
-              doc.input(type: 'checkbox', id: 'sul-embed-embed-search', 'data-embed-attr': 'hide_search', checked: true)
+              checkbox_options = { type: 'checkbox', id: 'sul-embed-embed-search', 'data-embed-attr': 'hide_search' }
+              checkbox_options[:checked] = 'checked' unless @request.hide_search?
+              doc.input(checkbox_options)
               doc.label(for: 'sul-embed-embed-search') { doc.text('add search box') }
               doc.label(for: 'sul-embed-min_files_to_search') do
                 doc.text(' for')
-                doc.input(type: 'text', id: 'sul-embed-min_files_to_search', 'data-embed-attr': 'min_files_to_search', value: '10')
+                doc.input(type: 'text', id: 'sul-embed-min_files_to_search', 'data-embed-attr': 'min_files_to_search', value: min_files_to_search)
                 doc.text('or more files')
               end
             end

--- a/lib/embed/viewer/image_x.rb
+++ b/lib/embed/viewer/image_x.rb
@@ -110,7 +110,9 @@ module Embed
         Embed::EmbedThisPanel.new(druid: @purl_object.druid, height: height, width: width, request: @request, purl_object_title: @purl_object.title) do
           Nokogiri::HTML::Builder.new do |doc|
             doc.div(class: 'sul-embed-section') do
-              doc.input(type: 'checkbox', id: 'sul-embed-embed-download', 'data-embed-attr': 'hide_download', checked: true)
+              checkbox_options = { type: 'checkbox', id: 'sul-embed-embed-download', 'data-embed-attr': 'hide_download' }
+              checkbox_options[:checked] = 'true' unless @request.hide_download?
+              doc.input(checkbox_options)
               doc.label(for: 'sul-embed-embed-download') { doc.text('download') }
             end
           end.to_html

--- a/lib/embed/viewer/image_x.rb
+++ b/lib/embed/viewer/image_x.rb
@@ -107,7 +107,7 @@ module Embed
 
       def embed_this_html
         return '' if @request.hide_embed_this?
-        Embed::EmbedThisPanel.new(druid: @purl_object.druid, height: height, width: width, purl_object_title: @purl_object.title) do
+        Embed::EmbedThisPanel.new(druid: @purl_object.druid, height: height, width: width, request: @request, purl_object_title: @purl_object.title) do
           Nokogiri::HTML::Builder.new do |doc|
             doc.div(class: 'sul-embed-section') do
               doc.input(type: 'checkbox', id: 'sul-embed-embed-download', 'data-embed-attr': 'hide_download', checked: true)

--- a/spec/features/embed_this_panel_spec.rb
+++ b/spec/features/embed_this_panel_spec.rb
@@ -2,11 +2,14 @@ require 'rails_helper'
 
 describe 'embed this panel', js: true do
   include PURLFixtures
-  let(:request) { Embed::Request.new(url: 'http://purl.stanford.edu/abc123') }
+
+  let(:iframe_options) { {} }
+
   before do
     stub_purl_response_with_fixture(spec_fixture)
-    visit_iframe_response('ab123cd4567')
+    visit_iframe_response('ab123cd4567', iframe_options)
   end
+
   describe 'embed code' do
     let(:spec_fixture) { file_purl }
     it 'includes the allowfullscreen no-scrolling, no-border, and no margin/padding attributes' do
@@ -54,6 +57,26 @@ describe 'embed this panel', js: true do
     it 'include the form elements for downloading an image' do
       page.find('[data-sul-embed-toggle="sul-embed-embed-this-panel"]', match: :first).trigger('click')
       expect(page).to have_css('input#sul-embed-embed-download[type="checkbox"]')
+    end
+  end
+
+  describe 'Customization Options' do
+    let(:spec_fixture) { file_purl }
+
+    context 'with an uncustomized request' do
+      it 'defaults to having the option checked' do
+        page.find('[data-sul-embed-toggle="sul-embed-embed-this-panel"]', match: :first).trigger('click')
+        expect(page.find('#sul-embed-embed-title')).to be_checked
+      end
+    end
+
+    context 'with a customized request' do
+      let(:iframe_options) { { hide_title: true } }
+
+      it "defaults to the options from the current viewer's request" do
+        page.find('[data-sul-embed-toggle="sul-embed-embed-this-panel"]', match: :first).trigger('click')
+        expect(page.find('#sul-embed-embed-title')).not_to be_checked
+      end
     end
   end
 end

--- a/spec/features/sandbox_spec.rb
+++ b/spec/features/sandbox_spec.rb
@@ -2,12 +2,26 @@ require 'rails_helper'
 
 describe 'embed sandbox page', js: true do
   include PURLFixtures
-  it 'returns the iframe output from the embed endpoint' do
-    stub_purl_response_with_fixture(file_purl)
 
+  before do
+    stub_purl_response_with_fixture(file_purl)
+  end
+
+  it 'returns the iframe output from the embed endpoint' do
     visit_sandbox
     expect(page).not_to have_css('iframe')
     send_embed_response
     expect(page).to have_css("iframe[src^='#{Settings.embed_iframe_url}']")
+  end
+
+  it 'passes the customization URL parameters down to the iframe successfully' do
+    visit_sandbox
+    expect(page).not_to have_css('iframe')
+    check('hide-title')
+    check('hide-search')
+    send_embed_response
+    iframe_src = page.find('iframe')['src']
+    expect(iframe_src).to match(/hide_title=true/)
+    expect(iframe_src).to match(/hide_search=true/)
   end
 end

--- a/spec/lib/embed/request_spec.rb
+++ b/spec/lib/embed/request_spec.rb
@@ -26,6 +26,38 @@ describe Embed::Request do
       expect(Embed::Request.new(url: purl, hide_metadata: 'true').hide_metadata?).to be_truthy
     end
   end
+
+  describe 'min_files_to_search' do
+    it 'returns the value passed in via the request parameters' do
+      expect(Embed::Request.new(url: purl, min_files_to_search: '5').min_files_to_search).to eq '5'
+    end
+  end
+
+  describe 'hide_search?' do
+    it 'defaults to false' do
+      expect(Embed::Request.new(url: purl).hide_search?).to be_falsy
+    end
+
+    it 'is true when the incoming request asked to hide the search box' do
+      expect(Embed::Request.new(url: purl, hide_search: 'true').hide_search?).to be_truthy
+    end
+  end
+
+  describe 'as_url_params' do
+    let(:url_params) do
+      Embed::Request.new(url: purl, hide_title: 'true', hide_metadata: 'true').as_url_params
+    end
+
+    it 'is a hash of parameters to be turned into url optinos' do
+      expect(url_params).to be_a Hash
+      expect(url_params[:hide_title]).to eq('true')
+    end
+
+    it 'does not include parameters that should not be passed along in a url (such as hide_metadata)' do
+      expect(url_params).to_not have_key(:hide_metadata)
+    end
+  end
+
   describe 'object_druid' do
     it 'should parse the druid out of the incoming URL parameter' do
       expect(Embed::Request.new(url: purl).object_druid).to eq 'abc123'

--- a/spec/lib/embed/response_spec.rb
+++ b/spec/lib/embed/response_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Embed::Response do
   let(:viewer) { double('viewer') }
-  let(:request) { double('request') }
+  let(:request) { double('request', as_url_params: {}) }
   let(:purl_object) { double('purl_object', druid: 'abc123') }
   let(:response) { Embed::Response.new(request) }
   describe 'static attributes' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,7 +75,6 @@ def visit_iframe_response(druid = 'ignored', min_files_to_search: nil, hide_sear
 end
 
 def send_embed_response
-  visit_sandbox
   fill_in_default_sandbox_form
   click_button 'Embed'
 end


### PR DESCRIPTION
This PR passes the `Embed::Request` context into the `EmbedThisPanel` so that the iframe code has access to the original request's customization parameters (such as whether to hide the title, download panel, etc).

This allows us to do two things:

1. The `embed/iframe` url that is in the `src` of the iframe returned in the oembed response now properly includes the incoming customization parameters.
1. The `EmbedThisPanel` now defaults to the customizations that were in the original request (i.e. if the embed the user is viewing was customized to hide the title, the embed code that the user gets from that object will default to having its title hidden as well).

## Before
![iframe-options-before](https://cloud.githubusercontent.com/assets/96776/17605832/3935bbd0-5fd1-11e6-950b-86e45c284fce.gif)

## After
![iframe-options](https://cloud.githubusercontent.com/assets/96776/17605759/d4a66034-5fd0-11e6-93d4-c9842dddd833.gif)
