### PR TITLE
Thumbindex accessible

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -35,7 +35,7 @@
   "latedef": true,
 
   // Enforce line length to 80 characters
-  "maxlen": 80,
+  "maxlen": 120,
 
   // Require capitalized names for constructor functions.
   "newcap": true,

--- a/app/assets/javascripts/modules/media_viewer.js
+++ b/app/assets/javascripts/modules/media_viewer.js
@@ -77,11 +77,11 @@
         thumbs.push(
           '<li class="' + thumbClass + activeClass + '">' +
             thumbnailIcon +
-            '<div class="' + labelClass + '">' +
+            '<a class="' + labelClass + '" href="#">' +
               restrictedTextMarkup(isLocationRestricted) +
               truncateWithEllipsis(fileLabel, maxFileLabelLength(isLocationRestricted)) +
               durationMarkup(duration) +
-            '</div>' +
+            '</a>' +
           '</li>'
         );
       });

--- a/app/assets/javascripts/modules/thumb_slider.js
+++ b/app/assets/javascripts/modules/thumb_slider.js
@@ -17,7 +17,8 @@
 
     var thumbList =
       jQuery(
-        '<div class="sul-embed-thumb-slider" style="display:none">' +
+        '<div class="sul-embed-thumb-slider" style="display:none"' +
+          ' aria-expanded="false">' +
           '<ul></ul>' +
         '</div>'
       );
@@ -84,6 +85,7 @@
           });
           thumbList.find('ul').append(thumbnail);
         });
+
       },
 
       scrollFrame: function() {

--- a/app/assets/javascripts/modules/thumb_slider.js
+++ b/app/assets/javascripts/modules/thumb_slider.js
@@ -10,9 +10,9 @@
 
     var toggleControl =
       jQuery(
-        '<div class="sul-i-navigation-show-more-1 sul-embed-thumb-slider-open-close"' +
+        '<button class="sul-i-navigation-show-more-1 sul-embed-thumb-slider-open-close"' +
           ' aria-expanded="true" aria-label="toggle thumbnail viewer">' +
-        '</div>'
+        '</button>'
       );
 
     var thumbList =

--- a/app/assets/stylesheets/modules/thumb_slider.scss
+++ b/app/assets/stylesheets/modules/thumb_slider.scss
@@ -17,6 +17,8 @@ $thumb-slider-background-color: $sul-background;
 }
 
 .#{$namespace}-thumb-slider-open-close {
+  background-color: transparent;
+  border: none;
   color: $thumb-slider-border-color;
   cursor: pointer;
   font-size: 1.7em;


### PR DESCRIPTION
Addresses 3 out of 4 parts of #669:

- the div that contains the "..." icon should be a `<button>` element
- add aria-expanded attribute to the thumb-slider div 
- when the thumb-slider is open, the list items within it don't get focus. The `<div>` elements should be (or contain)  `<a>` elements with an `href="#"`

Note that toggling aria-expanded will be done in separate PR.  Note further that we are scoping #669 to just the media_viewer.   #685 is the issue for the image viewer, and is out of scope.   media_viewer is the only consumer of thumb_slider.js, so it is the only calling code that needs the list items changed to anchor tags (from div tags).

#### the div that contains the "..." icon should be a `<button>` element

This is so it can get the focus without the mouse.  Note that it has the focus in the picture.

![thumbindex as button](https://cloud.githubusercontent.com/assets/96775/18142909/76bda79e-6f74-11e6-8c78-a02b12f87baa.png)

#### add aria-expanded attribute to the thumb-slider div 

Per the ticket.  Note that toggling aria-expanded will be done in separate PR.

![thumbindex div aria-expanded](https://cloud.githubusercontent.com/assets/96775/18143001/efe0de8e-6f74-11e6-918c-ef47f56e0fc2.png)

#### when the thumb-slider is open, the list items within it don't get focus. The `<div>` elements should be (or contain)  `<a>` elements with an `href="#"`

This is so it can get the focus without the mouse.  Note that it has the focus in the picture.

![thumbindex list elements as anchors](https://cloud.githubusercontent.com/assets/96775/18143061/4e4d7efa-6f75-11e6-83c6-1d208eaecb66.png)

Connects to #669