### PR TITLE
Zoom to search

### DIFF
--- a/public/uv-config.json
+++ b/public/uv-config.json
@@ -2,7 +2,8 @@
     "options": {
         "rightPanelEnabled": true,
         "limitLocales": true,
-        "shareFrameEnabled": false
+        "shareFrameEnabled": false,
+        "zoomToSearchResultEnabled": false
     },
     "modules": {
         "seadragonCenterPanel": {


### PR DESCRIPTION
This PR addresses 2/3 of the issues described in https://github.com/sul-dlss/universalviewer/issues/46 by changing a minor configuration option `"zoomToSearchResultEnabled": false`.

Resolved acceptance criteria:

- [x]  When a search is performed in the viewer (or pre-populated as described in sul-dlss/content_search#33), the document is initially shown at 100% zoom-level, not zoomed in on the hit as the viewer currently does.
- [x] However, if the user navigates to another page in the document, either by clicking a page thumbnail or by clicking one of the arrow icons, the newly displayed page is shown at 100%, even if the user was currently viewing at at a zoom level other than 100%.
 
