### PR TITLE
enables canvas index to be passed through to UV

### DIFF
--- a/app/assets/javascripts/modules/uv_viewer.js
+++ b/app/assets/javascripts/modules/uv_viewer.js
@@ -12,7 +12,8 @@
         iiifResourceUri: options.uvUri,
         configUri: options.uvConfig,
         root: options.uvRoot,
-        deepLinkingEnabled: false
+        deepLinkingEnabled: false,
+        canvasIndex: Number(options.canvasIndex)
       };
 
       createUV(id, data, new UV.URLDataProvider());

--- a/app/views/embed/body/_uv_image.html.erb
+++ b/app/views/embed/body/_uv_image.html.erb
@@ -1,7 +1,16 @@
 <script type='text/javascript' src='/uv-3/helpers.js'></script>
 <script type='text/javascript' src='/uv-3/lib/offline.js'></script>
 <div class='sul-embed-body' style='height: <%= viewer.body_height%>px' data-sul-embed-theme='<%= asset_url("uv.css") %>'>
-  <div id='uv' class='uv' data-behavior='uv' data-uv-root='<%= viewer.uv_root %>' data-uv-uri='<%= viewer.manifest_json_url %>' data-uv-config='<%= viewer.config_url %>' style='height: <%= viewer.body_height%>px; width:100%'></div>
+  <div
+    id='uv'
+    class='uv'
+    data-behavior='uv'
+    data-uv-root='<%= viewer.uv_root %>'
+    data-uv-uri='<%= viewer.manifest_json_url %>'
+    data-uv-config='<%= viewer.config_url %>'
+    data-canvas-index='<%= viewer.request.canvas_index %>'
+    style='height: <%= viewer.body_height%>px; width:100%'>
+  </div>
   <%= javascript_include_tag 'sul_uv.js', defer: true %>
   <script id='embedUV' src='<%= viewer.embed_url %>'></script>
 </div>

--- a/app/views/pages/sandbox.html.erb
+++ b/app/views/pages/sandbox.html.erb
@@ -98,6 +98,7 @@
     <label for="hide-search">Minimum files for search:</label> <input type="text" id="min-files" class="min-files" value="10" length="2" />
     <label for="hide-embed">Hide embed?</label> <input type="checkbox" id="hide-embed" class="hide-embed" />
     <label for="hide-download">Hide download?</label> <input type="checkbox" id="hide-download" class="hide-download" />
+    <label for="canvas-index">Canvas index</label> <input type="number" id="canvas-index" class="canvas-index" />
     <br>
     <input type="button" class="btn-render" value="Embed">
   </form>
@@ -245,6 +246,7 @@
             hideDownload = $('.hide-download').is(':checked'),
             maxWidth = parseInt($('.max-width').val(), 10),
             maxHeight = parseInt($('.max-height').val(), 10);
+            canvasIndex = parseInt($('.canvas-index').val(), 10);
 
         format = $('#select-format').val();
 
@@ -258,6 +260,7 @@
           if (hideDownload) url += "&hide_download=true";
           if (!isNaN(maxWidth)) url += "&maxwidth=" + maxWidth;
           if (!isNaN(maxHeight)) url += "&maxheight=" + maxHeight;
+          if (!isNaN(canvasIndex)) url += "&canvas_index=" + canvasIndex;
 
         } else {
           alert('Error:\nEmpty API endpoint and/or URL scheme')

--- a/lib/embed/request.rb
+++ b/lib/embed/request.rb
@@ -71,7 +71,8 @@ module Embed
         :hide_search,
         :hide_download,
         :min_files_to_search,
-        :fullheight
+        :fullheight,
+        :canvas_index
       )
 
       if p.respond_to? :permit!
@@ -79,6 +80,10 @@ module Embed
       else
         p
       end
+    end
+
+    def canvas_index
+      params[:canvas_index]
     end
 
     private

--- a/spec/lib/embed/request_spec.rb
+++ b/spec/lib/embed/request_spec.rb
@@ -87,6 +87,15 @@ describe Embed::Request do
     end
   end
 
+  describe 'canvas_index' do
+    it 'passes through the canvas_index param' do
+      expect(Embed::Request.new(url: purl, canvas_index: 3).canvas_index).to eq 3
+    end
+    it 'defaults to nil' do
+      expect(Embed::Request.new(url: purl).canvas_index).to eq nil
+    end
+  end
+
   describe 'object_druid' do
     it 'should parse the druid out of the incoming URL parameter' do
       expect(Embed::Request.new(url: purl).object_druid).to eq 'abc123'


### PR DESCRIPTION
This PR, closes #313 and required for https://github.com/sul-dlss/exhibits/issues/827 enables a user who knows the api, to link to a specific canvas by zero-based canvas index order. UV does not yet support linking to a canvas by canvasID.

![canvaslink](https://user-images.githubusercontent.com/1656824/33347119-cb977c30-d45f-11e7-8892-63d3e9953948.gif)
