### PR TITLE
Better index map

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,8 @@ gem 'leaflet-rails'
 
 gem 'sul_styles', '~>0.6'
 
+gem 'handlebars_assets'
+
 # Use okcomputer to monitor the application
 gem 'okcomputer'
 gem 'newrelic_rpm', group: :production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,10 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    handlebars_assets (0.23.2)
+      execjs (~> 2.0)
+      sprockets (>= 2.0.0)
+      tilt (>= 1.2)
     high_voltage (3.1.0)
     honeybadger (4.1.0)
     i18n (1.2.0)
@@ -364,6 +368,7 @@ DEPENDENCIES
   faraday
   filesize
   guard-rspec
+  handlebars_assets
   high_voltage
   honeybadger
   iso8601

--- a/app/assets/javascripts/geo.js
+++ b/app/assets/javascripts/geo.js
@@ -8,6 +8,8 @@
 //= require leaflet
 //= require Leaflet.Control.Custom.js
 //= require modules/geo_viewer
+//= require handlebars.runtime
+//= require templates/index_map_info
 
 CssInjection.injectFontIcons();
 CssInjection.appendToHead();

--- a/app/assets/javascripts/geo.js
+++ b/app/assets/javascripts/geo.js
@@ -10,6 +10,7 @@
 //= require modules/geo_viewer
 //= require handlebars.runtime
 //= require templates/index_map_info
+//= require templates/geo_sidebar
 
 CssInjection.injectFontIcons();
 CssInjection.appendToHead();

--- a/app/assets/javascripts/modules/geo_viewer.js
+++ b/app/assets/javascripts/modules/geo_viewer.js
@@ -99,16 +99,10 @@
       indexMapInspection: function(e) {
         var thumbDeferred = $.Deferred();
         var data = e.target.feature.properties;
+        var _this = this;
         $.when(thumbDeferred).done(function() {
           var html = HandlebarsTemplates["index_map_info"](data);
-          $el
-            .find('.sul-embed-geo-sidebar')
-            .removeClass('collapsed')
-            .find('.sul-embed-geo-sidebar-content')
-            .html(html)
-            .slideDown(400)
-            .css({'height': map.getSize().y - 90})
-            .attr('aria-hidden', false);
+          _this.openSidebarWithContent(html);
         });
 
         if (data.iiifUrl) {
@@ -123,6 +117,7 @@
         }
       },
       setupFeatureInspection: function() {
+        var _this = this;
         map.on('click', function(e) {
           // Return early if original target is not actually the map
           if (e.originalEvent.target.id !== 'sul-embed-geo-map') {
@@ -160,17 +155,20 @@
                 });
               });
               html += '</dl>';
-              $el
-                .find('.sul-embed-geo-sidebar')
-                .removeClass('collapsed')
-                .find('.sul-embed-geo-sidebar-content')
-                .html(html)
-                .slideDown(400)
-                .css({'height': map.getSize().y - 90})
-                .attr('aria-hidden', false);
+              _this.openSidebarWithContent(html);
             }
           });
         });
