### PR TITLE
Use CGI.escape instead of (discouraged) URI.escape to ensure we escap…

### DIFF
--- a/app/viewers/embed/viewer/common_viewer.rb
+++ b/app/viewers/embed/viewer/common_viewer.rb
@@ -45,7 +45,7 @@ module Embed
       # @param [Boolean] download
       # @return [String]
       def file_url(title, download: false)
-        uri = URI.parse("#{stacks_url}/#{URI.escape(title)}")
+        uri = URI.parse("#{stacks_url}/#{CGI.escape(title)}")
         uri.query = URI.encode_www_form(download: true) if download
         uri.to_s
       end

--- a/spec/features/download_panel_spec.rb
+++ b/spec/features/download_panel_spec.rb
@@ -15,7 +15,7 @@ describe 'download panel', type: :feature, js: true do
     stub_purl_response_with_fixture(wonky_filename_purl)
     visit_iframe_response
     link = page.find('.sul-embed-media-list a', match: :first)
-    expect(link['href']).to eq('https://stacks.stanford.edu/file/druid:ignored/%23Title%20of%20the%20PDF.pdf') # this file link had a # and spaces, encoding is needed
+    expect(link['href']).to eq('https://stacks.stanford.edu/file/druid:ignored/%23Title+of+the+PDF.pdf') # this file link had a # and spaces, encoding is needed
   end
   describe 'toggle button' do
     before do

--- a/spec/lib/embed/viewer/common_viewer_spec.rb
+++ b/spec/lib/embed/viewer/common_viewer_spec.rb
@@ -35,6 +35,9 @@ describe Embed::Viewer::CommonViewer do
     it 'adds a download param' do
       expect(file_viewer.file_url('cool_file', download: true)).to eq 'https://stacks.stanford.edu/file/druid:abc123/cool_file?download=true'
     end
+    it 'escapes special characters in the file' do
+      expect(file_viewer.file_url('[Dissertation] micro-TEC vfinal (for submission)-augmented.pdf')).to eq 'https://stacks.stanford.edu/file/druid:abc123/%5BDissertation%5D+micro-TEC+vfinal+%28for+submission%29-augmented.pdf'
+    end
   end
 
   describe '#sul_pretty_date' do

--- a/spec/views/embed/template/_file.html.erb_spec.rb
+++ b/spec/views/embed/template/_file.html.erb_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe 'embed/template/_file.html.erb' do
     it 'adds a Stanford specific embargo message with links still present' do
       # ?expect(file_viewer).to receive(:asset_host).at_least(:twice).and_return('http://example.com')
       expect(rendered).to have_css('.sul-embed-embargo-message', visible: false, text: "Access is restricted to Stanford-affiliated patrons until #{(Time.current + 1.month).strftime('%d-%b-%Y')}")
-      expect(rendered).to have_css('.sul-embed-media-heading a[href="https://stacks.stanford.edu/file/druid:12345/Title%20of%20the%20PDF.pdf"]', visible: false)
+      expect(rendered).to have_css('.sul-embed-media-heading a[href="https://stacks.stanford.edu/file/druid:12345/Title+of+the+PDF.pdf"]', visible: false)
     end
 
     it 'includes an element with a stanford icon class (with screen reader text)' do


### PR DESCRIPTION
…e all special characters that may be in the file nanme