### PR TITLE
Change response code from 501 to 415

### DIFF
--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -40,7 +40,7 @@ class EmbedController < ApplicationController
   end
 
   rescue_from Embed::Request::InvalidFormat do |e|
-    render body: e.to_s, status: 501
+    render body: e.to_s, status: 415
   end
 
   private

--- a/spec/controllers/embed_controller_spec.rb
+++ b/spec/controllers/embed_controller_spec.rb
@@ -22,9 +22,9 @@ describe EmbedController do
       get :get, params: { url: 'http://purl.stanford.edu/abc123notanobject' }
       expect(response.status).to eq(404)
     end
-    it 'has a 501 status code for an invalid format' do
+    it 'has a 415 status code for an invalid format' do
       get :get, params: { url: 'http://purl.stanford.edu/abc123', format: 'yml' }
-      expect(response.status).to eq(501)
+      expect(response.status).to eq(415)
     end
     it 'has a 200 status code for a matched url scheme param' do
       get :get, params: { url: 'http://purl.stanford.edu/fn662rv4961' }
@@ -48,9 +48,9 @@ describe EmbedController do
       get :iframe, params: { url: 'http://purl.stanford.edu/abc123notanobject' }
       expect(response.status).to eq(404)
     end
-    it 'has a 501 status code for an invalid format' do
+    it 'has a 415 status code for an invalid format' do
       get :iframe, params: { url: 'http://purl.stanford.edu/abc123', format: 'yml' }
-      expect(response.status).to eq(501)
+      expect(response.status).to eq(415)
     end
     it 'should not have an X-Frame-Options in the headers (so embedding in an iframe is allowed)' do
       get :iframe, params: { url: 'http://purl.stanford.edu/fn662rv4961' }


### PR DESCRIPTION
501 is for when the request method (e.g. GET, POST) is not implemented.
415 is for Unsupported Media Type.

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/415

Fixes #839