+      },
+      openSidebarWithContent: function(html) {
+        $el
+          .find('.sul-embed-geo-sidebar')
+          .removeClass('collapsed')
+          .find('.sul-embed-geo-sidebar-content')
+          .html(html)
+          .slideDown(400)
+          .css({'height': map.getSize().y - 90})
+          .attr('aria-hidden', false);
       },
       setupSidebar: function() {
         var control = HandlebarsTemplates['geo_sidebar']();

--- a/app/assets/javascripts/modules/geo_viewer.js
+++ b/app/assets/javascripts/modules/geo_viewer.js
@@ -1,4 +1,4 @@
-
+/* global HandlebarsTemplates */
 (function( global ) {
   'use strict';
   var Module = (function() {
@@ -83,7 +83,7 @@
         var style = {
           radius: 4,
           weight: 1,
-        }
+        };
         // Style the colors based on availability
         if (typeof(availability) === 'undefined') {
           return style; // default Leaflet style colorings
@@ -94,19 +94,19 @@
         } else {
           style.color = '#b3001e';
         }
-        return style
+        return style;
       },
       indexMapInspection: function(e) {
         var thumbDeferred = $.Deferred();
         var data = e.target.feature.properties;
         var _this = this;
         $.when(thumbDeferred).done(function() {
-          var html = HandlebarsTemplates["index_map_info"](data);
+          var html = HandlebarsTemplates.index_map_info(data);
           _this.openSidebarWithContent(html);
         });
 
         if (data.iiifUrl) {
-          var manifest = $.getJSON(data.iiifUrl, function(manifestResponse) {
+          $.getJSON(data.iiifUrl, function(manifestResponse) {
             if (manifestResponse.thumbnail['@id'] !== null) {
               data.thumbnailUrl = manifestResponse.thumbnail['@id'];
               thumbDeferred.resolve();
@@ -171,7 +171,7 @@
           .attr('aria-hidden', false);
       },
       setupSidebar: function() {
-        var control = HandlebarsTemplates['geo_sidebar']();
+        var control = HandlebarsTemplates.geo_sidebar();
         L.control.custom({
           position: 'topright',
           content: control,

--- a/app/assets/javascripts/modules/geo_viewer.js
+++ b/app/assets/javascripts/modules/geo_viewer.js
@@ -173,13 +173,7 @@
         });
       },
       setupSidebar: function() {
-        var control = '<div class="sul-embed-geo-sidebar">' +
-                        '<div class="sul-embed-geo-sidebar-header">' +
-                          '<h3>Features</h3>' +
-                          '<i class="sul-i-arrow-up-8"></i>' +
-                        '</div>' +
-                        '<div class="sul-embed-geo-sidebar-content">Click the map to inspect features.</div>' +
-                      '</div>';
+        var control = HandlebarsTemplates['geo_sidebar']();
         L.control.custom({
           position: 'topright',
           content: control,

--- a/app/assets/javascripts/templates/geo_sidebar.hbs
+++ b/app/assets/javascripts/templates/geo_sidebar.hbs
@@ -1,0 +1,7 @@
+<div class="sul-embed-geo-sidebar">
+  <div class="sul-embed-geo-sidebar-header">
+    <h3>Features</h3>
+    <i class="sul-i-arrow-up-8"></i>
+  </div>
+  <div class="sul-embed-geo-sidebar-content">Click the map to inspect features.</div>
+</div>

--- a/app/assets/javascripts/templates/index_map_info.hbs
+++ b/app/assets/javascripts/templates/index_map_info.hbs
@@ -1,0 +1,38 @@
+<div class="index-map-info">
+  {{#if title}}
+    <h3>{{title}}</h3>
+  {{/if}}
+  <div>
+    {{#if thumbnailUrl}}
+      {{#if websiteUrl}}
+        <a href="{{websiteUrl}}">
+          <img src="{{thumbnailUrl}}" style="max-width: 100%; height: auto;">
+        </a>
+      {{else}}
+        <img src="{{thumbnailUrl}}">
+      {{/if}}
+    {{/if}}
+    <dl>
+      {{#if websiteUrl}}
+        <dt>Website</dt>
+        <dd><a href="{{websiteUrl}}">{{websiteUrl}}</a></dd>
+      {{/if}}
+      {{#if downloadUrl}}
+        <dt>Download</dt>
+        <dd><a href="{{downloadUrl}}">{{downloadUrl}}</a></dd>
+      {{/if}}
+      {{#if recordIdentifier}}
+        <dt>Record Identifier</dt>
+        <dd>{{recordIdentifier}}</dd>
+      {{/if}}
+      {{#if label}}
+        <dt>Label</dt>
+        <dd>{{label}}</dd>
+      {{/if}}
+      {{#if note}}
+        <dt>Note</dt>
+        <dd>{{note}}</dd>
+      {{/if}}
+    </dl>
+  </div>
+</div>

--- a/app/assets/stylesheets/geo.scss
+++ b/app/assets/stylesheets/geo.scss
@@ -41,6 +41,10 @@
   overflow: scroll;
   padding: 0 10px 10px;
 
+  dt {
+    font-weight: bold;
+  }
+
   .inline-flex {
     display: flex;
     flex-flow: row;

--- a/app/viewers/embed/viewer/geo.rb
+++ b/app/viewers/embed/viewer/geo.rb
@@ -20,6 +20,7 @@ module Embed
           options['data-wms-url'] = Settings.geo_wms_url
           options['data-layers'] = "druid:#{@purl_object.druid}"
         end
+        options['data-index-map'] = file_url('index_map.json') if index_map?
         options
       end
 
@@ -33,6 +34,10 @@ module Embed
 
       def self.show_download?
         true
+      end
+
+      def index_map?
+        purl_object.contents.map { |c| c.files.map(&:title) }.flatten.include? 'index_map.json'
       end
 
       def external_url

--- a/spec/features/geo_viewer_spec.rb
+++ b/spec/features/geo_viewer_spec.rb
@@ -81,3 +81,24 @@ describe 'geo viewer restricted', js: true do
     end
   end
 end
+
+describe 'geo index map viewer', js: true do
+  include PURLFixtures
+
+  before do
+    stub_purl_response_with_fixture(geo_purl_index_map)
+    visit_iframe_response 'ts545zc6250'
+  end
+  describe 'loads viewer' do
+    it 'shows the geojson' do
+      # This is a hack, but there is no other way (that we know of) to
+      # find this svg element on the page.
+      # We also need to explicitly wait for the JS to run.
+      expect(page).to have_css('.sul-embed-geo', count: 1, visible: true)
+      expect(page).to have_css '[data-index-map="https://stacks.stanford.edu/file/druid:ts545zc6250/index_map.json"]'
+      page.save_and_open_screenshot
+      find '.leaflet-overlay-pane'
+      expect(Nokogiri::HTML.parse(page.body).css('path').length).to eq 480
+    end
+  end
+end

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -559,6 +559,49 @@ module PURLFixtures
       </publicObject>
     XML
   end
+  def geo_purl_index_map
+    <<-XML
+      <publicObject id="druid:ts545zc6250" published="2018-09-10T12:43:23Z" publishVersion="dor-services/5.31.1">
+        <identityMetadata>
+          <sourceId source="branner">topo_index_JMM_B14_J59.shp</sourceId>
+          <objectId>druid:ts545zc6250</objectId>
+        </identityMetadata>
+        <contentMetadata objectId="ts545zc6250" type="geo">
+          <resource id="ts545zc6250_1" sequence="1" type="object">
+            <label>Data</label>
+            <file id="data.zip" mimetype="application/zip" size="103504" role="master">
+              <geoData>
+                <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://purl.stanford.edu/ts545zc6250">
+                  <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">application/x-esri-shapefile; format=Shapefile</dc:format>
+                  <dc:type xmlns:dc="http://purl.org/dc/elements/1.1/">Dataset#Polygon</dc:type>
+                  <gml:boundedBy xmlns:gml="http://www.opengis.net/gml/3.2/">
+                    <gml:Envelope gml:srsName="EPSG:4326">
+                      <gml:lowerCorner>124.0 38.0</gml:lowerCorner>
+                      <gml:upperCorner>130.0 42.666667</gml:upperCorner>
+                    </gml:Envelope>
+                  </gml:boundedBy>
+                  <dc:coverage xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:resource="" dc:language="eng" dc:title="Korea (North)" />
+                </rdf:Description>
+              </geoData>
+            </file>
+            <file id="data_EPSG_4326.zip" mimetype="application/zip" size="25807" role="derivative">
+              <geoData srsName="EPSG:4326" />
+            </file>
+            <file id="index_map.json" mimetype="application/json" size="411978" role="master" />
+          </resource>
+          <resource id="ts545zc6250_2" sequence="2" type="preview">
+            <label>Preview</label>
+            <file id="preview.jpg" mimetype="image/jpeg" size="80392" role="master">
+              <imageData width="769" height="984" />
+            </file>
+          </resource>
+        </contentMetadata>
+        <rightsMetadata>
+          #{access_read_world}
+        </rightsMetadata>
+      </publicObject>
+    XML
+  end
   def geo_purl_restricted
     <<-XML
       <publicObject id="druid:fp756wn9369" published="2015-02-04T20:03:27-08:00">


### PR DESCRIPTION
Follow on to #935 

Adds OpenIndexMap support, better index map viewing for special content. `ts545zc6250` is a good test fixture. This ports over the index map viewer from GeoBlacklight
## Before
![screen shot 2018-12-14 at 10 15 21 am](https://user-images.githubusercontent.com/1656824/50017416-359ec480-ff89-11e8-85bb-8c980d78de58.png)
## After
![betterindexmap](https://user-images.githubusercontent.com/1656824/50016882-b6f55780-ff87-11e8-850f-cfed31b41ff2.gif)
