### PR TITLE
Update default configurations to use https all the time.

### DIFF
--- a/app/views/pages/sandbox.html.erb
+++ b/app/views/pages/sandbox.html.erb
@@ -83,7 +83,7 @@
 
 <body>
   <form action="" class="form-params">
-    <%= text_field_tag 'api-endpoint', "http://#{request.host}:#{request.port}#{embed_path}", class: 'api-endpoint', size: 50 %>/?url=
+    <%= text_field_tag 'api-endpoint', "//#{request.host}:#{request.port}#{embed_path}", class: 'api-endpoint', size: 50 %>/?url=
     <%= text_field_tag 'url-scheme', 'https://purl.stanford.edu/tn629pk3948', class:'url-scheme', size: 50 %>
     <label for="">&format=</label>
     <select name="select-format" id="select-format">

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,7 +7,7 @@ stacks_url: 'https://stacks.stanford.edu'
 iiif_stacks_url: 'https://stacks.stanford.edu'
 iiif_info_url: 'https://library.stanford.edu/iiif/viewers'
 enable_media_viewer?: <%= false %>
-embed_iframe_url: '//embed.stanford.edu/iframe'
+embed_iframe_url: 'https://embed.stanford.edu/iframe'
 jquery_version: '2.2.4'
 geo_external_url: 'https://earthworks.stanford.edu/catalog/stanford-'
 geo_wms_url: 'https://geowebservices.stanford.edu/geoserver/wms/'

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,1 @@
+embed_iframe_url: 'http://localhost:3000/iframe'

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,2 +1,2 @@
-static_assets_base: '//embed.stanford.edu'
+static_assets_base: 'https://embed.stanford.edu'
 cache_life: <%= 1.week.to_s %>

--- a/spec/lib/embed/response_spec.rb
+++ b/spec/lib/embed/response_spec.rb
@@ -43,7 +43,7 @@ describe Embed::Response do
       allow(viewer).to receive(:width).and_return('100')
     end
     it 'is the iframe snippet pointing to the embed' do
-      expect(response.html).to match(%r{<iframe src='//embed\.stanford\.edu.*'.*/>})
+      expect(response.html).to match(%r{<iframe src='https://embed\.stanford\.edu.*'.*/>})
     end
   end
   describe 'embed hash' do


### PR DESCRIPTION
Closes #629 

This PR turns the sandbox into a protocol relative URL since it is intended to work under http locally and under https remotely.

All the other configs have been turned from protocol relative to be https only.  We'll also need to update remote configs when we deploy.