### PR TITLE
Hint to the browser that download links should trigger a download action

### DIFF
--- a/lib/embed/viewer/geo.rb
+++ b/lib/embed/viewer/geo.rb
@@ -23,7 +23,7 @@ module Embed
                 doc.ul(class: 'sul-embed-download-list') do
                   resource.files.each do |file|
                     doc.li do
-                      doc.a(href: file_url(file.title), title: file.title, target: '_blank', rel: 'noopener noreferrer') do
+                      doc.a(href: file_url(file.title), title: file.title, target: '_blank', rel: 'noopener noreferrer', download: nil) do
                         doc.text "Download #{file.title}"
                       end
                       doc << " #{restrictions_text_for_file(file)}"

--- a/lib/embed/viewer/media.rb
+++ b/lib/embed/viewer/media.rb
@@ -59,7 +59,7 @@ module Embed
           file_size = "(#{pretty_filesize(file.size)})" if file.size
           <<-HTML.strip_heredoc
             <li>
-              <a href='#{file_url(file.title)}' title='#{file.title}' target='_blank' rel='noopener noreferrer'>Download #{file.label}</a>
+              <a href='#{file_url(file.title)}' title='#{file.title}' target='_blank' rel='noopener noreferrer' download>Download #{file.label}</a>
               #{restrictions_text_for_file(file)}
               #{file_size}
             </li>

--- a/spec/lib/embed/viewer/geo_spec.rb
+++ b/spec/lib/embed/viewer/geo_spec.rb
@@ -52,7 +52,7 @@ describe Embed::Viewer::Geo do
       stub_purl_response_and_request(geo_purl_public, request)
       html = Capybara.string(geo_viewer.download_html)
       expect(html).to have_css 'li', visible: false, count: 1
-      expect(html).to have_css 'a[href="https://stacks.stanford.edu/file/druid:12345/data.zip"]', visible: false
+      expect(html).to have_css 'a[href="https://stacks.stanford.edu/file/druid:12345/data.zip"][download]', visible: false
     end
     it 'stanford only resources have the stanford-only class (with screen reader text)' do
       stub_purl_response_and_request(stanford_restricted_multi_file_purl, request)

--- a/spec/lib/embed/viewer/media_spec.rb
+++ b/spec/lib/embed/viewer/media_spec.rb
@@ -64,7 +64,7 @@ describe Embed::Viewer::Media do
       end
 
       it 'includes attributes appropriate for _blank target download links' do
-        expect(download_html).to have_css('li a[target="_blank"][rel="noopener noreferrer"]', count: 3, visible: false)
+        expect(download_html).to have_css('li a[target="_blank"][rel="noopener noreferrer"][download]', count: 3, visible: false)
       end
 
       it 'includes downloadable files' do


### PR DESCRIPTION
I suspect this doesn't work and/or isn't cross-browser compatible, but it might improve the download experience for some users. In any case, it aligns the geo and media viewers with what other download panes are doing.