### PR TITLE
media viewer: only show downloadable files in download panel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'faraday'
 
 gem 'nokogiri'
 
-gem 'dor-rights-auth'
+gem 'dor-rights-auth', '>= 1.3.0' # need downloadable methods
 
 gem 'config'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
     docile (1.1.5)
     domain_name (0.5.25)
       unf (>= 0.0.5, < 1.0.0)
-    dor-rights-auth (1.1.0)
+    dor-rights-auth (1.3.0)
       nokogiri
     erubis (2.7.0)
     execjs (2.6.0)
@@ -160,16 +160,14 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (3.0.1)
     netrc (0.10.3)
-    nokogiri (1.6.8)
+    nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
     notiffany (0.0.8)
       nenv (~> 0.1)
       shellany (~> 0.0)
     okcomputer (1.11.1)
     parser (2.3.0.6)
       ast (~> 2.2)
-    pkg-config (1.1.7)
     poltergeist (1.7.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -320,7 +318,7 @@ DEPENDENCIES
   config
   coveralls
   dlss-capistrano
-  dor-rights-auth
+  dor-rights-auth (>= 1.3.0)
   faraday
   filesize
   guard-rspec

--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -2,7 +2,8 @@ module Embed
   class PURL
     require 'embed/media_duration'
     require 'dor/rights_auth'
-    delegate :embargoed?, :stanford_only_unrestricted?, :world_unrestricted?, to: :rights
+    delegate :embargoed?, :stanford_only_unrestricted?, :world_unrestricted?,
+             :world_downloadable_file?, :stanford_only_downloadable_file?, to: :rights
     attr_reader :druid
     def initialize(druid)
       @druid = druid
@@ -59,6 +60,12 @@ module Embed
 
     def all_resource_files
       contents.map(&:files).flatten
+    end
+
+    def downloadable_files
+      all_resource_files.select do |rf|
+        world_downloadable_file?(rf.title) || stanford_only_downloadable_file?(rf.title)
+      end
     end
 
     def purl_url

--- a/lib/embed/viewer/common_viewer.rb
+++ b/lib/embed/viewer/common_viewer.rb
@@ -86,7 +86,7 @@ module Embed
                   'aria-label' => 'open download panel',
                   'data-sul-embed-toggle' => 'sul-embed-download-panel'
                 ) do
-                  file_count = @purl_object.all_resource_files.length if show_download_count?
+                  file_count = @purl_object.downloadable_files.length if show_download_count?
                   if show_download_count? && file_count > 0
                     doc.span(class: 'sul-embed-footer-tool sul-embed-download-count',\
                              'aria-label' => 'number of downloadable files') { doc.text file_count }

--- a/lib/embed/viewer/media.rb
+++ b/lib/embed/viewer/media.rb
@@ -16,7 +16,7 @@ module Embed
       end
 
       def download_html
-        return '' if @request.hide_download?
+        return '' unless show_download?
         Embed::DownloadPanel.new do
           <<-HTML.strip_heredoc
             <div class='sul-embed-panel-body'>
@@ -39,6 +39,11 @@ module Embed
         [:media]
       end
 
+      # override CommonViewer instance method to ensure we do not show download panel when no downloadable files
+      def show_download?
+        super && @purl_object.downloadable_files.present?
+      end
+
       def self.show_download?
         true
       end
@@ -50,18 +55,16 @@ module Embed
       end
 
       def download_list_items
-        @purl_object.contents.map do |resource|
-          resource.files.map do |file|
-            file_size = "(#{pretty_filesize(file.size)})" if file.size
-            <<-HTML.strip_heredoc
-              <li>
-                <a href='#{file_url(file.title)}' title='#{file.title}' target='_blank' rel='noopener noreferrer'>Download #{file.label}</a>
-                #{restrictions_text_for_file(file)}
-                #{file_size}
-              </li>
-            HTML
-          end
-        end.flatten.join
+        @purl_object.downloadable_files.map do |file|
+          file_size = "(#{pretty_filesize(file.size)})" if file.size
+          <<-HTML.strip_heredoc
+            <li>
+              <a href='#{file_url(file.title)}' title='#{file.title}' target='_blank' rel='noopener noreferrer'>Download #{file.label}</a>
+              #{restrictions_text_for_file(file)}
+              #{file_size}
+            </li>
+          HTML
+        end.join
       end
 
       def media_accessibility_note

