### PR TITLE
Add a dummy home page route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  root to: 'pages#home'
 
   get 'embed' => 'embed#get'
 


### PR DESCRIPTION
It turns out, passenger has been trying, unsuccessfully, to use `/` to pre-warm the app.