### PR TITLE
Add methods to properly identify what the primary file is for a…

### DIFF
--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -172,8 +172,12 @@ module Embed
         end
       end
 
-      def non_thumbnail_files
-        files.reject(&:thumbnail?)
+      def primary_file
+        files.find(&:primary?)
+      end
+
+      def thumbnail
+        files.find(&:thumbnail?)
       end
 
       class ResourceFile
@@ -190,6 +194,11 @@ module Embed
 
         def title
           @file.attributes['id'].try(:value)
+        end
+
+        def primary?
+          primary_types = Settings.primary_mimetypes[resource.type] || []
+          !thumbnail? && primary_types.include?(mimetype)
         end
 
         def thumbnail

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,6 +19,17 @@ resource_types_that_contain_thumbnails:
   - audio
   - file
   - video
+# This indicates which mimetypes are the
+# primary file for a given resource type
+primary_mimetypes:
+  audio:
+    - audio/aac
+    - audio/mpeg
+  image:
+    - image/jp2
+  video:
+    - video/mp4
+    - video/quicktime
 streaming:
   auth_url: "%{host}/media/%{druid}/%{title}/auth_check"
   source_types:

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -19,15 +19,13 @@ module Embed
     def to_html
       output = ''
       purl_document.contents.each do |resource|
-        next unless primary_file?(resource)
-        resource.non_thumbnail_files.each do |file|
-          output << if SUPPORTED_MEDIA_TYPES.include?(resource.type.to_sym)
-                      media_element(file, resource.type)
-                    else
-                      previewable_element(file)
-                    end
-          self.file_index += 1
-        end
+        next unless resource.primary_file.present?
+        output << if SUPPORTED_MEDIA_TYPES.include?(resource.type.to_sym)
+                    media_element(resource.primary_file, resource.type)
+                  else
+                    previewable_element(resource.primary_file)
+                  end
+        self.file_index += 1
       end
       output
     end
@@ -102,12 +100,8 @@ module Embed
 
     def primary_files_count
       purl_document.contents.count do |resource|
-        primary_file?(resource)
+        resource.primary_file.present?
       end
-    end
-
-    def primary_file?(resource)
-      SUPPORTED_MEDIA_TYPES.include?(resource.type.to_sym) || resource.files.any?(&:previewable?)
     end
 
     def poster_attribute(file)

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -902,6 +902,7 @@ module PURLFixtures
           </resource>
           <resource id="video_2" type="video">
             <file id="video2.mp4" mimetype="video/mp4" size="77023"></file>
+            <file id="video2.jpg" mimetype="image/jpg" size="1234"></file>
           </resource>
           <resource id="book_1" type="image">
             <file id="book1.jp2" mimetype="image/jp2" size="77041"></file>

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -88,6 +88,11 @@ describe Embed::MediaTag do
         object = subject.find('[data-slider-object="1"]')
         expect(object['data-thumbnail-url']).to match(%r{%2Fvideo_1/square/75,75/})
       end
+
+      it 'does not mistakenly use secondary files like jpgs as thumbnails' do
+        object = subject.find('[data-slider-object="2"]')
+        expect(object['data-thumbnail-url']).to be_blank
+      end
     end
 
     context 'previewable files within media objects' do

--- a/spec/models/embed/purl_spec.rb
+++ b/spec/models/embed/purl_spec.rb
@@ -163,17 +163,6 @@ describe Embed::PURL do
       end
     end
 
-    describe '#non_thumbnail_files' do
-      it 'reduces the files to only those without thumbnails' do
-        resource = Embed::PURL::Resource.new(double('Resource'), double('Rights'))
-        allow(resource).to receive(:files).and_return(
-          [double(thumbnail?: true), double(thumbnail?: false), double(thumbnail?: true)]
-        )
-        expect(resource.non_thumbnail_files.count).to eq 1
-        expect(resource.non_thumbnail_files.first).not_to be_thumbnail
-      end
-    end
-
     describe 'PURL::Resource::ResourceFile' do
       describe 'attributes' do
         before { stub_purl_response_with_fixture(file_purl) }


### PR DESCRIPTION
…resource.
Closes #723 

This will allow us to single out the primary file for a resource, the thumbnail for a resource,
and by extension any secondary files for a resource like transcripts or captioning.

## Before (xy943wj0513)
<img width="618" alt="xy943wj0513-before" src="https://cloud.githubusercontent.com/assets/96776/19169059/94117a54-8bc7-11e6-9380-59005fc7ab99.png">

## After (xy943wj0513)
<img width="452" alt="xy943wj0513-after" src="https://cloud.githubusercontent.com/assets/96776/19169062/9898327a-8bc7-11e6-92ac-edd05bdae38a.png">
