### PR TITLE
Update jquery version and do not bust cache everytime

### DIFF
--- a/app/assets/javascripts/modules/geo_viewer.js
+++ b/app/assets/javascripts/modules/geo_viewer.js
@@ -126,8 +126,8 @@
           var wmsoptions = {
             LAYERS: dataAttributes.layers,
             BBOX: map.getBounds().toBBoxString(),
-            WIDTH: $('#sul-embed-geo-map').width(),
-            HEIGHT: $('#sul-embed-geo-map').height(),
+            WIDTH: Math.round($('#sul-embed-geo-map').width()),
+            HEIGHT: Math.round($('#sul-embed-geo-map').height()),
             QUERY_LAYERS: dataAttributes.layers,
             X: Math.round(e.containerPoint.x),
             Y: Math.round(e.containerPoint.y),

--- a/app/views/embed/body/_file.html.erb
+++ b/app/views/embed/body/_file.html.erb
@@ -78,6 +78,6 @@
         <% end %>
       <% end %>
     </ul>
-    <script>;jQuery.getScript("<%= asset_url('file.js') %>");</script>
+    <script>;jQuery.ajax({url: "<%= asset_url('file.js') %>", cache: true, dataType: 'script'});</script>
   </div>
 </div>

--- a/app/views/embed/body/_geo.html.erb
+++ b/app/views/embed/body/_geo.html.erb
@@ -5,5 +5,5 @@
   
   <% end %>
   
-  <script>;jQuery.getScript("<%= asset_url('geo.js') %>");</script>
+  <script>;jQuery.ajax({url: "<%= asset_url('geo.js') %>", cache: true, dataType: 'script'});</script>
 </div>

--- a/app/views/embed/body/_m3_viewer.html.erb
+++ b/app/views/embed/body/_m3_viewer.html.erb
@@ -7,5 +7,5 @@
     style='height: <%= viewer.body_height%>px; width:100%'>
   </div>
   
-  <script>;jQuery.getScript("<%= asset_url('m3.js') %>");</script>
+  <script>;jQuery.ajax({url: "<%= asset_url('m3.js') %>", cache: true, dataType: 'script'});</script>
 </div>

--- a/app/views/embed/body/_media.html.erb
+++ b/app/views/embed/body/_media.html.erb
@@ -1,5 +1,5 @@
 <div class='sul-embed-body sul-embed-media' style="height: <%= viewer.body_height %>px"
   data-sul-embed-theme="<%= asset_url('media.css') %>">
   <%= Embed::MediaTag.new(viewer).to_html.html_safe %>
-  <script>;jQuery.getScript("<%= asset_url('media.js') %>");</script>
+  <script>;jQuery.ajax({url: "<%= asset_url('media.js') %>", cache: true, dataType: 'script'});</script>
 </div>

--- a/app/views/embed/body/_was_seed.html.erb
+++ b/app/views/embed/body/_was_seed.html.erb
@@ -17,5 +17,5 @@
       <% end %>
     </ul>
   </div>
-  <script>;jQuery.getScript("<%= asset_url('was_seed.js') %>");</script>
+  <script>;jQuery.ajax({url: "<%= asset_url('was_seed.js') %>", cache: true, dataType: 'script'});</script>
 </div>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,7 +8,7 @@ stacks_url: 'https://stacks.stanford.edu'
 iiif_info_url: 'https://library.stanford.edu/iiif/viewers'
 enable_media_viewer?: <%= true %>
 embed_iframe_url: 'https://embed.stanford.edu/iframe'
-jquery_version: '2.2.4'
+jquery_version: '3.4.1'
 geo_external_url: 'https://earthworks.stanford.edu/catalog/stanford-'
 geo_wms_url: 'https://geowebservices.stanford.edu/geoserver/wms/'
 was_thumbs_url: 'https://thumbnail-service-example.edu'


### PR DESCRIPTION
Upon a further review of how we load javascripts, :sad_kitty: we have been cache busting all of the javascript loading (not UV).

I can't think of a reason why we would need to cache bust using jQuery, since sprockets will fingerprint for us.

Source: https://api.jquery.com/jQuery.getScript/#caching-requests