--- a/spec/features/download_panel_spec.rb
+++ b/spec/features/download_panel_spec.rb
@@ -83,12 +83,12 @@ describe 'download panel', js: true do
         expect(page).to have_css '.sul-embed-download-count[aria-label="number of downloadable files"]', text: 2
       end
     end
-    it 'has the file count for files all object resources in the download panel' do
-      stub_purl_response_with_fixture(multi_resource_multi_media_purl)
+    it 'only counts downloadable files' do
+      stub_purl_response_with_fixture(world_restricted_download_purl)
       visit_iframe_response
       expect(page).to have_css '.sul-embed-body.sul-embed-media' # so shows download count
       within '.sul-i-download-3' do
-        expect(page).to have_css '.sul-embed-download-count[aria-label="number of downloadable files"]', text: 4
+        expect(page).to have_css '.sul-embed-download-count[aria-label="number of downloadable files"]', text: 1
       end
     end
     it "doesn't show the file count for image_x viewer" do

--- a/spec/features/media_viewer_spec.rb
+++ b/spec/features/media_viewer_spec.rb
@@ -71,7 +71,7 @@ describe 'media viewer', js: true do
       expect(page).to have_css('[data-slider-object="1"] video', visible: false)
 
       within('.sul-embed-thumb-slider') do
-        expect(page).to have_css('.sul-embed-slider-thumb', count: 2)
+        expect(page).to have_css('.sul-embed-slider-thumb', count: 3)
       end
     end
 

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -310,6 +310,80 @@ module PURLFixtures
       </publicObject>
     XML
   end
+  def world_restricted_download_purl
+    <<-XML
+      <publicObject>
+        <identityMetadata>
+          <objectLabel>Title of the object</objectLabel>
+        </identityMetadata>
+        <contentMetadata type="media">
+          <resource sequence="1" id="zr649jg5679_1" type="video">
+            <label>Tape 1</label>
+            <file id="zr649jg5679_em_sl.mp4" mimetype="video/mp4" size="1755489213" />
+            <file id="zr649jg5679_thumb.jp2" mimetype="image/jp2" size="253270">
+              <imageData width="640" height="480"/>
+            </file>
+          </resource>
+          <resource sequence="2" id="zr649jg5679_2" type="file">
+              <label>Transcript</label>
+              <file id="zr649jg5679_script.pdf" mimetype="application/pdf" size="248915" />
+          </resource>
+        </contentMetadata>
+        <rightsMetadata>
+          #{access_discover_world}
+          <access type="read">
+            <machine>
+              <world rule="no-download"/>
+            </machine>
+          </access>
+          <access type="read">
+            <file>zr649jg5679_script.pdf</file>
+            <machine>
+              <world/>
+            </machine>
+          </access>
+        </rightsMetadata>
+      </publicObject>
+    XML
+  end
+  def stanford_restricted_download_purl
+    <<-XML
+    <publicObject>
+      <identityMetadata>
+        <objectLabel>Title of the object</objectLabel>
+      </identityMetadata>
+      <contentMetadata type="media">
+        <resource sequence="1" id="zr649jg5679_1" type="video">
+          <label>Tape 1</label>
+          <file id="no-download.mp4" mimetype="video/mp4" size="1755489213" />
+          <file id="download-ok.jp2" mimetype="image/jp2" size="253270">
+            <imageData width="640" height="480"/>
+          </file>
+        </resource>
+        <resource sequence="2" id="zr649jg5679_2" type="file">
+            <label>Transcript</label>
+            <file id="download-ok.pdf" mimetype="application/pdf" size="248915" />
+        </resource>
+      </contentMetadata>
+      <rightsMetadata>
+        #{access_discover_world}
+        <access type="read">
+          <machine>
+            <group rule="no-download">stanford</group>
+          </machine>
+        </access>
+        <access type="read">
+          <file>download-ok.jp2</file>
+          <file>download-ok.pdf</file>
+          <machine>
+            <group >stanford</group>
+          </machine>
+        </access>
+      </rightsMetadata>
+    </publicObject>
+  </access>
+    XML
+  end
   def stanford_restricted_multi_file_purl
     <<-XML
       <publicObject>
