### PR TITLE
Extract a ViewerFactory

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -36,7 +36,7 @@ Layout/MultilineHashBraceLayout:
 # SupportedStyles: aligned, indented
 Layout/MultilineOperationIndentation:
   Exclude:
-    - 'lib/embed/viewer/file.rb'
+    - 'app/viewers/embed/viewer/file.rb'
 
 # Offense count: 10
 Metrics/AbcSize:
@@ -80,7 +80,7 @@ Rails/Blank:
     - 'lib/embed/media_tag.rb'
     - 'lib/embed/metadata_panel.rb'
     - 'lib/embed/request.rb'
-    - 'lib/embed/viewer/media.rb'
+    - 'app/viewers/embed/viewer/media.rb'
 
 # Offense count: 2
 Rails/FilePath:
@@ -106,9 +106,9 @@ Rails/OutputSafety:
 # Configuration parameters: NotNilAndNotEmpty, NotBlank, UnlessBlank.
 Rails/Present:
   Exclude:
-    - 'lib/embed/viewer/common_viewer.rb'
-    - 'lib/embed/viewer/file.rb'
-    - 'lib/embed/viewer/was_seed.rb'
+    - 'app/viewers/embed/viewer/common_viewer.rb'
+    - 'app/viewers/embed/viewer/file.rb'
+    - 'app/viewers/embed/viewer/was_seed.rb'
 
 # Offense count: 31
 Style/Documentation:
@@ -118,7 +118,7 @@ Style/Documentation:
 # Configuration parameters: MinBodyLength.
 Style/GuardClause:
   Exclude:
-    - 'lib/embed/viewer/file.rb'
+    - 'app/viewers/embed/viewer/file.rb'
 
 # Offense count: 3
 # Cop supports --auto-correct.
@@ -126,7 +126,7 @@ Style/MultilineIfModifier:
   Exclude:
     - 'app/controllers/pages_controller.rb'
     - 'config/initializers/high_voltage.rb'
-    - 'lib/embed/viewer/common_viewer.rb'
+    - 'app/viewers/embed/viewer/common_viewer.rb'
 
 # Offense count: 13
 # Cop supports --auto-correct.

--- a/app/viewers/embed/viewer/common_viewer.rb
+++ b/app/viewers/embed/viewer/common_viewer.rb
@@ -1,13 +1,5 @@
-require 'embed/download_panel'
-require 'embed/embed_this_panel'
-require 'embed/metadata_panel'
-require 'embed/mimetypes'
-require 'embed/pretty_filesize'
-require 'embed/restricted_text'
-require 'embed/stacks_image'
-
 module Embed
-  class Viewer
+  module Viewer
     class CommonViewer
       include Embed::Mimetypes
       include Embed::PrettyFilesize

--- a/app/viewers/embed/viewer/file.rb
+++ b/app/viewers/embed/viewer/file.rb
@@ -1,5 +1,5 @@
 module Embed
-  class Viewer
+  module Viewer
     class File < CommonViewer
       def initialize(*args)
         super
@@ -226,5 +226,3 @@ module Embed
     end
   end
 end
-
-Embed.register_viewer(Embed::Viewer::File) if Embed.respond_to?(:register_viewer)

--- a/app/viewers/embed/viewer/geo.rb
+++ b/app/viewers/embed/viewer/geo.rb
@@ -1,5 +1,5 @@
 module Embed
-  class Viewer
+  module Viewer
     class Geo < CommonViewer
       def initialize(*args)
         super
@@ -74,5 +74,3 @@ module Embed
     end
   end
 end
-
-Embed.register_viewer(Embed::Viewer::Geo) if Embed.respond_to?(:register_viewer)

--- a/app/viewers/embed/viewer/image_x.rb
+++ b/app/viewers/embed/viewer/image_x.rb
@@ -1,5 +1,5 @@
 module Embed
-  class Viewer
+  module Viewer
     class ImageX < CommonViewer
       def initialize(*args)
         super
