### PR TITLE
Add (Restricted) text to links in the download panel as well as the file viewer

### DIFF
--- a/app/assets/javascripts/modules/media_viewer.js
+++ b/app/assets/javascripts/modules/media_viewer.js
@@ -9,13 +9,21 @@
   var Module = (function() {
     var restrictedMessageSelector = '[data-access-restricted-message]';
     var sliderObjectSelector = '[data-slider-object]';
-    var restrictedText = '(Restricted)'
+    var restrictedText = '(Restricted)';
     var MAX_FILE_LABEL_LENGTH = 45;
 
     function restrictedTextMarkup(isLocationRestricted) {
       if(isLocationRestricted) {
-        return '<span class="sul-embed-thumb-restricted-text">' + restrictedText + '</span> ';
+        return '<span class="sul-embed-location-restricted-text">' + restrictedText + '</span> ';
       } else {
+        return '';
+      }
+    }
+
+    function stanfordOnlyScreenreaderText(isStanfordRestricted) {
+      if(isStanfordRestricted) {
+        return '<span class="sul-embed-text-hide">Stanford only</span>';
+      }else{
         return '';
       }
     }
@@ -58,8 +66,8 @@
 
         var thumbClass = 'sul-embed-slider-thumb sul-embed-media-slider-thumb ';
         var labelClass = 'sul-embed-thumb-label';
-
-        if ($(mediaDiv).data('stanford-only')) {
+        var isStanfordRestricted = $(mediaDiv).data('stanford-only');
+        if (isStanfordRestricted) {
           labelClass += ' sul-embed-thumb-stanford-only';
         }
 
@@ -78,6 +86,7 @@
           '<li class="' + thumbClass + activeClass + '">' +
             thumbnailIcon +
             '<a class="' + labelClass + '" href="#">' +
+              stanfordOnlyScreenreaderText(isStanfordRestricted) +
               restrictedTextMarkup(isLocationRestricted) +
               truncateWithEllipsis(fileLabel, maxFileLabelLength(isLocationRestricted)) +
               durationMarkup(duration) +

--- a/app/assets/stylesheets/common.scss.erb
+++ b/app/assets/stylesheets/common.scss.erb
@@ -108,9 +108,16 @@
   }
 }
 
-.#{$namespace}-stanford-only a{
-  @include stanford-only;
-  padding-right: 20px;
+.#{$namespace}-stanford-only a {
+  @include stanford-only(right, 20px);
+}
+
+.#{$namespace}-stanford-only-text {
+  @include stanford-only(left, 15px);
+}
+
+.#{$namespace}-location-restricted-text {
+  color: $sul-restricted-text-color;
 }
 
 .#{$namespace}-header {

--- a/app/assets/stylesheets/mixins.scss.erb
+++ b/app/assets/stylesheets/mixins.scss.erb
@@ -43,10 +43,10 @@
   padding: 10px;
 }
 
-@mixin stanford-only {
-  background: url('#{$asset_base}<%= asset_url("stanford_s.png") %>') no-repeat right;
-  background: url('#{$asset_base}<%= asset_url("stanford_s.svg") %>') no-repeat right, none;
-  padding-right: 20px;
+@mixin stanford-only($orientation: right, $icon-padding: 20px) {
+  background: url('#{$asset_base}<%= asset_url("stanford_s.png") %>') no-repeat $orientation;
+  background: url('#{$asset_base}<%= asset_url("stanford_s.svg") %>') no-repeat $orientation, none;
+  padding-#{$orientation}: $icon-padding;
 }
 
 @mixin stanford-only-red {

--- a/app/assets/stylesheets/modules/thumb_slider.scss
+++ b/app/assets/stylesheets/modules/thumb_slider.scss
@@ -3,7 +3,6 @@
 
 $thumb-background-color: #fff;
 $thumb-slider-border-color: $sul-border-color;
-$restricted-text-color: $color-cardinal-red;
 $thumb-slider-background-color: $sul-background;
 
 .#{$namespace}-thumb-slider-container {
@@ -67,9 +66,5 @@ $thumb-slider-background-color: $sul-background;
 
   img {
     width: 100%;
-  }
-
-  .#{$namespace}-thumb-restricted-text {
-    color: $restricted-text-color;
   }
 }

