### PR TITLE
Add a message about accessing transcripts in the media viewer's…

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,6 +2,7 @@ purl_url: 'https://purl.stanford.edu'
 # timeouts specified in seconds
 purl_read_timeout: 2
 purl_conn_timeout: 2
+purl_feedback_email: ''
 valid_purl_url: <%= /https?:\/\/purl\.stanford\.edu\/*/ %>
 stacks_url: 'https://stacks.stanford.edu'
 iiif_stacks_url: 'https://stacks.stanford.edu'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,1 +1,2 @@
 enable_media_viewer?: <%= true %>
+purl_feedback_email: 'some-email-address@distribution-list-host.stanford.edu'

--- a/lib/embed/viewer/media.rb
+++ b/lib/embed/viewer/media.rb
@@ -28,6 +28,12 @@ module Embed
         end.to_html
       end
 
+      def metadata_html
+        Embed::MetadataPanel.new(@purl_object) do
+          media_accessibility_note
+        end.to_html
+      end
+
       def self.supported_types
         return [] unless ::Settings.enable_media_viewer?
         [:media]
@@ -62,6 +68,18 @@ module Embed
             HTML
           end
         end.flatten.join
+      end
+
+      def media_accessibility_note
+        return unless Settings.purl_feedback_email.present?
+        <<-HTML.strip_heredoc
+          <dt>Media accessibility</dt>
+          <dd>
+            A transcript may be available in the Download panel.<br />
+            To request a transcript or other assistance with media in this viewer, please contact us at
+            <a href="mailto:#{Settings.purl_feedback_email}">#{Settings.purl_feedback_email}</a>.
+          </dd>
+        HTML
       end
     end
   end

--- a/spec/lib/embed/viewer/media_spec.rb
+++ b/spec/lib/embed/viewer/media_spec.rb
@@ -61,4 +61,23 @@ describe Embed::Viewer::Media do
       expect(download_html).to have_css('li a[target="_blank"][rel="noopener noreferrer"]', count: 3, visible: false)
     end
   end
+
+  describe '#metadata_html' do
+    before { stub_purl_response_with_fixture(video_purl) }
+    let(:metadata_html) { Capybara.string(media_viewer.metadata_html.to_str) }
+
+    it 'includes a media accessibility note' do
+      expect(metadata_html).to have_css('dt', text: 'Media accessibility', visible: false)
+      expect(metadata_html).to have_css(
+        'dd',
+        text: /A transcript may be available in the Download panel/,
+        visible: false
+      )
+    end
+
+    it 'links to the feedback address' do
+      link = metadata_html.find('a', text: Settings.purl_feedback_email, visible: false)
+      expect(link['href']).to eq "mailto:#{Settings.purl_feedback_email}"
+    end
+  end
 end


### PR DESCRIPTION
…metadata panel.

_**Note:** I added an email address in a `purl_feedback_email` key to my `development.local.yml` to enable this locally.  That configuration has already been added to the deploy environments._

Closes #674 

<img width="756" alt="media-accessibility-note" src="https://cloud.githubusercontent.com/assets/96776/18023807/a5d7da1a-6bb2-11e6-88ef-ab39964c3421.png">
