### PR TITLE
Cast data attributes for duration and file label to string in case…

### DIFF
--- a/app/assets/javascripts/modules/media_viewer.js
+++ b/app/assets/javascripts/modules/media_viewer.js
@@ -82,8 +82,8 @@
         }
 
         var isLocationRestricted = $(mediaDiv).data('location-restricted');
-        var fileLabel = $(mediaDiv).data('file-label');
-        var duration = $(mediaDiv).data('duration');
+        var fileLabel = String($(mediaDiv).data('file-label') || '');
+        var duration = String($(mediaDiv).data('duration') || '');
         thumbs.push(
           '<li class="' + thumbClass + activeClass + '">' +
             thumbnailIcon +


### PR DESCRIPTION
…they contain only integers.

This branch is currently deployed to uat and you can see that this fixes streaming for druid `gd135hp1617` (since this error stops any js from executing after the error).