--- a/app/assets/stylesheets/sul_variables.scss.erb
+++ b/app/assets/stylesheets/sul_variables.scss.erb
@@ -64,5 +64,6 @@ $sul-media-index-height: 24px;
 $sul-metadata-bg: $color-beige-05;
 $sul-metadata-heading-color: $gray-54-percent;
 $sul-metadata-label-color: dimgrey;
+$sul-restricted-text-color: $color-cardinal-red;
 $sul-iiif-instruction-color: dimgrey;
 $sul-osd-toolbar-bg: $white-60-percent-opaque;

--- a/lib/embed/restricted_text.rb
+++ b/lib/embed/restricted_text.rb
@@ -1,0 +1,20 @@
+module Embed
+  module RestrictedText
+    private
+
+    def restrictions_text_for_file(file)
+      return unless file.location_restricted? || file.stanford_only?
+      <<-HTML.strip_heredoc
+        <span class='sul-embed-location-restricted-text #{('sul-embed-stanford-only-text' if file.stanford_only?)}'>
+          #{stanford_only_restricted_text(file)}
+          #{'(Restricted)' if file.location_restricted?}
+        </span>
+      HTML
+    end
+
+    def stanford_only_restricted_text(file)
+      return unless file.stanford_only?
+      '<span class="sul-embed-text-hide"> Stanford only </span>'
+    end
+  end
+end

--- a/lib/embed/viewer/common_viewer.rb
+++ b/lib/embed/viewer/common_viewer.rb
@@ -3,6 +3,7 @@ require 'embed/embed_this_panel'
 require 'embed/metadata_panel'
 require 'embed/mimetypes'
 require 'embed/pretty_filesize'
+require 'embed/restricted_text'
 require 'embed/stacks_image'
 
 module Embed
@@ -10,6 +11,7 @@ module Embed
     class CommonViewer
       include Embed::Mimetypes
       include Embed::PrettyFilesize
+      include Embed::RestrictedText
       include Embed::StacksImage
 
       attr_reader :purl_object

--- a/lib/embed/viewer/file.rb
+++ b/lib/embed/viewer/file.rb
@@ -144,17 +144,14 @@ module Embed
             doc.text file.title
           end
         else
-          doc.div(
-            class: 'sul-embed-media-heading '\
-              "#{'sul-embed-stanford-only' if file.stanford_only?}") do
+          doc.div(class: 'sul-embed-media-heading') do
             doc.a(
               href: file_url(file.title),
               title: tooltip_text(file),
               target: '_blank',
               rel: 'noopener noreferrer'
-            ) do
-              doc.text file.title
-            end
+            ) { doc.text file.title }
+            doc << " #{restrictions_text_for_file(file)}"
           end
         end
       end

--- a/lib/embed/viewer/geo.rb
+++ b/lib/embed/viewer/geo.rb
@@ -22,10 +22,11 @@ module Embed
               @purl_object.contents.each do |resource|
                 doc.ul(class: 'sul-embed-download-list') do
                   resource.files.each do |file|
-                    doc.li(class: ('sul-embed-stanford-only' if file.stanford_only?).to_s) do
+                    doc.li do
                       doc.a(href: file_url(file.title), title: file.title, target: '_blank', rel: 'noopener noreferrer') do
                         doc.text "Download #{file.title}"
                       end
+                      doc << " #{restrictions_text_for_file(file)}"
                     end
                   end
                 end

--- a/lib/embed/viewer/media.rb
+++ b/lib/embed/viewer/media.rb
@@ -59,10 +59,9 @@ module Embed
                         end
             file_size = "(#{pretty_filesize(file.size)})" if file.size
             <<-HTML.strip_heredoc
-              <li class='#{('sul-embed-stanford-only' if file.stanford_only?)}'>
-                <a href='#{file_url(file.title)}' title='#{file.title}' target='_blank' rel='noopener noreferrer'>
-                  Download #{link_text}
-                </a>
+              <li>
+                <a href='#{file_url(file.title)}' title='#{file.title}' target='_blank' rel='noopener noreferrer'>Download #{link_text}</a>
+                #{restrictions_text_for_file(file)}
                 #{file_size}
               </li>
             HTML

