### PR TITLE
Sets a sufficiently high maxZoomPixelRatio for OSD

### DIFF
--- a/public/uv-config.json
+++ b/public/uv-config.json
@@ -4,6 +4,7 @@
         "limitLocales": true,
         "shareFrameEnabled": false,
         "zoomToSearchResultEnabled": false,
+        "maxZoomPixelRatio": 1000,
         "metrics": [
           {
             "type": "watch",


### PR DESCRIPTION
This sets a UV config that instantiates OSD with a sufficiently high
maxZoomPixelRatio. This fixes the problem where very vertical images
(piano scrolls) do not disappear when zooming in. We cannot set to
`Infinity` since we create this config in JSON.

See: https://github.com/openseadragon/openseadragon/blob/beecde11d9ff1b31f2c346988468ebf6a38c1b69/src/openseadragon.js#L241

Fixes #900 

Checkout ch718mg2581