### PR TITLE
Add m4a extension.

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -56,3 +56,11 @@ stream:
     - mpeg
   audio:
     - mp3
+    - m4a
+# Mapping from file extensions to Wowza streaming prefixes
+streaming_prefix:
+  mov: 'mp4'
+  mp4: 'mp4'
+  mpeg: 'mp4'
+  m4a: 'mp4'
+  mp3: 'mp3'

--- a/lib/embed/stacks_media_stream.rb
+++ b/lib/embed/stacks_media_stream.rb
@@ -44,11 +44,7 @@ module Embed
     end
 
     def streaming_file_prefix
-      if video?
-        'mp4'
-      elsif audio?
-        'mp3'
-      end
+      Settings.streaming_prefix[file_extension]
     end
 
     def video?

--- a/spec/lib/embed/stacks_media_stream_spec.rb
+++ b/spec/lib/embed/stacks_media_stream_spec.rb
@@ -39,6 +39,10 @@ describe Embed::StacksMediaStream do
       sms = described_class.new(druid: 'ab012cd3456', file_name: 'def.mp3')
       expect(sms.to_manifest_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp3:def.mp3/manifest.mpd"
     end
+    it 'audio - m4a' do
+      sms = described_class.new(druid: 'ab012cd3456', file_name: 'def.m4a')
+      expect(sms.to_manifest_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp4:def.m4a/manifest.mpd"
+    end
     it 'unknown' do
       sms = described_class.new(druid: 'ab012cd3456', file_name: 'def.xxx')
       expect(sms.to_manifest_url).to be_nil


### PR DESCRIPTION
This PR implements support for the AAC audio format on the Mac platform. I've tested this on the various Mac browsers, my Android phone and in IE and the latest Edge for Windows 10, but the testing is not entirely complete yet. Nevertheless, I think this is a good step forward for supporting the new format.