### PR TITLE
okcomputer: check status url for thumbnail service

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -39,6 +39,7 @@ geo_ext_url_pieces = Settings.geo_external_url.split('/')
 url_to_check = geo_ext_url_pieces[0..-2].join('/')
 OkComputer::Registry.register 'geo_external_url', OkComputer::HttpCheck.new(url_to_check)
 
-OkComputer::Registry.register 'web_archive_seed_thumbnail_url', OkComputer::HttpCheck.new(Settings.was_thumbs_url)
+was_thumbs_status_url = "#{Settings.was_thumbs_url.split('.edu').first}.edu/status"
+OkComputer::Registry.register 'web_archive_seed_thumbnail_url', OkComputer::HttpCheck.new(was_thumbs_status_url)
 
 OkComputer.make_optional %w(geo_web_services_url geo_external_url web_archive_seed_thumbnail_url)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,7 +11,7 @@ embed_iframe_url: 'https://embed.stanford.edu/iframe'
 jquery_version: '2.2.4'
 geo_external_url: 'https://earthworks.stanford.edu/catalog/stanford-'
 geo_wms_url: 'https://geowebservices.stanford.edu/geoserver/wms/'
-was_thumbs_url: 'https://thumbnail-service-example'
+was_thumbs_url: 'https://thumbnail-service-example.edu'
 # timeouts specified in seconds
 was_thumb_read_timeout: 5
 was_thumb_conn_timeout: 5

--- a/spec/features/image_x_viewer_spec.rb
+++ b/spec/features/image_x_viewer_spec.rb
@@ -34,7 +34,7 @@ describe 'imageX viewer', js: true do
           expect(page).to have_css '.sul-embed-image-x-thumb-slider-container', visible: false
         end
         it 'reappears when canvas clicked' do
-          find('[data-id="https://purl.stanford.edu/fw090jw3474/iiif/canvas-2"]').click
+          find('[data-id="https://purl.stanford.edu/fw090jw3474/iiif/canvas/fw090jw3474_2"]').click
           expect(page).to have_css '.sul-embed-image-x-thumb-slider-container', visible: true
         end
         it 'reappears when detail select' do

--- a/spec/models/embed/was_seed_thumbs_spec.rb
+++ b/spec/models/embed/was_seed_thumbs_spec.rb
@@ -42,7 +42,7 @@ describe Embed::WasSeedThumbs do
     let(:connection) { double('connection') }
 
     it 'requests the thumb list form thumbnail-service' do
-      expect(Faraday).to receive(:new).with(url: 'https://thumbnail-service-example/ab123cd4567').and_return(connection)
+      expect(Faraday).to receive(:new).with(url: 'https://thumbnail-service-example.edu/ab123cd4567').and_return(connection)
       expect(connection).to receive(:get).and_return(response)
       expect(response).to receive(:success?).and_return(true)
       expect(response).to receive(:body).and_return('body')
@@ -51,7 +51,7 @@ describe Embed::WasSeedThumbs do
       expect(seed_thumbs.response).to eq('body')
     end
     it 'raises Embed::WasSeedThumbs::ResourceNotAvailable with a connection failure' do
-      expect(Faraday).to receive(:new).with(url: 'https://thumbnail-service-example/ab123cd4567').and_return(connection)
+      expect(Faraday).to receive(:new).with(url: 'https://thumbnail-service-example.edu/ab123cd4567').and_return(connection)
       expect(connection).to receive(:get).and_return(response)
       expect(response).to receive(:success?).and_return(false)
 
@@ -63,7 +63,7 @@ describe Embed::WasSeedThumbs do
   describe 'was_thumbs_url' do
     it 'builds the was_thumbs url based on the configuratino and druid' do
       seed_thumbs = Embed::WasSeedThumbs.new('ab123cd4567')
-      expect(seed_thumbs.was_thumbs_url).to eq('https://thumbnail-service-example/ab123cd4567')
+      expect(seed_thumbs.was_thumbs_url).to eq('https://thumbnail-service-example.edu/ab123cd4567')
     end
   end
 end


### PR DESCRIPTION
Fix the url for the was-thumbnail-service: go to okcomputer `/status` page instead of hammering `/api/v1/was/thumbnails/druid_id` which is invalid without a specific druid.

This will make was-thumbnail-service logs much quieter and closes sul-dlss/was-thumbnail-service/issues/56 