### PR TITLE
image viewer thumb filmstrip now closed by default, …

### DIFF
--- a/app/assets/javascripts/modules/image_x_viewer.js
+++ b/app/assets/javascripts/modules/image_x_viewer.js
@@ -433,7 +433,7 @@
       $thumbSlider = $(document.createElement('div'));
       $thumbSlider.addClass('sul-embed-image-x-thumb-slider');
       $thumbOpenClose = $(document.createElement('div'));
-      $thumbOpenClose.addClass('sul-i-navigation-show-more-1 open ' +
+      $thumbOpenClose.addClass('sul-i-navigation-show-more-1 ' +
         'sul-embed-image-x-thumb-slider-open-close');
       $thumbOpenClose.attr('aria-label', 'toggle thumbnail viewer');
       $thumbOpenClose.attr('aria-expanded', true);
@@ -497,6 +497,7 @@
       }).init();
 
       _loadImages($thumbSlider);
+      $thumbSlider.hide();
 
       thumbSliderSly.on('load move', function() {
         _loadImages($thumbSlider);

--- a/app/assets/javascripts/modules/layout_store.js
+++ b/app/assets/javascripts/modules/layout_store.js
@@ -19,7 +19,7 @@
       _this.state({
         authorized: false,
         bottomPanelEnabled: true,
-        bottomPanelOpen: true,
+        bottomPanelOpen: false,
         fullscreen: true,
         overviewPerspectiveAvailable: false,
         keyboardNavMode: null

--- a/spec/features/image_x_viewer_spec.rb
+++ b/spec/features/image_x_viewer_spec.rb
@@ -16,15 +16,15 @@ describe 'imageX viewer', js: true do
     end
   end
   describe 'thumbnail viewer' do
-    it 'is open by default' do
+    it 'is closed by default' do
       within '.sul-embed-image-x-thumb-slider-container' do
         expect(page).to have_css '.sul-embed-image-x-thumb-slider-open-close', visible: true
         expect(page).to have_css '.sul-embed-thumb-slider-scroll', visible: true
-        expect(page).to have_css '.sul-embed-image-x-thumb-slider', visible: true
-        expect(page).to have_css 'img', count: 36
+        expect(page).to have_css '.sul-embed-image-x-thumb-slider', visible: false
       end
       find('.sul-embed-image-x-thumb-slider-open-close').click
-      expect(page).to have_css '.sul-embed-image-x-thumb-slider', visible: false
+      expect(page).to have_css '.sul-embed-image-x-thumb-slider', visible: true
+      expect(page).to have_css 'img', count: 36
     end
     describe 'is hidden when in overview' do
       before do
@@ -43,6 +43,7 @@ describe 'imageX viewer', js: true do
     end
     describe 'keyboard controls' do
       it 'navigates left and right' do
+        find('.sul-embed-image-x-thumb-slider-open-close').click
         expect(page).to have_css '.active[title="Image 1"]'
         container = find('.sul-embed-container')
         container.native.send_key(:Right)
@@ -51,6 +52,7 @@ describe 'imageX viewer', js: true do
         expect(page).to have_css '.active[title="Image 1"]'
       end
       it 'in overview navigate left/right' do
+        find('.sul-embed-image-x-thumb-slider-open-close').click
         expect(page).to have_css '.active[title="Image 1"]'
         find('[data-sul-view-perspective="overview"]').click
         container = find('.sul-embed-container')
@@ -60,6 +62,7 @@ describe 'imageX viewer', js: true do
         expect(page).to have_css '.active[title="Image 1"]'
       end
       it 'with closed thumb slider' do
+        find('.sul-embed-image-x-thumb-slider-open-close').click
         expect(page).to have_css '.active[title="Image 1"]'
         find('.sul-embed-image-x-thumb-slider-open-close').click
         expect(page).to have_css '.sul-embed-image-x-thumb-slider-container',

--- a/spec/javascripts/layout_store/layout_store_spec.js
+++ b/spec/javascripts/layout_store/layout_store_spec.js
@@ -28,11 +28,11 @@ describe('LayoutStore', function() {
       expect(layoutStore.layoutState).toEqual({
         authorized: false,
         bottomPanelEnabled: true,
-        bottomPanelOpen: true,
+        bottomPanelOpen: false,
         fullscreen: true,
         overviewPerspectiveAvailable: false,
         keyboardNavMode: null
-      });      
+      });
       expect(storeSpy).not.toHaveBeenCalled();
       done();
     });
@@ -40,7 +40,7 @@ describe('LayoutStore', function() {
   describe('bottomPanelOpen', function() {
     it('reverses the state', function(done) {
       PubSub.publishSync('thumbSliderToggle');
-      expect(layoutStore.layoutState.bottomPanelOpen).toBe(false);
+      expect(layoutStore.layoutState.bottomPanelOpen).toBe(true);
       done();
     });
   });


### PR DESCRIPTION
… like media viewer thumbstrip.

#### before fw090jw3474

embed first state for this purl

![fw090jw3474 before](https://cloud.githubusercontent.com/assets/96775/18368648/dc6f2b8c-75d5-11e6-88ce-23dca5ef1651.png)

#### after fw090jw3474

embed first state for this purl

![fw090jw3474 after](https://cloud.githubusercontent.com/assets/96775/18368647/dc6f1a16-75d5-11e6-9fd0-12501917ff12.png)

connects to #630