### PR TITLE
Make node_modules and public/packs linked directories so that assets …

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -21,7 +21,7 @@ set :log_level, :info
 set :linked_files, %w(config/honeybadger.yml config/newrelic.yml)
 
 # Default value for linked_dirs is []
-set :linked_dirs, %w(config/settings log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system)
+set :linked_dirs, %w(config/settings log node_modules tmp/pids tmp/cache tmp/sockets vendor/bundle public/packs public/system)
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }


### PR DESCRIPTION
…are not compiled unless they change and previous packs are available.

Closes #1032 (I took this for a spin in UAT, we should still do some sort of cache invalidation though so that users pick-up on the new viewer code).