@@ -175,5 +175,3 @@ module Embed
     end
   end
 end
-
-Embed.register_viewer(Embed::Viewer::ImageX) if Embed.respond_to?(:register_viewer)

--- a/app/viewers/embed/viewer/media.rb
+++ b/app/viewers/embed/viewer/media.rb
@@ -1,6 +1,5 @@
-require 'embed/media_tag'
 module Embed
-  class Viewer
+  module Viewer
     class Media < CommonViewer
       def body_html
         Nokogiri::HTML::Builder.new do |doc|
@@ -81,5 +80,3 @@ module Embed
     end
   end
 end
-
-Embed.register_viewer(Embed::Viewer::Media) if Embed.respond_to?(:register_viewer)

--- a/app/viewers/embed/viewer/was_seed.rb
+++ b/app/viewers/embed/viewer/was_seed.rb
@@ -1,5 +1,5 @@
 module Embed
-  class Viewer
+  module Viewer
     class WasSeed < CommonViewer
       def initialize(*args)
         super
@@ -63,5 +63,3 @@ module Embed
     end
   end
 end
-
-Embed.register_viewer(Embed::Viewer::WasSeed) if Embed.respond_to?(:register_viewer)

--- a/app/viewers/embed/viewer_factory.rb
+++ b/app/viewers/embed/viewer_factory.rb
@@ -1,9 +1,5 @@
 module Embed
-  class Viewer
-    require 'embed/viewer/common_viewer'
-    # Auto-require all .rb files in the viewer directory
-    Dir[File.join(File.dirname(__FILE__), 'viewer', '*.rb')].each { |file| require file }
-
+  class ViewerFactory
     delegate :height, :width, to: :viewer
     def initialize(request)
       @request = request

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,5 @@ module SulEmbed
     config.load_defaults 5.1
 
     require 'embed'
-    require 'embed/viewer'
   end
 end

--- a/config/initializers/register_viewers.rb
+++ b/config/initializers/register_viewers.rb
@@ -1,0 +1,9 @@
+# This require is a workaround for toplevel constant
+# See https://github.com/rails/rails/issues/6931
+# fixed in https://github.com/ruby/ruby/commit/44a2576f798b07139adde2d279e48fdbe71a0148
+require 'embed/viewer/file'
+Embed.register_viewer(Embed::Viewer::File)
+Embed.register_viewer(Embed::Viewer::Geo)
+Embed.register_viewer(Embed::Viewer::ImageX)
+Embed.register_viewer(Embed::Viewer::Media)
+Embed.register_viewer(Embed::Viewer::WasSeed)

--- a/lib/embed.rb
+++ b/lib/embed.rb
@@ -5,6 +5,15 @@ module Embed
   require 'embed/response'
   require 'embed/stacks_media_stream'
 
+  require 'embed/download_panel'
+  require 'embed/embed_this_panel'
+  require 'embed/metadata_panel'
+  require 'embed/mimetypes'
+  require 'embed/pretty_filesize'
+  require 'embed/restricted_text'
+  require 'embed/stacks_image'
+  require 'embed/media_tag'
+
   mattr_accessor :registered_viewers do
     []
   end

--- a/lib/embed/response.rb
+++ b/lib/embed/response.rb
@@ -48,7 +48,7 @@ module Embed
     private
 
     def viewer
-      @viewer ||= Embed::Viewer.new(@request).viewer
+      @viewer ||= Embed::ViewerFactory.new(@request).viewer
     end
   end
 end

--- a/spec/lib/embed/viewer_factory_spec.rb
+++ b/spec/lib/embed/viewer_factory_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Embed::Viewer do
+describe Embed::ViewerFactory do
   include PURLFixtures
 
   let(:request) { double('EmbedRequest', purl_object: Embed::PURL.new('ignored')) }


### PR DESCRIPTION
Rather than having a bunch of nested classes that span multiple files,
extract ViewerFactory from Viewer.  This enables us to leverage standard
rails autoloading.