--- a/spec/features/media_viewer_spec.rb
+++ b/spec/features/media_viewer_spec.rb
@@ -55,13 +55,14 @@ describe 'media viewer', js: true do
       end
     end
 
-    it 'has the class indicating Stanford only for stanford restricted files' do
+    it 'has the class indicating Stanford only for stanford restricted files (with screenreader text)' do
       expect(page).not_to have_css('.sul-embed-thumb-slider', visible: true)
       page.find('.sul-embed-thumb-slider-open-close').click
       expect(page).to have_css('.sul-embed-thumb-slider', visible: true)
 
       expect(page).to have_css('.sul-embed-thumb-stanford-only', count: 1)
       expect(page).to have_css('.sul-embed-thumb-stanford-only', text: 'Second Video')
+      expect(page).to have_css('.sul-embed-thumb-stanford-only .sul-embed-text-hide', text: 'Stanford only', count: 1)
       expect(page).not_to have_css('.sul-embed-thumb-stanford-only', text: 'abc_123.mp4')
     end
   end
@@ -101,7 +102,7 @@ describe 'media viewer', js: true do
     end
     it 'displays no duration info after title when there is no duration we can interpret' do
       page.find('.sul-embed-thumb-slider-open-close').click
-      expect(page).to have_css('.sul-embed-media-slider-thumb', text: /^Second Video$/)
+      expect(page).to have_css('.sul-embed-media-slider-thumb', text: /Second Video$/)
     end
     context 'invalid duration format' do
       let(:purl) { invalid_video_duration_purl }

--- a/spec/features/media_viewer_spec.rb
+++ b/spec/features/media_viewer_spec.rb
@@ -89,7 +89,7 @@ describe 'media viewer', js: true do
       page.find('.sul-embed-thumb-slider-open-close').click
       expect(page).to have_css('.sul-embed-thumb-slider', visible: true)
 
-      expect(page).to have_css('.sul-embed-thumb-restricted-text', text: '(Restricted)', count: 1)
+      expect(page).to have_css('.sul-embed-location-restricted-text', text: '(Restricted)', count: 1)
       expect(page).to have_css('.sul-embed-media-slider-thumb', text: '(Restricted) abc_123.mp4')
     end
   end

--- a/spec/lib/embed/viewer/file_spec.rb
+++ b/spec/lib/embed/viewer/file_spec.rb
@@ -102,7 +102,17 @@ describe Embed::Viewer::File do
       expect(file_viewer).to receive(:asset_host).at_least(:twice).and_return('http://example.com')
       html = Capybara.string(file_viewer.body_html)
       expect(html).to have_css('.sul-embed-embargo-message', text: "Access is restricted to Stanford-affiliated patrons until #{(Time.current + 1.month).strftime('%d-%b-%Y')}")
-      expect(html).to have_css('.sul-embed-media-heading.sul-embed-stanford-only a[href="https://stacks.stanford.edu/file/druid:12345/Title%20of%20the%20PDF.pdf"]')
+      expect(html).to have_css('.sul-embed-media-heading a[href="https://stacks.stanford.edu/file/druid:12345/Title%20of%20the%20PDF.pdf"]')
+    end
+
+    it 'includes an element with a stanford icon class (with screen reader text)' do
+      stub_purl_response_and_request(embargoed_stanford_file_purl, request)
+      expect(file_viewer).to receive(:asset_host).at_least(:twice).and_return('http://example.com')
+      html = Capybara.string(file_viewer.body_html)
+      expect(html).to have_css(
+        '.sul-embed-media-heading .sul-embed-stanford-only-text .sul-embed-text-hide',
+        text: 'Stanford only'
+      )
     end
   end
   describe 'embargoed to world' do
@@ -112,6 +122,15 @@ describe Embed::Viewer::File do
       html = Capybara.string(file_viewer.body_html)
       expect(html).to have_css('.sul-embed-embargo-message', text: "Access is restricted until #{(Time.current + 1.month).strftime('%d-%b-%Y')}")
       expect(html).not_to have_css('a')
