### PR TITLE
Handle file and object level thumbnails in the media viewer

### DIFF
--- a/app/assets/stylesheets/media.scss
+++ b/app/assets/stylesheets/media.scss
@@ -60,6 +60,7 @@
   }
 
   .#{$namespace}-media-square-icon {
+    float: left;
     margin-right: 5px;
     width: auto;
   }

--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -172,6 +172,10 @@ module Embed
         end
       end
 
+      def non_thumbnail_files
+        files.reject(&:thumbnail?)
+      end
+
       class ResourceFile
         def initialize(resource, file, rights)
           @resource = resource
@@ -186,6 +190,12 @@ module Embed
 
         def title
           @file.attributes['id'].try(:value)
+        end
+
+        def thumbnail?
+          return true if resource.object_thumbnail?
+          return false unless image?
+          Settings.resource_types_that_contain_thumbnails.include?(resource.type)
         end
 
         def mimetype

--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -162,6 +162,10 @@ module Embed
                          end
       end
 
+      def object_thumbnail?
+        @resource.attributes['thumb'].try(:value) == 'yes' || type == 'thumb'
+      end
+
       def files
         @files ||= @resource.xpath('./file').map do |file|
           ResourceFile.new(self, file, @rights)

--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -164,14 +164,20 @@ module Embed
 
       def files
         @files ||= @resource.xpath('./file').map do |file|
-          ResourceFile.new(file, @rights)
+          ResourceFile.new(self, file, @rights)
         end
       end
 
       class ResourceFile
-        def initialize(file, rights)
+        def initialize(resource, file, rights)
+          @resource = resource
           @file = file
           @rights = rights
+        end
+
+        def label
+          return resource.description if resource.description.present?
+          title
         end
 
         def title
@@ -228,6 +234,8 @@ module Embed
         end
 
         private
+
+        attr_reader :resource
 
         def image_data?
           @file.xpath('./imageData').present?

--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -192,6 +192,10 @@ module Embed
           @file.attributes['id'].try(:value)
         end
 
+        def thumbnail
+          resource.files.find(&:thumbnail?).try(:title)
+        end
+
         def thumbnail?
           return true if resource.object_thumbnail?
           return false unless image?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,6 +16,10 @@ was_thumbs_url: 'https://thumbnail-service-example'
 # timeouts specified in seconds
 was_thumb_read_timeout: 5
 was_thumb_conn_timeout: 5
+resource_types_that_contain_thumbnails:
+  - audio
+  - file
+  - video
 streaming:
   source_types:
     - hls

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -8,9 +8,12 @@ module Embed
 
     include Embed::StacksImage
 
+    attr_accessor :file_index
+
     def initialize(viewer)
       @viewer = viewer
       @purl_document = viewer.purl_object
+      @file_index = 0
     end
 
     def to_html
@@ -23,7 +26,7 @@ module Embed
                     else
                       previewable_element(file)
                     end
-          @file_index += 1
+          self.file_index += 1
         end
       end
       output
@@ -137,10 +140,6 @@ module Embed
 
     def enabled_streaming_types
       Settings.streaming[:source_types]
-    end
-
-    def file_index
-      @file_index ||= 0
     end
 
     def streaming_url_for(file, type)

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -37,7 +37,8 @@ module Embed
     attr_reader :purl_document, :request, :viewer
 
     def media_element(file, type)
-      media_wrapper(file: file) do
+      file_thumb = stacks_square_url(@purl_document.druid, file.thumbnail, size: '75') if file.thumbnail
+      media_wrapper(thumbnail: file_thumb, file: file) do
         <<-HTML.strip_heredoc
           <#{type}
             id="sul-embed-media-#{file_index}"

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -44,6 +44,7 @@ module Embed
             id="sul-embed-media-#{file_index}"
             data-src="#{streaming_url_for(file, :dash)}"
             data-auth-url="#{authentication_url(file)}"
+            #{poster_attribute(file)}
             controls='controls'
             aria-labelledby="access-restricted-message-div-#{file_index}"
             class="#{'sul-embed-many-media' if many_primary_files?}"
