### PR TITLE
fix imagex viewer height when title is hidden

### DIFF
--- a/app/viewers/embed/viewer/common_viewer.rb
+++ b/app/viewers/embed/viewer/common_viewer.rb
@@ -111,6 +111,9 @@ module Embed
           .compact.join(' until ')
       end
 
+      ##
+      # Not a great method name here as sometimes the header is still displayed,
+      # even if the title is hidden.
       def display_header?
         !@request.hide_title?
       end

--- a/app/viewers/embed/viewer/image_x.rb
+++ b/app/viewers/embed/viewer/image_x.rb
@@ -64,6 +64,14 @@ module Embed
       def default_body_height
         420
       end
+
+      ##
+      # Overriding CommonViewer because the ImageX viewer also has other things
+      # in the header, we need a larger height calculation.
+      def header_height
+        return 40 unless display_header?
+        super
+      end
     end
   end
 end

--- a/spec/lib/embed/viewer/image_x_spec.rb
+++ b/spec/lib/embed/viewer/image_x_spec.rb
@@ -30,5 +30,17 @@ describe Embed::Viewer::ImageX do
         expect(url).to match(%r{^#{purl}\?manifest=#{purl}/iiif/manifest$})
       end
     end
+    describe '#header_height' do
+      it 'sets a height of 40 when display_header? is false' do
+        expect(image_x_viewer).to receive(:display_header?).and_return false
+        height = image_x_viewer.send(:header_height)
+        expect(height).to eq 40
+      end
+      it 'sets the default height when display_header? is true' do
+        expect(image_x_viewer).to receive(:display_header?).and_return(true).at_least :once
+        height = image_x_viewer.send(:header_height)
+        expect(height).to eq 63
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR fixes a regression introduced in #777 (see https://github.com/sul-dlss/sul-embed/pull/777/files#diff-21226f0f711e46a8402a9e2e0dc15218L243 for reference)

## Before
![screen shot 2017-08-24 at 5 32 34 pm](https://user-images.githubusercontent.com/1656824/29690455-0d2196ce-88f5-11e7-807b-db7a7acf8656.png)
## After
![screen shot 2017-08-24 at 5 51 08 pm](https://user-images.githubusercontent.com/1656824/29690461-12ce99c8-88f5-11e7-9fbd-2e9f55f12403.png)
![screen shot 2017-08-24 at 5 51 00 pm](https://user-images.githubusercontent.com/1656824/29690464-146f4c28-88f5-11e7-9ace-2e019b1c71ca.png)

