### PR TITLE
Add a box-shadow to the m3 viewer's container

### DIFF
--- a/app/assets/stylesheets/m3.scss
+++ b/app/assets/stylesheets/m3.scss
@@ -1,1 +1,8 @@
 @import 'common';
+
+.#{$namespace}-container {
+  border: 0;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.2), 0 2px 1px -1px rgba(0, 0, 0, 0.2);
+  margin: 1px;
+  position: relative;
+}


### PR DESCRIPTION
Fixes #1055 

<img width="650" alt="Screen Shot 2019-07-11 at 21 30 47" src="https://user-images.githubusercontent.com/111218/61102553-2a2e5180-a423-11e9-8bff-106460a1305a.png">

I figured out what happened to our old shadow; we used to have all the mosaic cruft in the DOM and one of the styles we got from upstream was the `box-shadow` I've applied here.
