### PR TITLE
[WIP] resource level thumbnails

### DIFF
--- a/app/assets/stylesheets/media.scss
+++ b/app/assets/stylesheets/media.scss
@@ -60,6 +60,7 @@
   }
 
   .#{$namespace}-media-square-icon {
+    float: left;
     margin-right: 5px;
     width: auto;
   }

--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -203,6 +203,16 @@ module Embed
         end
       end
 
+      # get first file of appropriate mime type
+      def media_file
+        files.find { |file| file.mimetype.match "^#{type}\/" }
+      end
+
+      # get first image file (if any) for the resource
+      def media_thumb
+        files.find(&:image?)
+      end
+
       class ResourceFile
         def initialize(file, rights)
           @file = file

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -15,34 +15,34 @@ module Embed
 
     def to_html
       output = ''
-      @file_index = 0 # TODO: this file index thing is set in a messy way
+      file_index = 0
       purl_document.contents.select { |resource| primary_file?(resource) }.each do |resource|
-        output << output_for_resource(resource)
-        @file_index += 1
+        output << output_for_resource(resource, file_index)
+        file_index += 1
       end
       output
     end
 
     private
 
-    attr_reader :file_index, :purl_document, :request, :viewer
+    attr_reader :purl_document, :request, :viewer
 
-    def output_for_resource(resource)
+    def output_for_resource(resource, file_index)
       label = resource.description
       if resource.media_file
         label = resource.media_file.title if label.blank?
-        media_element(label, resource)
+        media_element(label, resource, file_index)
       elsif resource.media_thumb
         label = resource.media_thumb.title if label.blank?
-        previewable_element(label, resource.media_thumb)
+        previewable_element(label, resource.media_thumb, file_index)
       else
         ''
       end
     end
 
-    def media_element(label, resource)
+    def media_element(label, resource, file_index)
       thumbnail = stacks_square_url(purl_document.druid, resource.media_thumb.title, size: '75') if resource.media_thumb
-      media_wrapper(label: label, file: resource.media_file, thumbnail: thumbnail) do
+      media_wrapper(label: label, file: resource.media_file, thumbnail: thumbnail, file_index: file_index) do
         <<-HTML.strip_heredoc
           <#{resource.type}
             id="sul-embed-media-#{file_index}"
@@ -60,8 +60,8 @@ module Embed
       end
     end
 
-    def previewable_element(label, file)
-      media_wrapper(label: label, thumbnail: stacks_square_url(@purl_document.druid, file.title, size: '75')) do
+    def previewable_element(label, file, file_index)
+      media_wrapper(label: label, thumbnail: stacks_square_url(@purl_document.druid, file.title, size: '75'), file_index: file_index) do
         "<img
           src='#{stacks_thumb_url(@purl_document.druid, file.title)}'
           class='sul-embed-media-thumb #{'sul-embed-many-media' if many_primary_files?}'
@@ -70,7 +70,7 @@ module Embed
       end
     end
 
-    def media_wrapper(label:, thumbnail: '', file: nil, &block)
+    def media_wrapper(label:, thumbnail: '', file: nil, file_index: nil, &block)
       <<-HTML.strip_heredoc
         <div data-stanford-only="#{file.try(:stanford_only?)}"
              data-location-restricted="#{file.try(:location_restricted?)}"

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -41,7 +41,8 @@ module Embed
     end
 
     def media_element(label, resource)
-      media_wrapper(label: label, file: resource.media_file) do
+      thumbnail = stacks_square_url(purl_document.druid, resource.media_thumb.title, size: '75') if resource.media_thumb
+      media_wrapper(label: label, file: resource.media_file, thumbnail: thumbnail) do
         <<-HTML.strip_heredoc
           <#{resource.type}
             id="sul-embed-media-#{file_index}"
@@ -51,6 +52,7 @@ module Embed
             aria-labelledby="access-restricted-message-div-#{file_index}"
             class="#{'sul-embed-many-media' if many_primary_files?}"
             style="height: #{media_element_height}; display:none;"
+            #{poster_attr_html(resource.media_thumb)}
             height="#{media_element_height}">
             #{enabled_streaming_sources(resource.media_file)}
           </#{resource.type}>
@@ -91,6 +93,10 @@ module Embed
            type='#{streaming_settings_for(streaming_type)[:mimetype]}'>
         </source>"
       end.join
+    end
+
+    def poster_attr_html(file)
+      "poster='#{stacks_thumb_url(purl_document.druid, file.title)}'" if file
     end
 
     def media_element_height

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -31,7 +31,7 @@ module Embed
       label = resource.description
       if resource.media_file
         label = resource.media_file.title if label.blank?
