### PR TITLE
Fix the styling of the login link in the image viewer

### DIFF
--- a/app/assets/stylesheets/image_x.scss
+++ b/app/assets/stylesheets/image_x.scss
@@ -147,21 +147,6 @@ $image-thumb-slider-background-color: $sul-background;
   text-align: center;
 }
 
-.#{$namespace}-image-x-restricted-thumb-container {
-  .#{$namespace}-image-x-auth-link {
-    @include rounded();
-    background: rgba($sul-background, 0.65);
-    bottom: 10px;
-    left: 10px;
-    padding: 5px;
-    position: absolute;
-  }
-
-  a {
-    @include stanford-only;
-  }
-}
-
 .#{$namespace}-image-x-iiif-drag-and-drop-link {
   border-bottom: none !important;
   cursor: move; // For non-webkit browsers

--- a/app/views/pages/sandbox.html.erb
+++ b/app/views/pages/sandbox.html.erb
@@ -137,6 +137,9 @@
         Image with pdf and other downloads - bg262qk2288
       </li>
       <li>
+        Image (Stanford Only) - yh887qk5737
+      </li>
+      <li>
         mp4 - bd786fy6312, bb582xs1304
       </li>
       <li>


### PR DESCRIPTION
Closes #680 

## yh887qk5737 (before)
<img width="522" alt="yh887qk5737-before" src="https://cloud.githubusercontent.com/assets/96776/18105468/54c2aa4c-6eb4-11e6-851f-6e293947f5de.png">

## yh887qk5737 (after)
<img width="520" alt="yh887qk5737-after" src="https://cloud.githubusercontent.com/assets/96776/18105469/54d58806-6eb4-11e6-8978-518f046d7ff4.png">
