### PR TITLE
Update the height of the file viewer based on the number of resources…

### DIFF
--- a/lib/embed/viewer/file.rb
+++ b/lib/embed/viewer/file.rb
@@ -65,7 +65,23 @@ module Embed
       end
 
       def default_body_height
-        400 - (header_height + footer_height)
+        file_specific_body_height - (header_height + footer_height)
+      end
+
+      # This is neccessary because the file viewer's height is meant to be dynamic,
+      # however we need to specify the exact height of the containing iframe (which
+      # will give us extra whitespace below the embed viewer unless we do this)
+      def file_specific_body_height
+        case @purl_object.all_resource_files.count
+        when 1
+          200
+        when 2
+          275
+        when 3
+          375
+        else
+          400
+        end
       end
 
       def preview_file_toggle(file, doc, file_count)

--- a/spec/features/embed_this_panel_spec.rb
+++ b/spec/features/embed_this_panel_spec.rb
@@ -22,7 +22,7 @@ describe 'embed this panel', js: true do
     end
     it 'includes height and width attributes' do
       page.find('[data-sul-embed-toggle="sul-embed-embed-this-panel"]', match: :first).trigger('click')
-      expect(page.find('.sul-embed-embed-this-panel textarea').value).to match(/<iframe.*height='400px'.*\/>/)
+      expect(page.find('.sul-embed-embed-this-panel textarea').value).to match(/<iframe.*height='200px'.*\/>/)
       expect(page.find('.sul-embed-embed-this-panel textarea').value).to match(/<iframe.*width='100%'.*\/>/)
     end
   end

--- a/spec/lib/embed/viewer/file_spec.rb
+++ b/spec/lib/embed/viewer/file_spec.rb
@@ -23,14 +23,25 @@ describe Embed::Viewer::File do
   end
   describe 'body_height' do
     it 'defaults to 400 minus the footer and header height' do
-      stub_request(request)
+      stub_purl_response_and_request(multi_resource_multi_type_purl, request)
       expect(file_viewer.send(:body_height)).to eq 307
     end
+
     it 'consumer requested maxheight minus the header/footer height' do
       height_request = Embed::Request.new(url: 'http://purl.stanford.edu/abc123', maxheight: '500')
       stub_request(height_request)
       viewer = Embed::Viewer::File.new(height_request)
       expect(viewer.send(:body_height)).to eq 407
+    end
+
+    it 'reduces the height based on the number of files in the object (1 file)' do
+      stub_purl_response_and_request(file_purl, request)
+      expect(file_viewer.send(:body_height)).to eq 107
+    end
+
+    it 'reduces the height based on the number of files in the object (2 files)' do
+      stub_purl_response_and_request(image_purl, request)
+      expect(file_viewer.send(:body_height)).to eq 182
     end
   end
   describe 'header tools' do


### PR DESCRIPTION
… being displayed.

Closes #677 

## bb054mz1203 (before)
<img width="531" alt="bb054mz1203-before" src="https://cloud.githubusercontent.com/assets/96776/18112026/4f052fc4-6ed9-11e6-8157-e1d31f734ef0.png">

## bb054mz1203 (after)
<img width="567" alt="bb054mz1203-after" src="https://cloud.githubusercontent.com/assets/96776/18112027/4f1552d2-6ed9-11e6-8551-614f73fb9dc1.png">

## bd786fy6312 (before)
<img width="526" alt="bd786fy6312-before" src="https://cloud.githubusercontent.com/assets/96776/18112031/5ac7a3a0-6ed9-11e6-8976-09ace81f10f8.png">

## bd786fy6312 (after)
<img width="541" alt="bd786fy6312-after" src="https://cloud.githubusercontent.com/assets/96776/18112030/5ac6e94c-6ed9-11e6-9b40-061775c2c000.png">

## zw177zm0384 (before)
<img width="532" alt="zw177zm0384-before" src="https://cloud.githubusercontent.com/assets/96776/18112035/664a6762-6ed9-11e6-8232-d6a016ce9434.png">

## zw177zm0384 (after)
<img width="532" alt="zw177zm0384-after" src="https://cloud.githubusercontent.com/assets/96776/18112036/664ad42c-6ed9-11e6-8834-8f7698b0e078.png">

## tn629pk3948 (before)
<img width="543" alt="tn629pk3948-before" src="https://cloud.githubusercontent.com/assets/96776/18112046/70201886-6ed9-11e6-8d90-8244ffe7cf60.png">

## tn629pk3948 (after)
<img width="530" alt="tn629pk3948-after" src="https://cloud.githubusercontent.com/assets/96776/18112045/70159d8e-6ed9-11e6-8648-a7f9cc44c6a2.png">