-        media_element(label, resource.media_file, resource.type)
+        media_element(label, resource)
       elsif resource.media_thumb
         label = resource.media_thumb.title if label.blank?
         previewable_element(label, resource.media_thumb)
@@ -40,20 +40,20 @@ module Embed
       end
     end
 
-    def media_element(label, file, type)
-      media_wrapper(label: label, file: file) do
+    def media_element(label, resource)
+      media_wrapper(label: label, file: resource.media_file) do
         <<-HTML.strip_heredoc
-          <#{type}
+          <#{resource.type}
             id="sul-embed-media-#{file_index}"
-            data-src="#{streaming_url_for(file, :dash)}"
-            data-auth-url="#{authentication_url(file)}"
+            data-src="#{streaming_url_for(resource.media_file, :dash)}"
+            data-auth-url="#{authentication_url(resource.media_file)}"
             controls='controls'
             aria-labelledby="access-restricted-message-div-#{file_index}"
             class="#{'sul-embed-many-media' if many_primary_files?}"
             style="height: #{media_element_height}; display:none;"
             height="#{media_element_height}">
-            #{enabled_streaming_sources(file)}
-          </#{type}>
+            #{enabled_streaming_sources(resource.media_file)}
+          </#{resource.type}>
         HTML
       end
     end

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -61,9 +61,9 @@ module Embed
     end
 
     def previewable_element(label, file, file_index)
-      media_wrapper(label: label, thumbnail: stacks_square_url(@purl_document.druid, file.title, size: '75'), file_index: file_index) do
+      media_wrapper(label: label, thumbnail: stacks_square_url(purl_document.druid, file.title, size: '75'), file_index: file_index) do
         "<img
-          src='#{stacks_thumb_url(@purl_document.druid, file.title)}'
+          src='#{stacks_thumb_url(purl_document.druid, file.title)}'
           class='sul-embed-media-thumb #{'sul-embed-many-media' if many_primary_files?}'
           style='max-height: #{media_element_height}'
         />"

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -8,17 +8,18 @@ module Embed
 
     include Embed::StacksImage
 
+    attr_accessor :file_index
     def initialize(viewer)
       @viewer = viewer
       @purl_document = viewer.purl_object
+      @file_index = 0
     end
 
     def to_html
       output = ''
-      file_index = 0
       purl_document.contents.select { |resource| primary_file?(resource) }.each do |resource|
-        output << output_for_resource(resource, file_index)
-        file_index += 1
+        output << output_for_resource(resource)
+        self.file_index += 1
       end
       output
     end
@@ -27,22 +28,22 @@ module Embed
 
     attr_reader :purl_document, :request, :viewer
 
-    def output_for_resource(resource, file_index)
+    def output_for_resource(resource)
       label = resource.description
       if resource.media_file
         label = resource.media_file.title if label.blank?
-        media_element(label, resource, file_index)
+        media_element(label, resource)
       elsif resource.media_thumb
         label = resource.media_thumb.title if label.blank?
-        previewable_element(label, resource.media_thumb, file_index)
+        previewable_element(label, resource.media_thumb)
       else
         ''
       end
     end
 
-    def media_element(label, resource, file_index)
+    def media_element(label, resource)
       thumbnail = stacks_square_url(purl_document.druid, resource.media_thumb.title, size: '75') if resource.media_thumb
-      media_wrapper(label: label, file: resource.media_file, thumbnail: thumbnail, file_index: file_index) do
+      media_wrapper(label: label, file: resource.media_file, thumbnail: thumbnail) do
         <<-HTML.strip_heredoc
           <#{resource.type}
             id="sul-embed-media-#{file_index}"
@@ -60,8 +61,8 @@ module Embed
       end
     end
 
-    def previewable_element(label, file, file_index)
-      media_wrapper(label: label, thumbnail: stacks_square_url(purl_document.druid, file.title, size: '75'), file_index: file_index) do
+    def previewable_element(label, file)
+      media_wrapper(label: label, thumbnail: stacks_square_url(purl_document.druid, file.title, size: '75')) do
         "<img
           src='#{stacks_thumb_url(purl_document.druid, file.title)}'
           class='sul-embed-media-thumb #{'sul-embed-many-media' if many_primary_files?}'
@@ -70,7 +71,7 @@ module Embed
       end
     end
 
-    def media_wrapper(label:, thumbnail: '', file: nil, file_index: nil, &block)
+    def media_wrapper(label:, thumbnail: '', file: nil, &block)
       <<-HTML.strip_heredoc
         <div data-stanford-only="#{file.try(:stanford_only?)}"
              data-location-restricted="#{file.try(:location_restricted?)}"