@@ -107,6 +108,11 @@ module Embed
 
     def primary_file?(resource)
       SUPPORTED_MEDIA_TYPES.include?(resource.type.to_sym) || resource.files.any?(&:previewable?)
+    end
+
+    def poster_attribute(file)
+      return unless file.thumbnail
+      "poster='#{stacks_thumb_url(@purl_document.druid, file.thumbnail)}'"
     end
 
     def access_restricted_message(stanford_only, location_restricted)

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -17,13 +17,11 @@ module Embed
       output = ''
       purl_document.contents.each do |resource|
         next unless primary_file?(resource)
-        label = resource.description
         resource.files.each do |file|
-          label = file.title if label.blank?
           output << if SUPPORTED_MEDIA_TYPES.include?(resource.type.to_sym)
-                      media_element(label, file, resource.type)
+                      media_element(file, resource.type)
                     else
-                      previewable_element(label, file)
+                      previewable_element(file)
                     end
           @file_index += 1
         end
@@ -35,8 +33,8 @@ module Embed
 
     attr_reader :purl_document, :request, :viewer
 
-    def media_element(label, file, type)
-      media_wrapper(label: label, file: file) do
+    def media_element(file, type)
+      media_wrapper(file: file) do
         <<-HTML.strip_heredoc
           <#{type}
             id="sul-embed-media-#{file_index}"
@@ -53,8 +51,8 @@ module Embed
       end
     end
 
-    def previewable_element(label, file)
-      media_wrapper(label: label, thumbnail: stacks_square_url(@purl_document.druid, file.title, size: '75')) do
+    def previewable_element(file)
+      media_wrapper(thumbnail: stacks_square_url(@purl_document.druid, file.title, size: '75'), file: file) do
         "<img
           src='#{stacks_thumb_url(@purl_document.druid, file.title)}'
           class='sul-embed-media-thumb #{'sul-embed-many-media' if many_primary_files?}'
@@ -63,11 +61,11 @@ module Embed
       end
     end
 
-    def media_wrapper(label:, thumbnail: '', file: nil, &block)
+    def media_wrapper(thumbnail: '', file: nil, &block)
       <<-HTML.strip_heredoc
         <div data-stanford-only="#{file.try(:stanford_only?)}"
              data-location-restricted="#{file.try(:location_restricted?)}"
-             data-file-label="#{label}"
+             data-file-label="#{file.label}"
              data-slider-object="#{file_index}"
              data-thumbnail-url="#{thumbnail}"
              data-duration="#{file.try(:duration)}">

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -20,7 +20,7 @@ module Embed
       output = ''
       purl_document.contents.each do |resource|
         next unless primary_file?(resource)
-        resource.files.each do |file|
+        resource.non_thumbnail_files.each do |file|
           output << if SUPPORTED_MEDIA_TYPES.include?(resource.type.to_sym)
                       media_element(file, resource.type)
                     else

--- a/lib/embed/viewer/media.rb
+++ b/lib/embed/viewer/media.rb
@@ -52,15 +52,10 @@ module Embed
       def download_list_items
         @purl_object.contents.map do |resource|
           resource.files.map do |file|
-            link_text = if resource.description.present?
-                          resource.description
-                        else
-                          file.title
-                        end
             file_size = "(#{pretty_filesize(file.size)})" if file.size
             <<-HTML.strip_heredoc
               <li>
-                <a href='#{file_url(file.title)}' title='#{file.title}' target='_blank' rel='noopener noreferrer'>Download #{link_text}</a>
+                <a href='#{file_url(file.title)}' title='#{file.title}' target='_blank' rel='noopener noreferrer'>Download #{file.label}</a>
                 #{restrictions_text_for_file(file)}
                 #{file_size}
               </li>

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -803,7 +803,7 @@ module PURLFixtures
           <resource sequence="1" id="abc123_1" type="video">
             <file id="abc_123.mp4" mimetype="video/mp4" size="152000000"></file>
           </resource>
