### PR TITLE
Move some blank targets to parent targets and add some explanatory`…

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ The file that the class is defined in (or your preferred method) should register
 
 ### Linking in viewers
 
-The rich HTML payload that is supplied via the oEmbed API is an iframe. This means that all consumers will be embedding an iframe into their page. Given this fact, generating links will require explicit targets if they are not intended to internally replace embed content.  Given this, there are two patterns that can be used.  For links intended to download files, a `target="_blank"` can be used (effectively opening a new tab for the download which is immediately closed). For links that are intended to navigate the users browser away from the current page (e.g. the links to Memento/GeoBlacklight/etc.) then `target="_parent"` should be used to give the link the default browser behavior. [More about link targets](http://www.w3schools.com/tags/att_a_target.asp).
+The rich HTML payload that is supplied via the oEmbed API is an iframe. This means that all consumers will be embedding an iframe into their page. Given this fact, generating links will require explicit targets if they are not intended to internally replace embed content.  Given this, there are two patterns that can be used.  For links intended to download files, a `target="_blank"` can be used (effectively opening a new tab for the download which is immediately closed).  When using `target="_blank"` add `rel="noopener noreferrer"` **particularly** when linking externally (although this should be reserved for linking to internal resources when possible). See [this blog post](https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/) for an explanation. *Note: This does not apply to WebAuth links.*
+
+For links that are intended to navigate the users browser away from the current page (e.g. the links to Memento/GeoBlacklight/etc.) then `target="_parent"` should be used to give the link the default browser behavior. [More about link targets](http://www.w3schools.com/tags/att_a_target.asp).
 
 ### Console Example
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ The file that the class is defined in (or your preferred method) should register
     Embed.register_viewer(Embed::Viewer::DemoViewer) if Embed.respond_to?(:register_viewer)
 
 
+### Linking in viewers
+
+The rich HTML payload that is supplied via the oEmbed API is an iframe. This means that all consumers will be embedding an iframe into their page. Given this fact, generating links will require explicit targets if they are not intended to internally replace embed content.  Given this, there are two patterns that can be used.  For links intended to download files, a `target="_blank"` can be used (effectively opening a new tab for the download which is immediately closed). For links that are intended to navigate the users browser away from the current page (e.g. the links to Memento/GeoBlacklight/etc.) then `target="_parent"` should be used to give the link the default browser behavior. [More about link targets](http://www.w3schools.com/tags/att_a_target.asp).
+
 ### Console Example
 
     $ viewer = Embed.registered_viewers.first

--- a/app/assets/javascripts/modules/download_panel.js
+++ b/app/assets/javascripts/modules/download_panel.js
@@ -19,7 +19,7 @@
       var $listMarkup = $('<li class="sul-embed-download-list-item"></li>');
       // Append a thumb download link
       $downloadList.append($listMarkup.clone()
-        .append('<a target="_blank" class="download-link" href="' + imageData['@id'] +
+        .append('<a target="_blank" rel="noopener noreferrer" class="download-link" href="' + imageData['@id'] +
         '/full/!' + disableDownloadWidthCutoff + ',' +
         disableDownloadWidthCutoff +
         '/0/default.jpg?download=true" download>Download Thumbnail</a>'));

--- a/app/assets/javascripts/modules/geo_viewer.js
+++ b/app/assets/javascripts/modules/geo_viewer.js
@@ -4,7 +4,7 @@
   var Module = (function() {
     var dataAttributes;
     var map;
-    
+
     var isDefined = function(object) {
        return typeof object !== 'undefined';
     };
@@ -19,10 +19,10 @@
           maxZoom: 19,
           attribution: '&copy; <a href="http://www.openstreetmap.org/copyrigh' +
             't">OpenStreetMap</a>, Tiles courtesy of <a href="http://hot.open' +
-            'streetmap.org/" target="_blank">Humanitarian OpenStreetMap Team<' +
+            'streetmap.org/" target="_blank" rel="noopener noreferrer">Humanitarian OpenStreetMap Team<' +
             '/a>',
         }).addTo(map);
-        
+
         Module.addVisualizationLayer();
         map.invalidateSize();
       },

--- a/lib/embed/viewer/common_viewer.rb
+++ b/lib/embed/viewer/common_viewer.rb
@@ -95,7 +95,8 @@ module Embed
                 doc.a(
                   class: 'sul-embed-footer-tool sul-embed-btn sul-embed-btn-toolbar' \
                     ' sul-embed-btn-default sul-i-navigation-next-4',
-                  href: external_url.to_s
+                  href: external_url.to_s,
+                  target: '_parent'
                 ) do
                   doc.span(class: 'sul-embed-sr-only') { doc.text external_url_text }
                 end

--- a/lib/embed/viewer/file.rb
+++ b/lib/embed/viewer/file.rb
@@ -134,7 +134,8 @@ module Embed
             doc.a(
               href: file_url(file.title),
               title: tooltip_text(file),
-              target: '_blank'
+              target: '_blank',
+              rel: 'noopener noreferrer'
             ) do
               doc.text file.title
             end
@@ -154,7 +155,7 @@ module Embed
             doc.text pretty_filesize(file.size)
           end
         else
-          doc.a(href: file_url(file.title), download: nil, target: '_blank') do
+          doc.a(href: file_url(file.title), download: nil, target: '_blank', rel: 'noopener noreferrer') do
             doc.span(class: 'sul-embed-sr-only') do
               doc.text "Download item #{file_count}"
             end

--- a/lib/embed/viewer/geo.rb
+++ b/lib/embed/viewer/geo.rb
@@ -23,7 +23,7 @@ module Embed
                 doc.ul(class: 'sul-embed-download-list') do
                   resource.files.each do |file|
                     doc.li(class: ('sul-embed-stanford-only' if file.stanford_only?).to_s) do
-                      doc.a(href: file_url(file.title), title: file.title, target: '_blank') do
+                      doc.a(href: file_url(file.title), title: file.title, target: '_blank', rel: 'noopener noreferrer') do
                         doc.text "Download #{file.title}"
                       end
                     end

--- a/lib/embed/viewer/image_x.rb
+++ b/lib/embed/viewer/image_x.rb
@@ -44,11 +44,11 @@ module Embed
         <<-HTML
           <dt>International Image Interoperability Framework</dt>
           <dd>
-            <a class='sul-embed-image-x-iiif-drag-and-drop-link' href='#{drag_and_drop_url}' target='_blank'>
+            <a class='sul-embed-image-x-iiif-drag-and-drop-link' href='#{drag_and_drop_url}' target='_parent'>
               <img src="#{asset_url('iiif-drag-icon.png')}" />
             </a>
             <span class='sul-embed-iiif-instruction'>
-              #{drag_and_drop_instruction_text} <a href='#{Settings.iiif_info_url}' target='_blank'>IIIF viewer</a>
+              #{drag_and_drop_instruction_text} <a href='#{Settings.iiif_info_url}' target='_parent'>IIIF viewer</a>
             </span>
           </dd>
         HTML

--- a/lib/embed/viewer/media.rb
+++ b/lib/embed/viewer/media.rb
@@ -54,7 +54,7 @@ module Embed
             file_size = "(#{pretty_filesize(file.size)})" if file.size
             <<-HTML.strip_heredoc
               <li class='#{('sul-embed-stanford-only' if file.stanford_only?)}'>
-                <a href='#{file_url(file.title)}' title='#{file.title}' target='_blank'>
+                <a href='#{file_url(file.title)}' title='#{file.title}' target='_blank' rel='noopener noreferrer'>
                   Download #{link_text}
                 </a>
                 #{file_size}

--- a/lib/embed/viewer/was_seed.rb
+++ b/lib/embed/viewer/was_seed.rb
@@ -15,7 +15,7 @@ module Embed
                     doc.div(class: 'sul-embed-was-thumb-item-div', style: "height: #{item_size[0]}px; width: #{item_size[1]}px;") do
                       doc.img(class: 'sul-embed-was-thumb-item-img', style: "height: #{image_height}px;", src: thumb_record['thumbnail_uri'])
                       doc.div(class: 'sul-embed-was-thumb-item-date') do
-                        doc.a(href: thumb_record['memento_uri'], target: '_blank') do
+                        doc.a(href: thumb_record['memento_uri'], target: '_parent') do
                           doc.text(format_memento_datetime(thumb_record['memento_datetime']))
                         end
                       end

--- a/spec/features/geo_viewer_spec.rb
+++ b/spec/features/geo_viewer_spec.rb
@@ -38,11 +38,11 @@ describe 'geo viewer public', js: true do
       end
     end
 
-    it 'includes a "_blank" target on the download links' do
+    it 'includes proper attributes for a _blank target on the download links' do
       find('button.sul-embed-footer-tool.sul-i-download-3').click
       within '.sul-embed-download-panel' do
         within '.sul-embed-panel-body' do
-          expect(page).to have_css('li a[target="_blank"]', count: 1)
+          expect(page).to have_css('li a[target="_blank"][rel="noopener noreferrer"]', count: 1)
         end
       end
     end

--- a/spec/features/image_x_viewer_spec.rb
+++ b/spec/features/image_x_viewer_spec.rb
@@ -89,12 +89,12 @@ describe 'imageX viewer', js: true do
         expect(link['href']).to match(%r{^#{purl_url}\?manifest=#{purl_url}/iiif/manifest\.json$})
       end
 
-      it 'has a links with blank targets' do
+      it 'has a links with _parent targets' do
         toggle_metadata_panel
 
         within('.sul-embed-metadata-panel') do
-          expect(page).to have_css('a.sul-embed-image-x-iiif-drag-and-drop-link[target="_blank"]')
-          expect(page).to have_css('.sul-embed-iiif-instruction a[target="_blank"]')
+          expect(page).to have_css('a.sul-embed-image-x-iiif-drag-and-drop-link[target="_parent"]')
+          expect(page).to have_css('.sul-embed-iiif-instruction a[target="_parent"]')
         end
       end
     end

--- a/spec/features/image_x_viewer_spec.rb
+++ b/spec/features/image_x_viewer_spec.rb
@@ -113,11 +113,11 @@ describe 'imageX viewer', js: true do
   end
 
   describe 'Download panel' do
-    it 'includes target = "_blank" for download links' do
+    it 'includes proper attributes for _blank target download links' do
       toggle_download_panel
 
       within('.sul-embed-download-panel') do
-        expect(page).to have_css('a[target="_blank"]')
+        expect(page).to have_css('a[target="_blank"][rel="noopener noreferrer"]')
       end
     end
   end

--- a/spec/features/was_seed_viewer_spec.rb
+++ b/spec/features/was_seed_viewer_spec.rb
@@ -32,8 +32,8 @@ describe 'was seed viewer public', js: true do
       expect(page.find('.active').text).to eq('29-Nov-2012')
     end
 
-    it 'links to the memento URI with a blank target' do
-      expect(page).to have_css('.sul-embed-was-thumb-item-date a[target="_blank"]')
+    it 'links to the memento URI with a _parent target' do
+      expect(page).to have_css('.sul-embed-was-thumb-item-date a[target="_parent"]')
     end
   end
 

--- a/spec/lib/embed/viewer/file_spec.rb
+++ b/spec/lib/embed/viewer/file_spec.rb
@@ -66,12 +66,12 @@ describe Embed::Viewer::File do
     end
 
     context 'link targets' do
-      it 'is "_blank"' do
+      it 'have the appropriate attributes for being _blank' do
         stub_purl_response_and_request(multi_resource_multi_type_purl, request)
         expect(file_viewer).to receive(:asset_host).at_least(:twice).and_return('http://example.com/')
         html = Capybara.string(file_viewer.to_html)
-        expect(html).to have_css('.sul-embed-media-heading a[target="_blank"]', visible: false)
-        expect(html).to have_css('.sul-embed-download a[target="_blank"]', visible: false)
+        expect(html).to have_css('.sul-embed-media-heading a[target="_blank"][rel="noopener noreferrer"]', visible: false)
+        expect(html).to have_css('.sul-embed-download a[target="_blank"][rel="noopener noreferrer"]', visible: false)
       end
     end
   end

--- a/spec/lib/embed/viewer/media_spec.rb
+++ b/spec/lib/embed/viewer/media_spec.rb
@@ -57,8 +57,8 @@ describe Embed::Viewer::Media do
       expect(download_html).to have_css('li', text: /\(\d+\.\d+ kB\)/, visible: false)
     end
 
-    it 'includes a "_blank" target on the download links' do
-      expect(download_html).to have_css('li a[target="_blank"]', count: 3, visible: false)
+    it 'includes attributes appropriate for _blank target download links' do
+      expect(download_html).to have_css('li a[target="_blank"][rel="noopener noreferrer"]', count: 3, visible: false)
     end
   end
 end


### PR DESCRIPTION
…text about which targets to use in the README.

Also added a `rel` attribute to `_blank` targets for good measure (even though we control _almost_ every endpoint we link to using this method, it is still good practice to include this attribute).