### PR TITLE
Add ability to construct rtmp links for flash fallbacks

### DIFF
--- a/app/assets/javascripts/modules/media_viewer.js
+++ b/app/assets/javascripts/modules/media_viewer.js
@@ -115,11 +115,14 @@
       if(token === undefined) {
         return;
       }
-      var source = mediaObject.find('source[type="application/x-mpegURL"]');
-      var originalSrc = source.attr('src');
-      if(!originalSrc.includes('stacks_token')) {
-        source.prop('src', originalSrc + '?stacks_token=' + token);
-      }
+      var sources = mediaObject.find('source');
+      jQuery.each(sources, function(){
+        var source = jQuery(this);
+        var originalSrc = source.attr('src');
+        if(!originalSrc.includes('stacks_token')) {
+          source.prop('src', originalSrc + '?stacks_token=' + token);
+        }
+      });
     }
 
     function initializeVideoJSPlayer(mediaObject) {

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,14 +21,20 @@ was_thumb_conn_timeout: 5
 streaming:
   source_types:
     - hls
+    - flash
   hls:
     suffix: '.m3u8'
     mimetype: 'application/x-mpegURL'
+    protocol: 'https'
+  flash:
+    mimetype: 'audio/mpeg'
+    protocol: 'rtmp'
   dash:
     suffix: '.mpd'
     mimetype: 'application/dash+xml'
+    protocol: 'https'
 stream:
-  url: http://streaming-server.com:1935/stuff
+  url: streaming-server.com:1935/stuff
   # streaming media file extensions we support
   video:
     - mov

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -158,6 +158,8 @@ module Embed
       case type.to_sym
       when :hls
         stacks_media_stream.to_playlist_url
+      when :flash
+        stacks_media_stream.to_rtmp_url
       when :dash
         stacks_media_stream.to_manifest_url
       end

--- a/lib/embed/stacks_media_stream.rb
+++ b/lib/embed/stacks_media_stream.rb
@@ -4,8 +4,9 @@
 module Embed
   class StacksMediaStream
     TYPE_TO_MANIFEST_FILE = {
-      hls: 'playlist.m3u8',
-      dash: 'manifest.mpd'
+      hls: '/playlist.m3u8',
+      flash: '',
+      dash: '/manifest.mpd'
     }.freeze
 
     def initialize(druid:, file_name:)
@@ -15,6 +16,10 @@ module Embed
 
     def to_playlist_url
       streaming_url_for(:hls)
+    end
+
+    def to_rtmp_url
+      streaming_url_for(:flash)
     end
 
     def to_manifest_url
@@ -27,8 +32,15 @@ module Embed
 
     def streaming_url_for(type)
       return unless file_name && streaming_file_prefix
+      protocol = streaming_protocol(type)
       suffix = TYPE_TO_MANIFEST_FILE[type]
-      "#{streaming_base_url}/#{druid_tree}/#{streaming_url_file_segment}/#{suffix}"
+      delimiter = streaming_url_delimiter(type)
+      "#{protocol}://#{streaming_base_url}#{delimiter}#{druid_tree}/#{streaming_url_file_segment}#{suffix}"
+    end
+
+    def streaming_url_delimiter(type)
+      return '&' if type == :flash
+      '/'
     end
 
     def streaming_file_prefix
@@ -64,6 +76,10 @@ module Embed
 
     def streaming_url_file_segment
       "#{streaming_file_prefix}:#{file_name}"
+    end
+
+    def streaming_protocol(type)
+      Settings.streaming[type].protocol
     end
   end
 end

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -159,6 +159,7 @@ describe Embed::MediaTag do
       it 'gets the correct URL based on the passed in type' do
         expect(subject_klass.send(:streaming_url_for, file, :hls)).to match(%r{.*/playlist.m3u8$})
         expect(subject_klass.send(:streaming_url_for, file, :dash)).to match(%r{.*/manifest.mpd$})
+        expect(subject_klass.send(:streaming_url_for, file, :flash)).to match(%r{^rtmp://.*})
       end
     end
 

--- a/spec/lib/embed/stacks_media_stream_spec.rb
+++ b/spec/lib/embed/stacks_media_stream_spec.rb
@@ -7,16 +7,16 @@ describe Embed::StacksMediaStream do
     context 'video' do
       it 'mp4 extension' do
         sms = described_class.new(druid: 'ab012cd3456', file_name: 'def.mp4')
-        expect(sms.to_playlist_url).to eq "#{streaming_base_url}/ab/012/cd/3456/mp4:def.mp4/playlist.m3u8"
+        expect(sms.to_playlist_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp4:def.mp4/playlist.m3u8"
       end
       it 'mov extension' do
         sms = described_class.new(druid: 'ab012cd3456', file_name: 'def.mov')
-        expect(sms.to_playlist_url).to eq "#{streaming_base_url}/ab/012/cd/3456/mp4:def.mov/playlist.m3u8"
+        expect(sms.to_playlist_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp4:def.mov/playlist.m3u8"
       end
     end
     it 'audio - mp3' do
       sms = described_class.new(druid: 'ab012cd3456', file_name: 'def.mp3')
-      expect(sms.to_playlist_url).to eq "#{streaming_base_url}/ab/012/cd/3456/mp3:def.mp3/playlist.m3u8"
+      expect(sms.to_playlist_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp3:def.mp3/playlist.m3u8"
     end
     it 'unknown' do
       sms = described_class.new(druid: 'ab012cd3456', file_name: 'def.xxx')
@@ -28,20 +28,35 @@ describe Embed::StacksMediaStream do
     context 'video' do
       it 'mp4 extension' do
         sms = described_class.new(druid: 'ab012cd3456', file_name: 'def.mp4')
-        expect(sms.to_manifest_url).to eq "#{streaming_base_url}/ab/012/cd/3456/mp4:def.mp4/manifest.mpd"
+        expect(sms.to_manifest_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp4:def.mp4/manifest.mpd"
       end
       it 'mov extension' do
         sms = described_class.new(druid: 'ab012cd3456', file_name: 'def.mov')
-        expect(sms.to_manifest_url).to eq "#{streaming_base_url}/ab/012/cd/3456/mp4:def.mov/manifest.mpd"
+        expect(sms.to_manifest_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp4:def.mov/manifest.mpd"
       end
     end
     it 'audio - mp3' do
       sms = described_class.new(druid: 'ab012cd3456', file_name: 'def.mp3')
-      expect(sms.to_manifest_url).to eq "#{streaming_base_url}/ab/012/cd/3456/mp3:def.mp3/manifest.mpd"
+      expect(sms.to_manifest_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp3:def.mp3/manifest.mpd"
     end
     it 'unknown' do
       sms = described_class.new(druid: 'ab012cd3456', file_name: 'def.xxx')
       expect(sms.to_manifest_url).to be_nil
+    end
+  end
+
+  describe '#to_rtmp_url' do
+    let(:sms) { described_class.new(druid: 'ab012cd3456', file_name: 'def.mp3') }
+    it 'does not include a suffix' do
+      expect(sms.to_rtmp_url).to match(%r{/mp3:def.mp3$})
+    end
+
+    it 'delimits the stream host/application name from the stream name with an "&"' do
+      expect(sms.to_rtmp_url).to match(%r{#{streaming_base_url}&ab/012/cd})
+    end
+
+    it 'adds the rtmp protocl to the URL' do
+      expect(sms.to_rtmp_url).to match(%r{^rtmp://})
     end
   end
 end


### PR DESCRIPTION
Also removes HLS playlist URLs for mp3 on browsers that don't support HLS natively.

Closes #631