@@ -671,7 +745,7 @@ module PURLFixtures
               <videoData duration="P0DT1H2M3S" height="288" width="352"/>
             </file>
           </resource>
-          <resource sequence="2" id="abc321_1" type="video">
+          <resource sequence="2" id="abc321_2" type="video">
             <label>Second Video</label>
             <file id="abc_321.mp4" mimetype="video/mp4" size="666000000">
               <videoData duration="-P1W" height="288" width="352"/>
@@ -680,6 +754,11 @@ module PURLFixtures
           <resource sequence="3" id="bb051hp9404_2" type="file">
             <label>Transcript</label>
             <file id="abc_123_script.pdf" mimetype="application/pdf" size="557708"></file>
+          </resource>
+          <resource sequence="4" id="abc333" type="video">
+            <file id="abc_333.mp4" mimetype="video/mp4" size="152000000">
+              <videoData duration="P0DT1H2M3S" height="288" width="352"/>
+            </file>
           </resource>
         </contentMetadata>
         <rightsMetadata>

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -30,11 +30,11 @@ describe Embed::MediaTag do
     end
 
     it 'includes a data-src attribute for the dash player' do
-      expect(subject).to have_css('[data-src]', count: 2, visible: false)
+      expect(subject).to have_css('[data-src]', count: 3, visible: false)
     end
 
     it 'includes a data attribute that includes the url to check the users auth status' do
-      expect(subject).to have_css('video[data-auth-url]', count: 2, visible: false)
+      expect(subject).to have_css('video[data-auth-url]', count: 3, visible: false)
       auth_url = subject.all('video[data-auth-url]', visible: false).first['data-auth-url']
       expect(auth_url).to eq(Settings.streaming.auth_url)
     end

--- a/spec/lib/embed/viewer/common_viewer_spec.rb
+++ b/spec/lib/embed/viewer/common_viewer_spec.rb
@@ -157,14 +157,16 @@ describe Embed::Viewer::CommonViewer do
   end
 
   describe '#show_download?' do
-    it 'not shown for file viewers' do
+    it 'false for file viewers' do
       expect(file_viewer.show_download?).to be_falsey
     end
-    it 'shown for image and geo viewer' do
+    it 'true for image, geo and media viewer' do
       expect(image_x_viewer.show_download?).to be_truthy
       expect(geo_viewer.show_download?).to be_truthy
+      expect_any_instance_of(Embed::PURL).to receive(:downloadable_files).and_return(['a'])
+      expect(media_viewer.show_download?).to be_truthy
     end
-    it 'not shown when hide_download is specified' do
+    it 'false when hide_download is specified' do
       hide_request = Embed::Request.new(url: 'http://purl.stanford.edu/abc123',
                                         hide_download: 'true')
       geo_hide_viewer = Embed::Viewer::Geo.new(hide_request)

--- a/spec/lib/embed/viewer/media_spec.rb
+++ b/spec/lib/embed/viewer/media_spec.rb
@@ -40,43 +40,89 @@ describe Embed::Viewer::Media do
   end
 
   describe '#download_html' do
-    let(:purl) { video_purl }
-    before { stub_purl_response_with_fixture(purl) }
-    let(:download_html) { Capybara.string(media_viewer.download_html.to_str) }
-
-    it 'uses the label as the link text when present' do
-      expect(download_html).to have_css('li a', text: 'Download Transcript', visible: false)
-      expect(download_html).not_to have_css('li a', text: 'Download abc_123_script.pdf', visible: false)
+    it 'empty string when show_download? is false' do
+      expect(media_viewer).to receive(:show_download?).and_return false
+      expect(media_viewer.download_html).to eq ''
     end
+    context 'when downloadable files' do
+      let(:purl) { video_purl }
+      before { stub_purl_response_with_fixture(purl) }
+      let(:download_html) { Capybara.string(media_viewer.download_html.to_str) }
 
