### PR TITLE
is_it_working: differentiate non_crucial checks 

### DIFF
--- a/config/initializers/is_it_working.rb
+++ b/config/initializers/is_it_working.rb
@@ -1,9 +1,29 @@
 Rails.configuration.middleware.use(IsItWorking::Handler) do |h|
   h.check :url, get: Settings.purl_url
   h.check :url, get: Settings.stacks_url
-  h.check :url, get: Settings.geo_wms_url
-  # check geo_external_url without the last part after the slash
-  pieces = Settings.geo_external_url.split('/')
-  h.check :url, get: pieces[0..-2].join('/')
-  h.check :url, get: Settings.was_thumbs_url
+
+  h.check :non_crucial do |status|
+    non_crucial_url_check(Settings.geo_wms_url, status, 'Geo viewer uses this')
+  end
+
+  h.check :non_crucial do |status|
+    # check geo_external_url without the last part after the slash
+    geo_ext_url_pieces = Settings.geo_external_url.split('/')
+    url_to_check = geo_ext_url_pieces[0..-2].join('/')
+    non_crucial_url_check(url_to_check, status, 'Geo objects use this to link out to Earthworks')
+  end
+
+  h.check :non_crucial do |status|
+    non_crucial_url_check(Settings.was_thumbs_url, status, 'Web Archive Seeds use this to get thumbnail images')
+  end
+end
+
+# even if url doesn't return 2xx or 304, return status 200 here
+#  (for load-balancer check) but expose failure in message text (for nagios check and humans)
+def non_crucial_url_check(url, return_status, info)
+  non_crucial_status = IsItWorking::Status.new('')
+  IsItWorking::UrlCheck.new(get: url).call(non_crucial_status)
+  non_crucial_status.messages.each do |x|
+    return_status.ok "#{'FAIL: ' unless x.ok?}#{x.message} (#{info})"
+  end
 end


### PR DESCRIPTION
... and ignore their status for is_it_working overall status

A failing "non-crucial" check not only returns 200 to the overall is_it_working status, but has an additional message that can be used to hopefully make it easier for PSMs to communicate with users/stakeholders.

### Before

![sul-embed before](https://cloud.githubusercontent.com/assets/96775/17719510/eca0bb96-63cf-11e6-8875-c469673ac481.png)

### After

![sul-embed after](https://cloud.githubusercontent.com/assets/96775/17719512/f26a3570-63cf-11e6-952b-708e3aa768f6.png)

This will allow the load balancer to check for status 200 while also allowing nagios to look for status 200 (for crucial alerts) and string matching on "FAIL" for non-crucial alerts.

Closes #649