### PR TITLE
Ensure videoJS audio and video elements are 100% height and width in …

### DIFF
--- a/app/assets/stylesheets/media.scss
+++ b/app/assets/stylesheets/media.scss
@@ -101,8 +101,13 @@
     visibility: hidden;
   }
 
+  // Ensure fullscreen media is as large as possible.
   &.vjs-fullscreen {
-    height: auto;
+    audio,
+    video {
+      height: 100% !important;
+      width: 100% !important;
+    }
   }
 
   .vjs-poster {


### PR DESCRIPTION
…fullscreen.

Closes #693 

## Before
<img width="1440" alt="before" src="https://cloud.githubusercontent.com/assets/96776/18354720/82bd71be-759b-11e6-82dc-dcfc024f33c4.png">

## After
<img width="1440" alt="after" src="https://cloud.githubusercontent.com/assets/96776/18354719/82a87b60-759b-11e6-969f-ce7466d5c023.png">
