### PR TITLE
Add a target to links intended for downloading files from stacks.

### DIFF
--- a/app/assets/javascripts/modules/download_panel.js
+++ b/app/assets/javascripts/modules/download_panel.js
@@ -19,7 +19,7 @@
       var $listMarkup = $('<li class="sul-embed-download-list-item"></li>');
       // Append a thumb download link
       $downloadList.append($listMarkup.clone()
-        .append('<a class="download-link" href="' + imageData['@id'] +
+        .append('<a target="_blank" class="download-link" href="' + imageData['@id'] +
         '/full/!' + disableDownloadWidthCutoff + ',' +
         disableDownloadWidthCutoff +
         '/0/default.jpg?download=true" download>Download Thumbnail</a>'));

--- a/lib/embed/viewer/file.rb
+++ b/lib/embed/viewer/file.rb
@@ -133,7 +133,8 @@ module Embed
               "#{'sul-embed-stanford-only' if file.stanford_only?}") do
             doc.a(
               href: file_url(file.title),
-              title: tooltip_text(file)
+              title: tooltip_text(file),
+              target: '_blank'
             ) do
               doc.text file.title
             end
@@ -153,7 +154,7 @@ module Embed
             doc.text pretty_filesize(file.size)
           end
         else
-          doc.a(href: file_url(file.title), download: nil) do
+          doc.a(href: file_url(file.title), download: nil, target: '_blank') do
             doc.span(class: 'sul-embed-sr-only') do
               doc.text "Download item #{file_count}"
             end

--- a/lib/embed/viewer/geo.rb
+++ b/lib/embed/viewer/geo.rb
@@ -23,7 +23,7 @@ module Embed
                 doc.ul(class: 'sul-embed-download-list') do
                   resource.files.each do |file|
                     doc.li(class: ('sul-embed-stanford-only' if file.stanford_only?).to_s) do
-                      doc.a(href: file_url(file.title), title: file.title) do
+                      doc.a(href: file_url(file.title), title: file.title, target: '_blank') do
                         doc.text "Download #{file.title}"
                       end
                     end

--- a/lib/embed/viewer/media.rb
+++ b/lib/embed/viewer/media.rb
@@ -54,7 +54,9 @@ module Embed
             file_size = "(#{pretty_filesize(file.size)})" if file.size
             <<-HTML.strip_heredoc
               <li class='#{('sul-embed-stanford-only' if file.stanford_only?)}'>
-                <a href='#{file_url(file.title)}' title='#{file.title}'>Download #{link_text}</a>
+                <a href='#{file_url(file.title)}' title='#{file.title}' target='_blank'>
+                  Download #{link_text}
+                </a>
                 #{file_size}
               </li>
             HTML

--- a/spec/features/geo_viewer_spec.rb
+++ b/spec/features/geo_viewer_spec.rb
@@ -37,6 +37,15 @@ describe 'geo viewer public', js: true do
         end
       end
     end
+
+    it 'includes a "_blank" target on the download links' do
+      find('button.sul-embed-footer-tool.sul-i-download-3').click
+      within '.sul-embed-download-panel' do
+        within '.sul-embed-panel-body' do
+          expect(page).to have_css('li a[target="_blank"]', count: 1)
+        end
+      end
+    end
   end
 end
 

--- a/spec/features/image_x_viewer_spec.rb
+++ b/spec/features/image_x_viewer_spec.rb
@@ -102,4 +102,14 @@ describe 'imageX viewer', js: true do
       end
     end
   end
+
+  describe 'Download panel' do
+    it 'includes target = "_blank" for download links' do
+      toggle_download_panel
+
+      within('.sul-embed-download-panel') do
+        expect(page).to have_css('a[target="_blank"]')
+      end
+    end
+  end
 end

--- a/spec/lib/embed/viewer/file_spec.rb
+++ b/spec/lib/embed/viewer/file_spec.rb
@@ -64,6 +64,16 @@ describe Embed::Viewer::File do
         expect(html).to have_css 'a[download]', visible: false, text: /Download$/
       end
     end
+
+    context 'link targets' do
+      it 'is "_blank"' do
+        stub_purl_response_and_request(multi_resource_multi_type_purl, request)
+        expect(file_viewer).to receive(:asset_host).at_least(:twice).and_return('http://example.com/')
+        html = Capybara.string(file_viewer.to_html)
+        expect(html).to have_css('.sul-embed-media-heading a[target="_blank"]', visible: false)
+        expect(html).to have_css('.sul-embed-download a[target="_blank"]', visible: false)
+      end
+    end
   end
   describe 'file_type_icon' do
     it 'default file icon if mimetype is not recognized' do

--- a/spec/lib/embed/viewer/media_spec.rb
+++ b/spec/lib/embed/viewer/media_spec.rb
@@ -45,5 +45,9 @@ describe Embed::Viewer::Media do
       expect(download_html).to have_css('li', text: /\(\d+\.\d+ MB\)/, visible: false)
       expect(download_html).to have_css('li', text: /\(\d+\.\d+ kB\)/, visible: false)
     end
+
+    it 'includes a "_blank" target on the download links' do
+      expect(download_html).to have_css('li a[target="_blank"]', count: 3, visible: false)
+    end
   end
 end


### PR DESCRIPTION
Closes #648 

This prevents certain browsers from viewing the link as navigational
and replacing the embed content with empty HTML.