--- a/spec/features/media_viewer_spec.rb
+++ b/spec/features/media_viewer_spec.rb
@@ -83,6 +83,21 @@ describe 'media viewer', js: true do
     end
   end
 
+  context 'a media resource with its own thumbnail in a media object' do
+    let(:purl) { video_purl_with_image }
+
+    it 'includes a thumb for the video in the thumb slider' do
+      page.find('.sul-embed-thumb-slider-open-close').click
+      thumb_url = 'https://stacks.stanford.edu/image/iiif/ignored%2Fabc_123_thumb/square/75,75/0/default.jpg'
+      expect(page).to have_css("img.sul-embed-media-square-icon[src='#{thumb_url}']")
+    end
+
+    it 'uses the thumb for the video as the key frame (via the poster attribute)' do
+      poster_url = 'https://stacks.stanford.edu/image/iiif/ignored%2Fabc_123_thumb/full/!400,400/0/default.jpg'
+      expect(page).to have_css("div.sul-embed-media-wrapper video[poster='#{poster_url}']")
+    end
+  end
+
   context 'a location restricted file within a media object' do
     it 'displays the restricted text with the appropriate styling' do
       expect(page).not_to have_css('.sul-embed-thumb-slider', visible: true)

--- a/spec/features/media_viewer_spec.rb
+++ b/spec/features/media_viewer_spec.rb
@@ -94,7 +94,7 @@ describe 'media viewer', js: true do
 
     it 'uses the thumb for the video as the key frame (via the poster attribute)' do
       poster_url = 'https://stacks.stanford.edu/image/iiif/ignored%2Fabc_123_thumb/full/!400,400/0/default.jpg'
-      expect(page).to have_css("div.sul-embed-media-wrapper video[poster='#{poster_url}']")
+      expect(page).to have_css("div.sul-embed-media-wrapper video[poster='#{poster_url}']", visible: false)
     end
   end
 

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -801,6 +801,11 @@ module PURLFixtures
         </identityMetadata>
         <contentMetadata type="media">
           <resource sequence="1" id="abc123_1" type="video">
+            <!-- note that the resource-level thumb is listed before the media file for the resource;
+              the order of the two (if there is a resource-level thumb) shouldn't matter -->
+            <file id="abc_123_thumb.jp2" mimetype="image/jp2" size="274083">
+              <imageData height="1491" width="1719"/>
+            </file>
             <file id="abc_123.mp4" mimetype="video/mp4" size="152000000"></file>
           </resource>
           <resource sequence="2" id="bb051hp9404_2" type="file">

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -170,7 +170,7 @@ describe Embed::MediaTag do
 
     describe '#previewable_element' do
       before { stub_purl_response_with_fixture(purl) }