-    it 'uses the file id as the link text when no label present' do
-      expect(download_html).to have_css('li a', text: 'Download abc_123.mp4', visible: false)
-    end
+      it 'uses the label as the link text when present' do
+        expect(download_html).to have_css('li a', text: 'Download Transcript', visible: false)
+        expect(download_html).not_to have_css('li a', text: 'Download abc_123_script.pdf', visible: false)
+      end
 
-    it 'includes the file sizes when present' do
-      expect(download_html).to have_css('li', text: /\(\d+\.\d+ MB\)/, visible: false)
-      expect(download_html).to have_css('li', text: /\(\d+\.\d+ kB\)/, visible: false)
-    end
+      it 'uses the file id as the link text when no label present' do
+        expect(download_html).to have_css('li a', text: 'Download abc_333.mp4', visible: false)
+      end
 
-    it 'includes attributes appropriate for _blank target download links' do
-      expect(download_html).to have_css('li a[target="_blank"][rel="noopener noreferrer"]', count: 3, visible: false)
-    end
+      it 'includes the file sizes when present' do
+        expect(download_html).to have_css('li', text: /\(\d+\.\d+ MB\)/, visible: false)
+        expect(download_html).to have_css('li', text: /\(\d+\.\d+ kB\)/, visible: false)
+      end
 
-    context 'Stanford only' do
-      let(:purl) { stanford_restricted_file_purl }
+      it 'includes attributes appropriate for _blank target download links' do
+        expect(download_html).to have_css('li a[target="_blank"][rel="noopener noreferrer"]', count: 3, visible: false)
+      end
 
-      it 'has a span with a stanford-only s icon class (with screen-reader text)' do
-        expect(download_html).to have_css('.sul-embed-stanford-only-text', visible: false)
-        expect(download_html).to have_css('.sul-embed-text-hide', text: 'Stanford only', visible: false)
+      it 'includes downloadable files' do
+        expect(download_html).to have_content 'Download item'
+        expect(download_html).to have_content 'Download Second Video'
+        expect(download_html).to have_content 'Download Transcript'
+      end
+
+      it 'does not include files with no-download rule' do
+        expect(download_html).not_to have_content('Download Tape 1')
+      end
+
+      it 'does not include files with read location restricted' do
+        expect(download_html).not_to have_content 'Download abc_123.mp4'
+      end
+
+      context 'Stanford only' do
+        let(:purl) { stanford_restricted_file_purl }
+
+        it 'has a span with a stanford-only s icon class (with screen-reader text)' do
+          expect(download_html).to have_css('.sul-embed-stanford-only-text', visible: false)
+          expect(download_html).to have_css('.sul-embed-text-hide', text: 'Stanford only', visible: false)
+        end
+      end
+
+      context 'Location restricted' do
+        let(:purl) { single_video_purl }
+
+        it 'not included in download panel' do
+          expect(media_viewer.download_html).to eq ''
+        end
       end
     end
+  end
 
-    context 'Location restricted' do
-      let(:purl) { single_video_purl }
-
-      it 'has a span with the location restricted message' do
-        expect(download_html).to have_css('.sul-embed-location-restricted-text', text: '(Restricted)', visible: false)
+  context '#download_list_items' do
+    context '(non-empty)' do
+      let(:dli) do
+        stub_purl_response_with_fixture(video_purl)
+        media_viewer.send(:download_list_items)
       end
+      it 'includes downloadable files' do
+        expect(dli).to match 'Download Second Video'
+        expect(dli).to match 'Download Transcript'
+      end
+      it 'does not include non-downloadable files' do
+        expect(dli).not_to match 'Download Tape 1'
+      end
+      it 'does not include location restricted files (read access)' do
+        expect(dli).not_to match 'Download abc_123.mp4'
+      end
+    end
+    it 'empty string when no downloadable files' do
+      my_purl_obj = double(Embed::PURL, downloadable_files: [])
+      my_req = double(Embed::Request, purl_object: my_purl_obj)
+      my_media_viewer = Embed::Viewer::Media.new(my_req)
+      my_dli = my_media_viewer.send(:download_list_items)
+      expect(my_dli).to eq ''
     end
   end
 
