### PR TITLE
Update references from our local IIIF stacks to be /manifest instead …

### DIFF
--- a/lib/embed/viewer/image_x.rb
+++ b/lib/embed/viewer/image_x.rb
@@ -29,7 +29,7 @@ module Embed
       end
 
       def manifest_json_url
-        "#{Settings.purl_url}/#{@purl_object.druid}/iiif/manifest.json"
+        "#{Settings.purl_url}/#{@purl_object.druid}/iiif/manifest"
       end
 
       def metadata_html
@@ -56,7 +56,7 @@ module Embed
 
       def drag_and_drop_url
         purl_url = "#{Settings.purl_url}/#{@purl_object.druid}"
-        "#{purl_url}?manifest=#{purl_url}/iiif/manifest.json"
+        "#{purl_url}?manifest=#{purl_url}/iiif/manifest"
       end
 
       def drag_and_drop_instruction_text

--- a/spec/features/image_x_viewer_spec.rb
+++ b/spec/features/image_x_viewer_spec.rb
@@ -90,7 +90,7 @@ describe 'imageX viewer', js: true do
           purl_url = 'https://purl.stanford.edu/fw090jw3474'
 
           link = page.find('a.sul-embed-image-x-iiif-drag-and-drop-link')
-          expect(link['href']).to match(%r{^#{purl_url}\?manifest=#{purl_url}/iiif/manifest\.json$})
+          expect(link['href']).to match(%r{^#{purl_url}\?manifest=#{purl_url}/iiif/manifest$})
         end
 
         it 'has a links with _parent targets' do

--- a/spec/javascripts/fixtures/manifest.json
+++ b/spec/javascripts/fixtures/manifest.json
@@ -1,6 +1,6 @@
 {
   "@context": "http://iiif.io/api/presentation/2/context.json",
-  "@id": "https://purl.stanford.edu/fw090jw3474/iiif/manifest.json",
+  "@id": "https://purl.stanford.edu/fw090jw3474/iiif/manifest",
   "@type": "sc:Manifest",
   "label": "1st Street Arcade San Francisco",
   "attribution": "Copyright (c) Stanford University. All Rights Reserved.",

--- a/spec/lib/embed/viewer/image_x_spec.rb
+++ b/spec/lib/embed/viewer/image_x_spec.rb
@@ -30,7 +30,7 @@ describe Embed::Viewer::ImageX do
 
       # visible false because we display:none the container until we've loaded the CSS.
       expect(html).to have_css '.sul-embed-image-x', visible: false
-      expect(html).to have_css('#sul-embed-image-x[data-manifest-url=\'https://purl.stanford.edu/12345/iiif/manifest.json\']', visible: false)
+      expect(html).to have_css('#sul-embed-image-x[data-manifest-url=\'https://purl.stanford.edu/12345/iiif/manifest\']', visible: false)
       expect(html).to have_css('.sul-embed-image-x-buttons button[aria-label]', count: 4, visible: false)
       expect(html).to have_css('#sul-embed-image-x[data-world-restriction=false]', visible: false)
     end
@@ -66,7 +66,7 @@ describe Embed::Viewer::ImageX do
       it 'links to a PURL with a manifest parameter' do
         url = image_x_viewer.send(:drag_and_drop_url)
         purl = 'https://purl.stanford.edu/abc123'
-        expect(url).to match(%r{^#{purl}\?manifest=#{purl}/iiif/manifest\.json$})
+        expect(url).to match(%r{^#{purl}\?manifest=#{purl}/iiif/manifest$})
       end
     end
   end


### PR DESCRIPTION
…of /manifest.json

Closes #744 

cc @aeschylus 