-          <resource sequence="2" id="bb051hp9404_2" type="file">
+          <resource sequence="2" id="bb051hp9404_2" type="image">
             <label>Image of media (1 of 1)</label>
             <file id="bd786fy6312_img.jp2" mimetype="image/jp2" size="213147">
               <imageData height="384" width="2896"/>

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -861,6 +861,32 @@ module PURLFixtures
     XML
   end
 
+  def file_and_object_level_thumb_purl
+    <<-XML
+      <publicObject>
+        <contentMetadata type="file">
+          <resource id="audio_1" type="audio">
+            <file id="audio.mp3" mimetype="audio/mpeg" size="77033"></file>
+            <file id="audio_1.jp2" mimetype="image/jp2" size="42"></file>
+          </resource>
+          <resource id="video_1" type="video">
+            <file id="video.mp4" mimetype="video/mp4" size="77023"></file>
+            <file id="video_1.jp2" mimetype="image/jp2" size="42"></file>
+          </resource>
+          <resource id="video_2" type="video">
+            <file id="video2.mp4" mimetype="video/mp4" size="77023"></file>
+          </resource>
+          <resource id="book_1" type="image">
+            <file id="book1.jp2" mimetype="image/jp2" size="77041"></file>
+          </resource>
+          <resource id="thumb_1" type="thumb" thumb="yes">
+            <file id="thumb.jp2" mimetype="image/jp2" size="7722"></file>
+          </resource>
+        </contentMetadata>
+      </publicObject>
+    XML
+  end
+
   def empty_content_metadata_purl
     <<-XML
       <publicObject>

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -92,6 +92,22 @@ describe Embed::MediaTag do
       end
     end
 
+    describe 'poster' do
+      context 'when a file level thumbnail is present' do
+        let(:purl) { file_and_object_level_thumb_purl }
+        it 'includes a poster attribute' do
+          expect(subject).to have_css('video[poster]', visible: false)
+          video = subject.find('video[poster]', visible: false)
+          expect(video['poster']).to match(%r{/druid%2Fvideo_1/full/})
+        end
+      end
+      context 'when a file level thumbnail is not present' do
+        it 'does not include a poster attribute' do
+          expect(subject).to_not have_css('video[poster]', visible: false)
+        end
+      end
+    end
+
     context 'audio' do
       let(:purl) { audio_purl }
 
@@ -130,6 +146,7 @@ describe Embed::MediaTag do
         expect(media_wrapper).not_to have_css('.sul-embed-media-access-restricted .line2', text: 'See Access conditions for more information')
       end
     end
+
     describe 'duration' do
       it 'sets the duration when the resource file has duration' do
         resource_file = double(Embed::PURL::Resource::ResourceFile, label: 'ignored', duration: '1:02')

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -82,27 +82,27 @@ describe Embed::MediaTag do
   describe '#media_wrapper' do
     describe 'data-stanford-only attribute' do
       it 'true for Stanford only files' do
-        resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: true, location_restricted?: false, duration: nil)
-        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', file: resource_file))
+        resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: true, location_restricted?: false, label: 'ignored', duration: nil)
+        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, file: resource_file))
         expect(media_wrapper).to have_css('[data-stanford-only="true"]')
       end
 
       it 'false for public files' do
-        resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: false, location_restricted?: false, duration: nil)
-        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', file: resource_file))
+        resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: false, location_restricted?: false, label: 'ignored', duration: nil)
+        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, file: resource_file))
         expect(media_wrapper).to have_css('[data-stanford-only="false"]')
       end
     end
     describe 'location restriction message' do
       it 'displayed when not in location' do
-        resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: false, location_restricted?: true, duration: nil)
-        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', file: resource_file))
+        resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: false, location_restricted?: true, label: 'ignored', duration: nil)
+        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, file: resource_file))
         expect(media_wrapper).to have_css('.sul-embed-media-access-restricted .line1', text: 'Restricted media cannot be played in your location')
         expect(media_wrapper).to have_css('.sul-embed-media-access-restricted .line2', text: 'See Access conditions for more information')
       end
       it 'not displayed when in location' do
