### PR TITLE
Set workspace type to single to avoid getting all the mosaic workspace markup

### DIFF
--- a/app/assets/javascripts/modules/m3_viewer.js
+++ b/app/assets/javascripts/modules/m3_viewer.js
@@ -85,6 +85,7 @@ export default {
           },
           workspace: {
             showZoomControls: true,
+            type: 'single',
           },
           workspaceControlPanel: {
             enabled: false,


### PR DESCRIPTION
`single` isn't really a thing, but it triggers appropriate fallback behavior in mirador, so 🤷‍♂.  