### PR TITLE
Add share plugin

### DIFF
--- a/app/assets/javascripts/modules/m3_viewer.js
+++ b/app/assets/javascripts/modules/m3_viewer.js
@@ -1,4 +1,4 @@
-import Mirador from 'mirador';
+import Mirador from 'mirador/dist/es/src/index.js';
 
 export default class M3Viewer {
   static init() {

--- a/app/assets/javascripts/modules/m3_viewer.js
+++ b/app/assets/javascripts/modules/m3_viewer.js
@@ -1,4 +1,6 @@
 import Mirador from 'mirador/dist/es/src/index.js';
+import miradorShareDialogPlugin from 'mirador-share-plugin/es/MiradorShareDialog.js';
+import miradorSharePlugin from 'mirador-share-plugin/es/miradorSharePlugin.js';
 
 export default class M3Viewer {
   static init() {
@@ -6,7 +8,16 @@ export default class M3Viewer {
     var data = $el.data();
     Mirador.viewer({
       id: 'sul-embed-m3',
-
+      miradorSharePlugin: {
+        dragAndDropInfoLink: 'https://library.stanford.edu/projects/international-image-interoperability-framework/viewers',
+        shareLink: {
+          enabled: true,
+          manifestIdReplacePattern: [
+            /\/iiif\/manifest/,
+            '',
+          ],
+        },
+      },
       selectedTheme: 'sul',
       themes: {
         sul: {
@@ -46,6 +57,8 @@ export default class M3Viewer {
         enabled: false,
         showZoomControls: true
       }
-    });
+    }, [
+      miradorSharePlugin, miradorShareDialogPlugin,
+    ]);
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   "dependencies": {
     "@rails/webpacker": "^4.0.7",
     "list.js": "1.1.1",
-    "mirador": "^3.0.0-alpha.9"
+    "mirador": "^3.0.0-alpha.9",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
   },
   "devDependencies": {
     "webpack-dev-server": "^3.7.0"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@rails/webpacker": "^4.0.7",
     "list.js": "1.1.1",
     "mirador": "^3.0.0-alpha.9",
+    "mirador-share-plugin": "^0.1.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6144,6 +6144,16 @@ react-dom@^15.4.2:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
+react-dom@^16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
+  integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.6"
+
 react-draggable@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-3.1.1.tgz#ed1db43e09b146805f6d158296e58eae4f768d36"
@@ -6309,6 +6319,16 @@ react@^15.4.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
     prop-types "^15.5.10"
+
+react@^16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
+  integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.6"
 
 read-cache@^1.0.0:
   version "1.0.0"
@@ -6680,6 +6700,14 @@ sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
+scheduler@^0.13.6:
+  version "0.13.6"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
+  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 schema-utils@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4456,6 +4456,11 @@ minizlib@^1.2.1:
   dependencies:
     minipass "^2.2.1"
 
+mirador-share-plugin@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/mirador-share-plugin/-/mirador-share-plugin-0.1.0.tgz#2b63377700407e8a29bae43ff511b69254ffe1fe"
+  integrity sha512-oCaL6jfjvLARm4Qd/OmSVENTALNjFT3qZZEPok7VAj8b4pBM4AxPqJZVP2TNdKqpCdXgqZNeDa7nsnMOR0oi0Q==
+
 mirador@^3.0.0-alpha.9:
   version "3.0.0-alpha.9"
   resolved "https://registry.yarnpkg.com/mirador/-/mirador-3.0.0-alpha.9.tgz#eb9fac99fa360eca0c7ddab9ea21f895467043d3"


### PR DESCRIPTION
Starts integration of mirador-share-plugin into sul-embed.

There will be some console errors until https://github.com/ProjectMirador/mirador-share-plugin/pull/8 is shipped and integrated. (should be ok though)