@@ -96,6 +142,27 @@ describe Embed::Viewer::Media do
     it 'links to the feedback address' do
       link = metadata_html.find('a', text: Settings.purl_feedback_email, visible: false)
       expect(link['href']).to eq "mailto:#{Settings.purl_feedback_email}"
+    end
+  end
+
+  describe '#show_download?' do
+    it 'false when downloadable file count is 0' do
+      my_purl_obj = double(Embed::PURL, downloadable_files: [])
+      my_req = double(Embed::Request, purl_object: my_purl_obj, hide_download?: false)
+      my_media_viewer = Embed::Viewer::Media.new(my_req)
+      expect(my_media_viewer.show_download?).to be false
+    end
+    it 'true when downloadable file count is non-zero' do
+      my_purl_obj = double(Embed::PURL, downloadable_files: ['a'])
+      my_req = double(Embed::Request, purl_object: my_purl_obj, hide_download?: false)
+      my_media_viewer = Embed::Viewer::Media.new(my_req)
+      expect(my_media_viewer.show_download?).to be true
+    end
+    it 'false when request hide_download? is true' do
+      my_purl_obj = double(Embed::PURL, downloadable_files: ['a'])
+      my_req = double(Embed::Request, purl_object: my_purl_obj, hide_download?: true)
+      my_media_viewer = Embed::Viewer::Media.new(my_req)
+      expect(my_media_viewer.show_download?).to be false
     end
   end
 end

--- a/spec/models/embed/purl_spec.rb
+++ b/spec/models/embed/purl_spec.rb
@@ -70,7 +70,31 @@ describe Embed::PURL do
   describe 'all_resource_files' do
     it 'should return a flattened array of resource files' do
       stub_purl_response_with_fixture(multi_resource_multi_type_purl)
-      expect(Embed::PURL.new('12345').all_resource_files.count).to eq 4
+      df = Embed::PURL.new('12345').all_resource_files
+      expect(df).to be_an_instance_of Array
+      expect(df.first).to be_an_instance_of Embed::PURL::Resource::ResourceFile
+      expect(df.count).to eq 4
+    end
+  end
+  describe '#downloadable_files' do
+    it 'returns a flattened array of downloadable resource files' do
+      stub_purl_response_with_fixture(multi_resource_multi_type_purl)
+      df = Embed::PURL.new('12345').downloadable_files
+      expect(df).to be_an_instance_of Array
+      expect(df.first).to be_an_instance_of Embed::PURL::Resource::ResourceFile
+      expect(df.count).to eq 4
+    end
+    it 'returns only downloadable files (world)' do
+      stub_purl_response_with_fixture(world_restricted_download_purl)
+      purl_obj = Embed::PURL.new('12345')
+      expect(purl_obj.all_resource_files.count).to eq 3
+      expect(purl_obj.downloadable_files.count).to eq 1
+    end
+    it 'returns only downloadable files (stanford)' do
+      stub_purl_response_with_fixture(stanford_restricted_download_purl)
+      purl_obj = Embed::PURL.new('5678')
+      expect(purl_obj.all_resource_files.count).to eq 3
+      expect(purl_obj.downloadable_files.count).to eq 2
     end
   end
   describe '#bounding_box' do


### PR DESCRIPTION
closes #728 

Assumptions: 
- if a file is location restricted for read access, it is NOT downloadable.
- this is for the media viewer only

### Before (zr649jg5679)

![zg649jg5679 download before](https://cloud.githubusercontent.com/assets/96775/19750126/864e8768-9ba3-11e6-99cb-ac72f5778cc0.png)
### After (zr649jg5679)

![zg649jg5679 download after](https://cloud.githubusercontent.com/assets/96775/19876083/a6be3468-9f8f-11e6-8eab-2d594b561d1f.png)

### Before (nm201qr8213)

![nm201qr8213 before](https://cloud.githubusercontent.com/assets/96775/19876133/2738606e-9f90-11e6-98ed-392066ea9abe.png)

### After (nm201qr8213)

![nm201qr8213 after](https://cloud.githubusercontent.com/assets/96775/19876134/2738a2fe-9f90-11e6-8abf-bea1b466bacf.png)
