### PR TITLE
Omit access restriction overlay for regular (non-media) thumbnails.

### DIFF
--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -40,6 +40,7 @@ module Embed
       file_thumb = stacks_square_url(@purl_document.druid, file.thumbnail, size: '75') if file.thumbnail
       media_wrapper(thumbnail: file_thumb, file: file) do
         <<-HTML.strip_heredoc
+          #{access_restricted_overlay(file.try(:stanford_only?), file.try(:location_restricted?))}
           <#{type}
             id="sul-embed-media-#{file_index}"
             data-src="#{streaming_url_for(file, :dash)}"
@@ -75,7 +76,6 @@ module Embed
              data-thumbnail-url="#{thumbnail}"
              data-duration="#{file.try(:duration)}">
           <div class='sul-embed-media-wrapper'>
-            #{access_restricted_overlay(file.try(:stanford_only?), file.try(:location_restricted?))}
             #{yield(block) if block_given?}
           </div>
         </div>

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -704,6 +704,33 @@ module PURLFixtures
     XML
   end
 
+  def video_purl_unrestricted
+    <<-XML
+      <publicObject>
+        <identityMetadata>
+          <objectLabel>Title of a video with spaces in the file name</objectLabel>
+        </identityMetadata>
+        <contentMetadata type="media">
+          <resource sequence="1" id="abc123_1" type="video">
+            <file id="A video title.mp4" mimetype="video/mp4" size="152000000">
+              <videoData duration="P0DT1H2M3S" height="288" width="352"/>
+            </file>
+          </resource>
+        </contentMetadata>
+        <rightsMetadata>
+          <access type="read">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+        </rightsMetadata>
+        <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+          <dc:title>stupid dc title of video</dc:title>
+        </oai_dc>
+      </publicObject>
+    XML
+  end
+
   def video_with_spaces_in_filename_purl
     <<-XML
       <publicObject>

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -49,6 +49,17 @@ describe Embed::MediaTag do
         expect(subject).to have_css('video[aria-labelledby="access-restricted-message-div-0"]', visible: false)
         expect(subject).to have_css('div#access-restricted-message-div-0')
       end
+
+      it 'shows a location restricted message in place of the video' do
+        expect(subject).to have_css('.sul-embed-media-access-restricted .line1', text: 'Restricted media cannot be played in your location')
+      end
+    end
+
+    context 'single video open to the world' do
+      let(:purl) { video_purl_unrestricted }
+      it 'does not show any location restricted messages' do
+        expect(subject).not_to have_css('.sul-embed-media-access-restricted .line1', text: 'Restricted media cannot be played in your location')
+      end
     end
 
     context 'multiple videos' do
@@ -79,7 +90,7 @@ describe Embed::MediaTag do
       end
     end
 
-    context 'previewable files withing media objects' do
+    context 'previewable files within media objects' do
       let(:purl) { video_purl_with_image }
       it 'are included as top level objects' do
         expect(subject).to have_css('div img.sul-embed-media-thumb')
@@ -129,21 +140,6 @@ describe Embed::MediaTag do
         resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: false, location_restricted?: false, label: 'ignored', duration: nil)
         media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, file: resource_file))
         expect(media_wrapper).to have_css('[data-stanford-only="false"]')
-      end
-    end
-    describe 'location restriction message' do
-      it 'displayed when not in location' do
-        resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: false, location_restricted?: true, label: 'ignored', duration: nil)
-        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, file: resource_file))
-        expect(media_wrapper).to have_css('.sul-embed-media-access-restricted .line1', text: 'Restricted media cannot be played in your location')
-        expect(media_wrapper).to have_css('.sul-embed-media-access-restricted .line2', text: 'See Access conditions for more information')
-      end
-      it 'not displayed when in location' do
-        resource_file = double(Embed::PURL::Resource::ResourceFile, stanford_only?: false, location_restricted?: false, label: 'ignored', duration: nil)
-        media_wrapper = Capybara.string(subject_klass.send(:media_wrapper, file: resource_file))
-        expect(media_wrapper).not_to have_css('.sul-embed-media-access-restricted')
-        expect(media_wrapper).not_to have_css('.sul-embed-media-access-restricted .line1', text: 'Limited access for non-Stanford guests')
-        expect(media_wrapper).not_to have_css('.sul-embed-media-access-restricted .line2', text: 'See Access conditions for more information')
       end
     end
 


### PR DESCRIPTION
Fixes #707 

Currently, we display access restriction messages for all thumbnails. I think we only need to display them for actual videos and audio files. I believe the regular thumbnails that are mostly pictures of the media itself (cassettes, disks etc.) are in the open domain and can be viewed by anyone at any time regardless of restrictions.

Before:

![screen shot 2016-09-16 at 12 30 07 pm](https://cloud.githubusercontent.com/assets/3740294/18598751/563739da-7c09-11e6-9cae-743d845f0998.png)



After:

![screen shot 2016-09-16 at 12 27 09 pm](https://cloud.githubusercontent.com/assets/3740294/18598676/ebf187ce-7c08-11e6-8c55-8fae5afedb8e.png)

The access restriction message is still the same for playable media.