-        resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: false, location_restricted?: false, duration: nil)
-        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', file: resource_file))
+        resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: false, location_restricted?: false, label: 'ignored', duration: nil)
+        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, file: resource_file))
         expect(media_wrapper).not_to have_css('.sul-embed-media-access-restricted')
         expect(media_wrapper).not_to have_css('.sul-embed-media-access-restricted .line1', text: 'Limited access for non-Stanford guests')
         expect(media_wrapper).not_to have_css('.sul-embed-media-access-restricted .line2', text: 'See Access conditions for more information')
@@ -110,13 +110,13 @@ describe Embed::MediaTag do
     end
     describe 'duration' do
       it 'sets the duration when the resource file has duration' do
-        resource_file = double(Embed::PURL::Resource::ResourceFile, duration: '1:02')
-        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', file: resource_file))
+        resource_file = double(Embed::PURL::Resource::ResourceFile, label: 'ignored', duration: '1:02')
+        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, file: resource_file))
         expect(media_wrapper).to have_css('[data-duration="1:02"]')
       end
       it 'leaves the duration empty when the resource file is missing duration' do
-        resource_file = double(Embed::PURL::Resource::ResourceFile, duration: nil)
-        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', file: resource_file))
+        resource_file = double(Embed::PURL::Resource::ResourceFile, label: 'ignored', duration: nil)
+        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, file: resource_file))
         expect(media_wrapper).to have_css('[data-duration=""]')
       end
     end
@@ -124,27 +124,27 @@ describe Embed::MediaTag do
     describe 'data-location-restricted attribute' do
       context 'stanford_only' do
         it 'true for location restricted files' do
-          resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: true, location_restricted?: true, duration: nil)
-          media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', file: resource_file))
+          resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: true, location_restricted?: true, label: 'ignored', duration: nil)
+          media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, file: resource_file))
           expect(media_wrapper).to have_css('[data-location-restricted="true"]')
         end
 
         it 'false for public files' do
-          resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: true, location_restricted?: false, duration: nil)
-          media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', file: resource_file))
+          resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: true, location_restricted?: false, label: 'ignored', duration: nil)
+          media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, file: resource_file))
           expect(media_wrapper).to have_css('[data-location-restricted="false"]')
         end
       end
       context 'not stanford_only' do
         it 'true for location restricted files' do
-          resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: false, location_restricted?: true, duration: nil)
-          media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', file: resource_file))
+          resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: false, location_restricted?: true, label: 'ignored', duration: nil)
+          media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, file: resource_file))
           expect(media_wrapper).to have_css('[data-location-restricted="true"]')
         end
 
         it 'false for public files' do
-          resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: false, location_restricted?: false, duration: nil)
-          media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, label: 'ignored', file: resource_file))
+          resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: false, location_restricted?: false, label: 'ignored', duration: nil)
+          media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, file: resource_file))
           expect(media_wrapper).to have_css('[data-location-restricted="false"]')
         end
       end
@@ -170,7 +170,7 @@ describe Embed::MediaTag do
 
     describe '#previewable_element' do
       before { stub_purl_response_with_fixture(purl) }
