### PR TITLE
upgrade to honeybadger 2.6.1 to avoid deployment warning 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     high_voltage (2.4.0)
-    honeybadger (2.6.0)
+    honeybadger (2.6.1)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)


### PR DESCRIPTION
about git set_current_version