### PR TITLE
thumb_slider: toggle aria-expanded appropriate when clicking '...' button

### DIFF
--- a/app/assets/javascripts/modules/thumb_slider.js
+++ b/app/assets/javascripts/modules/thumb_slider.js
@@ -11,7 +11,7 @@
     var toggleControl =
       jQuery(
         '<button class="sul-i-navigation-show-more-1 sul-embed-thumb-slider-open-close"' +
-          ' aria-expanded="true" aria-label="toggle thumbnail viewer">' +
+          ' aria-expanded="false" aria-label="toggle thumbnail viewer">' +
         '</button>'
       );
 
@@ -38,9 +38,20 @@
       }
     }
 
+    function toggleAriaAttributes() {
+      if(toggleControl.attr('aria-expanded') === 'true') {
+        toggleControl.attr('aria-expanded', 'false');
+        thumbList.attr('aria-expanded', 'false');
+      }else{
+        toggleControl.attr('aria-expanded', 'true');
+        thumbList.attr('aria-expanded', 'true');
+      }
+    }
+
     function addToggleControlBehavior() {
       toggleControl.on('click', function() {
         thumbList.slideToggle();
+        toggleAriaAttributes();
       });
     }
 
@@ -85,7 +96,6 @@
           });
           thumbList.find('ul').append(thumbnail);
         });
-
       },
 
       scrollFrame: function() {

--- a/spec/features/media_viewer_spec.rb
+++ b/spec/features/media_viewer_spec.rb
@@ -42,9 +42,11 @@ describe 'media viewer', js: true do
     it 'has a toggle-able thumbnail slider panel' do
       expect(page).to have_css('.sul-embed-thumb-slider-container', visible: true)
       expect(page).to have_css('.sul-embed-thumb-slider-open-close', visible: true)
-      expect(page).not_to have_css('.sul-embed-thumb-slider', visible: true)
+      expect(page).to have_css('.sul-embed-thumb-slider[aria-expanded="false"]', visible: false)
+      expect(page).to have_css('.sul-embed-thumb-slider-open-close[aria-expanded="false"]', visible: true)
       page.find('.sul-embed-thumb-slider-open-close').click
-      expect(page).to have_css('.sul-embed-thumb-slider', visible: true)
+      expect(page).to have_css('.sul-embed-thumb-slider[aria-expanded="true"]', visible: true)
+      expect(page).to have_css('.sul-embed-thumb-slider-open-close[aria-expanded="true"]', visible: true)
       expect(page).to have_css('[data-slider-object="0"] video', visible: false)
       expect(page).to have_css('[data-slider-object="1"] video', visible: false)
 


### PR DESCRIPTION
closes #669 by completing the fourth of four fixes listed in that ticket.

`aria-expanded` attribute for for `...` button and for the div containing the thumbslider list now are toggled appropriately to true and false when the button is clicked.

#### before clicking `...` button
![aria before click](https://cloud.githubusercontent.com/assets/96775/18149028/724f43de-6f92-11e6-8686-ba6fce4fbcff.png)

#### after clicking `...` button
![aria after click 1](https://cloud.githubusercontent.com/assets/96775/18149025/6ef2a2c6-6f92-11e6-9ecd-bf3a389e1d13.png)

#### after clicking `...` button again
![aria after click 2](https://cloud.githubusercontent.com/assets/96775/18149024/6bd42a4c-6f92-11e6-8c4b-79dde81e2846.png)