-      let(:previewable_element) { subject_klass.send(:previewable_element, 'Some Label', file) }
+      let(:previewable_element) { subject_klass.send(:previewable_element, double('file', label: 'abc123', title: 'abc123')) }
       it 'passes the square thumb url as a data attribute' do
         expect(previewable_element).to match(
           %r{data-thumbnail-url="https://stacks.*/iiif/.*abc123/square/75,75.*"}

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -72,6 +72,11 @@ describe Embed::MediaTag do
       it 'does not include file level thumbnails' do
         expect(subject).not_to have_css('[data-file-label="audio_1.jp2"]', visible: false)
       end
+
+      it 'includes the file level thumbnail data-attribute when present' do
+        object = subject.find('[data-slider-object="1"]')
+        expect(object['data-thumbnail-url']).to match(%r{%2Fvideo_1/square/75,75/})
+      end
     end
 
     context 'previewable files withing media objects' do

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -57,6 +57,23 @@ describe Embed::MediaTag do
       end
     end
 
+    context 'file and object level thumbnails' do
+      let(:purl) { file_and_object_level_thumb_purl }
+
+      it 'has the correct number of objects (4)' do
+        expect(subject).to have_css('[data-slider-object]', count: 4, visible: false)
+      end
+
+      it 'does not include object level thumbnails' do
+        expect(subject).to have_css('[data-file-label="audio.mp3"]', visible: false)
+        expect(subject).not_to have_css('[data-file-label="thumb.jp2"]', visible: false)
+      end
+
+      it 'does not include file level thumbnails' do
+        expect(subject).not_to have_css('[data-file-label="audio_1.jp2"]', visible: false)
+      end
+    end
+
     context 'previewable files withing media objects' do
       let(:purl) { video_purl_with_image }
       it 'are included as top level objects' do

--- a/spec/models/embed/purl_spec.rb
+++ b/spec/models/embed/purl_spec.rb
@@ -135,6 +135,25 @@ describe Embed::PURL do
       stub_purl_response_with_fixture(multi_file_purl)
       expect(Embed::PURL.new('12345').contents.first.description).to eq 'File1 Label'
     end
+
+    describe '#object_thumbnail?' do
+      let(:purl_resource) { double('Resource') }
+      it 'is true when type="thumb"' do
+        allow(purl_resource).to receive(:attributes).and_return('type' => double(value: 'thumb'))
+        expect(Embed::PURL::Resource.new(purl_resource, double('Rights'))).to be_object_thumbnail
+      end
+
+      it 'is true when thumb="yes"' do
+        allow(purl_resource).to receive(:attributes).and_return('thumb' => double(value: 'yes'))
+        expect(Embed::PURL::Resource.new(purl_resource, double('Rights'))).to be_object_thumbnail
+      end
+
+      it 'is false otherwise' do
+        allow(purl_resource).to receive(:attributes).and_return('type' => double(value: 'image'))
+        expect(Embed::PURL::Resource.new(purl_resource, double('Rights'))).not_to be_object_thumbnail
+      end
+    end
+
     describe 'files' do
       it 'should return an array of PURL::Resource::ResourceFile objects' do
         stub_purl_response_with_fixture(file_purl)

--- a/spec/models/embed/purl_spec.rb
+++ b/spec/models/embed/purl_spec.rb
@@ -204,6 +204,35 @@ describe Embed::PURL do
         end
       end
 
+      describe '#thumbnail' do
+        let(:resource_with_thumb) do
+          double(
+            'PURL::Resource', files: [
+              double(thumbnail?: false, title: 'Non thumb'),
+              double(thumbnail?: true, title: 'The Thumb')
+            ]
+          )
+        end
+        let(:resource_without_thumb) do
+          double(
+            'PURL::Resource', files: [
+              double(thumbnail?: false, title: 'Non thumb'),
+              double(thumbnail?: false, title: 'Another Non Thumb')
+            ]
+          )
+        end
+
+        it 'is the file name of the thumbnail within the same resource' do
+          file = Embed::PURL::Resource::ResourceFile.new(resource_with_thumb, double('File'), double('Rights'))
+          expect(file.thumbnail).to eq 'The Thumb'
+        end
+
+        it 'is nil when the resource does not have a file specific thumb' do
+          file = Embed::PURL::Resource::ResourceFile.new(resource_without_thumb, double('File'), double('Rights'))
+          expect(file.thumbnail).to be_nil
+        end
+      end
+
       describe '#thumbnail?' do
         let(:resource) { double('Resource') }
         let(:file) { double('File') }


### PR DESCRIPTION
Closes #623 


## dv738kn2168 (before)
<img width="903" alt="dv738kn2168-before" src="https://cloud.githubusercontent.com/assets/96776/18331435/cc4bdc7c-7513-11e6-93ea-9d1a6f32e3c5.png">


## dv738kn2168 (after)
<img width="533" alt="dv738kn2168" src="https://cloud.githubusercontent.com/assets/96776/18331372/493bdc7e-7513-11e6-952d-bb24a8688ca6.png">
