### PR TITLE
Update Rake to 12.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,5 +74,3 @@ gem 'sul_styles', '~>0.6'
 
 # Use okcomputer to monitor the application
 gem 'okcomputer'
-
-gem 'rake', '~>11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,7 +216,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.2.2)
       rake
-    rake (11.3.0)
+    rake (12.0.0)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -333,7 +333,6 @@ DEPENDENCIES
   poltergeist
   pry-byebug
   rails (~> 5.1.2)
-  rake (~> 11)
   rspec-rails (~> 3.5.2)
   rubocop
   sass-rails


### PR DESCRIPTION
There is no reason to include rake in the gemfile. Rake is a transitive
dependenncy (via railties).  When you generate a new Rails application
there is no `rake` entry in the Gemfile.