-      let(:previewable_element) { subject_klass.send(:previewable_element, 'Some Label', file) }
+      let(:previewable_element) { subject_klass.send(:previewable_element, 'Some Label', file, 'ignored'.to_i) }
       it 'passes the square thumb url as a data attribute' do
         expect(previewable_element).to match(
           %r{data-thumbnail-url="https://stacks.*/iiif/.*abc123/square/75,75.*"}

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -170,7 +170,7 @@ describe Embed::MediaTag do
 
     describe '#previewable_element' do
       before { stub_purl_response_with_fixture(purl) }
-      let(:previewable_element) { subject_klass.send(:previewable_element, 'Some Label', file, 'ignored'.to_i) }
+      let(:previewable_element) { subject_klass.send(:previewable_element, 'Some Label', file) }
       it 'passes the square thumb url as a data attribute' do
         expect(previewable_element).to match(
           %r{data-thumbnail-url="https://stacks.*/iiif/.*abc123/square/75,75.*"}
@@ -198,10 +198,10 @@ describe Embed::MediaTag do
       let(:media_file) { double('ResourceFile', title: 'media_file.mp4') }
       let(:media_thumb_file) { nil }
       let(:resource) { double('Resource', title: 'abc123.mp4', media_file: media_file, media_thumb: media_thumb_file, type: '_') }
-      let(:media_element) { subject_klass.send(:media_element, 'Some Label', resource, 0) }
+      let(:media_element) { subject_klass.send(:media_element, 'Some Label', resource) }
 
       it 'includes id indicating the position of the resource in the slider' do
-        expect(subject_klass).to receive(:media_wrapper).with(label: 'Some Label', file: media_file, thumbnail: nil, file_index: 0).and_call_original
+        expect(subject_klass).to receive(:media_wrapper).with(label: 'Some Label', file: media_file, thumbnail: nil).and_call_original
 
         expect(media_element).to match(/id="sul-embed-media-0"/)
       end
@@ -212,7 +212,7 @@ describe Embed::MediaTag do
         it 'includes resource level thumbs where available' do
           expect(subject_klass).to receive(:stacks_square_url).with('druid', media_thumb_file.title, size: '75').and_return('thumb_url.jp2')
           expect(subject_klass).to receive(:stacks_thumb_url).with('druid', media_thumb_file.title).and_return('thumb_url.jp2')
-          expect(subject_klass).to receive(:media_wrapper).with(label: 'Some Label', file: media_file, thumbnail: 'thumb_url.jp2', file_index: 0).and_call_original
+          expect(subject_klass).to receive(:media_wrapper).with(label: 'Some Label', file: media_file, thumbnail: 'thumb_url.jp2').and_call_original
 
           expect(media_element).to match(/poster='thumb_url.jp2'/)
           expect(media_element).to match(/data-thumbnail-url="thumb_url.jp2"/)

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -192,5 +192,32 @@ describe Embed::MediaTag do
         expect(previewable_element).to match(/class='.* sul-embed-many-media/)
       end
     end
+
+    describe '#media_element' do
+      before { stub_purl_response_with_fixture(purl) }
+      let(:media_file) { double('ResourceFile', title: 'media_file.mp4') }
+      let(:media_thumb_file) { nil }
+      let(:resource) { double('Resource', title: 'abc123.mp4', media_file: media_file, media_thumb: media_thumb_file, type: '_') }
+      let(:media_element) { subject_klass.send(:media_element, 'Some Label', resource, 0) }
+
+      it 'includes id indicating the position of the resource in the slider' do
+        expect(subject_klass).to receive(:media_wrapper).with(label: 'Some Label', file: media_file, thumbnail: nil, file_index: 0).and_call_original
+
+        expect(media_element).to match(/id="sul-embed-media-0"/)
+      end
+
+      context 'resource level thumbs' do
+        let(:media_thumb_file) { double('ResourceFile', title: 'media_thumb.jp2') }
+
+        it 'includes resource level thumbs where available' do
+          expect(subject_klass).to receive(:stacks_square_url).with('druid', media_thumb_file.title, size: '75').and_return('thumb_url.jp2')
+          expect(subject_klass).to receive(:stacks_thumb_url).with('druid', media_thumb_file.title).and_return('thumb_url.jp2')
+          expect(subject_klass).to receive(:media_wrapper).with(label: 'Some Label', file: media_file, thumbnail: 'thumb_url.jp2', file_index: 0).and_call_original
+
+          expect(media_element).to match(/poster='thumb_url.jp2'/)
+          expect(media_element).to match(/data-thumbnail-url="thumb_url.jp2"/)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
before (chrome):
![screen shot 2016-08-18 at 2 56 46 pm](https://cloud.githubusercontent.com/assets/7741604/17792136/05f2a750-6554-11e6-8acd-133eec9efa8a.png)

after (chrome):
![screen shot 2016-08-18 at 3 07 06 pm](https://cloud.githubusercontent.com/assets/7741604/17792436/8376a4d2-6555-11e6-95cc-93290b264f6c.png)

note the extra copy of "The relaxing song.mp3" in the before version.  that was due to a bug where all files belonging to supported resources were listed, instead of just an entry for each resource (with the supported media file from the given resource).  additionally, there was a bug in determining the label in such cases, where the label from the first file in the resource would be used for all files under the resource.  both bugs were fixed as a natural consequence of the refactoring needed to implement this enhancement.  the old offending code was: https://github.com/sul-dlss/sul-embed/blob/8bc11d43f8058ddf98c10263bfaf986b38ec8c49/lib/embed/media_tag.rb#L16-L32

the WIP label on this is because there's a display issue in FF, where the div with the label text for a slider entry appears below the slider entry:
![screen shot 2016-08-18 at 3 01 56 pm](https://cloud.githubusercontent.com/assets/7741604/17792295/d1da9e68-6554-11e6-942f-e220192b01f5.png)

advice from @jkeck or @jvine on the display issue?

this is currently deployed to embed-dev (and so should be used by purl-test).  ~~note that audio won't play for the test object for which the screenshots were taken, likely because there's a space in each of the file names, which we suspect embed is not properly encoding.  however, this should work for testing that audio still plays properly:  https://purl-test.stanford.edu/bb051hp9404~~ _note: audio should play for files with spaces now, including "Pizza Time!.mp3" and "The Relaxing Song.mp3" from the dv738kn2168 test object in the screenshots.  this got fixed with the merge of PR #660.  bb051hp9404 should still work also, of course._

closes sul-dlss/sul-embed#623
connects to sul-dlss/sul-embed#623