+    end
+  end
+
+  describe 'location restricted' do
+    it 'includes text indicating the file is location restricted' do
+      stub_purl_response_and_request(single_video_purl, request)
+      expect(file_viewer).to receive(:asset_host).at_least(:twice).and_return('http://example.com')
+      html = Capybara.string(file_viewer.body_html)
+      expect(html).to have_css('.sul-embed-media-heading .sul-embed-location-restricted-text', text: '(Restricted)')
     end
   end
 end

--- a/spec/lib/embed/viewer/geo_spec.rb
+++ b/spec/lib/embed/viewer/geo_spec.rb
@@ -54,10 +54,16 @@ describe Embed::Viewer::Geo do
       expect(html).to have_css 'li', visible: false, count: 1
       expect(html).to have_css 'a[href="https://stacks.stanford.edu/file/druid:12345/data.zip"]', visible: false
     end
-    it 'stanford only resources have the stanford-only class' do
+    it 'stanford only resources have the stanford-only class (with screen reader text)' do
       stub_purl_response_and_request(stanford_restricted_multi_file_purl, request)
       html = Capybara.string(geo_viewer.download_html)
-      expect(html).to have_css 'li.sul-embed-stanford-only', visible: false
+      expect(html).to have_css 'li .sul-embed-stanford-only-text .sul-embed-text-hide', text: 'Stanford only', visible: false
+    end
+
+    it 'location restricted files include text to indicate that they are restricted' do
+      stub_purl_response_and_request(single_video_purl, request)
+      html = Capybara.string(geo_viewer.download_html)
+      expect(html).to have_css 'li .sul-embed-location-restricted-text', text: '(Restricted)', visible: false
     end
   end
   describe '#map_element_options' do

--- a/spec/lib/embed/viewer/media_spec.rb
+++ b/spec/lib/embed/viewer/media_spec.rb
@@ -40,7 +40,8 @@ describe Embed::Viewer::Media do
   end
 
   describe '#download_html' do
-    before { stub_purl_response_with_fixture(video_purl) }
+    let(:purl) { video_purl }
+    before { stub_purl_response_with_fixture(purl) }
     let(:download_html) { Capybara.string(media_viewer.download_html.to_str) }
 
     it 'uses the label as the link text when present' do
@@ -59,6 +60,23 @@ describe Embed::Viewer::Media do
 
     it 'includes attributes appropriate for _blank target download links' do
       expect(download_html).to have_css('li a[target="_blank"][rel="noopener noreferrer"]', count: 3, visible: false)
+    end
+
+    context 'Stanford only' do
+      let(:purl) { stanford_restricted_file_purl }
+
+      it 'has a span with a stanford-only s icon class (with screen-reader text)' do
+        expect(download_html).to have_css('.sul-embed-stanford-only-text', visible: false)
+        expect(download_html).to have_css('.sul-embed-text-hide', text: 'Stanford only', visible: false)
+      end
+    end
+
+    context 'Location restricted' do
+      let(:purl) { single_video_purl }
+
+      it 'has a span with the location restricted message' do
+        expect(download_html).to have_css('.sul-embed-location-restricted-text', text: '(Restricted)', visible: false)
+      end
     end
   end
 


### PR DESCRIPTION
Closes #683 


## gm746xg1831 (via file viewer)
<img width="406" alt="gm746xg1831-as-file" src="https://cloud.githubusercontent.com/assets/96776/18213032/0b809620-70fb-11e6-8d9a-18d1fe0ad9c8.png">

## gm746xg1831 (via media viewer)
<img width="512" alt="gm746xg1831-as-media-index" src="https://cloud.githubusercontent.com/assets/96776/18213030/0b81adbc-70fb-11e6-9193-d722a213ec3d.png">

## gm746xg1831 (via media viewer)
<img width="420" alt="gm746xg1831-as-media-download" src="https://cloud.githubusercontent.com/assets/96776/18213031/0b842632-70fb-11e6-8766-f28ba565162e.png">
