### PR TITLE
Allow viewers to take the full height/width of the page…

### DIFF
--- a/app/assets/javascripts/modules/was_seed_viewer.js
+++ b/app/assets/javascripts/modules/was_seed_viewer.js
@@ -6,6 +6,13 @@
 
     return {
       init: function() {
+        $('li.sul-embed-was-thumb-item').each(function() {
+
+          // Set all list item widths to their height (making a square)
+          // so that Sly can calculate the container's width appropriately
+          $(this).width($(this).height());
+        });
+
         var $wasThumbFrame = $('.sul-embed-was-seed');
         var dataAttributes = $wasThumbFrame.data();
 
@@ -20,7 +27,7 @@
           activateMiddle: 1,
           activateOn: 'click',
           mouseDragging: 1,
-          touchDragging: 1,       
+          touchDragging: 1,
           releaseSwing: 1,
           scrollBar: $wasThumbScroll,
           dragHandle: 1,

--- a/app/assets/stylesheets/common.scss.erb
+++ b/app/assets/stylesheets/common.scss.erb
@@ -7,17 +7,39 @@
 @import 'modules/shadows';
 @import 'modules/utility';
 
+body {
+  margin: 0;
+  padding: 0;
+}
+
+.#{$namespace}-container {
+  display: flex;
+  flex-direction: column;
+
+  .#{$namespace}-header {
+    flex: 0 1 auto;
+  }
+
+  .#{$namespace}-body {
+    flex: 1 1 auto;
+    overflow-y: scroll; // May need to evaluate this on a viewer by viewer basis
+  }
+
+  .#{$namespace}-footer {
+    flex: 0 1 auto;
+  }
+}
+
+
 .#{$namespace}-container {
   background: $white-color;
   border: 1px solid $color-pantone-405;
   color: $sul-font-color;
   font-family: 'Source Sans Pro', 'Arial Unicode MS', Helvetica, sans-serif;
   font-size: $font-size-base;
+  height: 100vh;
   overflow-x: hidden;
   overflow-y: hidden;
-  width: 1px;
-  min-width: 99%;
-  *width: 99%;
 
   * {
     padding: 0;

--- a/app/assets/stylesheets/file.scss
+++ b/app/assets/stylesheets/file.scss
@@ -2,7 +2,15 @@
 @import 'modules/bootstrap_media';
 @import 'vendor/tooltip';
 
+body {
+  overflow-y: hidden;
+}
+
 .#{$namespace}-container {
+  .#{$namespace}-header {
+    flex-shrink: 0;
+  }
+
   .#{$namespace}-search {
     padding-top: 8px;
 
@@ -19,7 +27,7 @@
   }
 
   .#{$namespace}-body {
-    overflow-y: auto;
+    overflow-y: scroll;
   }
 
   .#{$namespace}-description {
@@ -69,6 +77,8 @@
 
 .#{$namespace}-file-list {
   @include well-container;
+
+  height: 100%;
 }
 
 .#{$namespace}-media-list {

--- a/app/assets/stylesheets/m3.scss
+++ b/app/assets/stylesheets/m3.scss
@@ -3,6 +3,7 @@
 .#{$namespace}-container {
   border: 0;
   box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.2), 0 2px 1px -1px rgba(0, 0, 0, 0.2);
-  margin: 1px;
+  height: calc(100vh - 3px); // Give a little space for the box shadow
+  margin: 0 1px 3px 0;
   position: relative;
 }

--- a/app/assets/stylesheets/media.scss
+++ b/app/assets/stylesheets/media.scss
@@ -5,6 +5,7 @@
 
 .#{$namespace}-media {
   min-height: 175px;
+  overflow-y: hidden !important;
   position: relative;
   text-align: center;
 
@@ -13,13 +14,19 @@
     width: 100%;
   }
 
-  .#{$namespace}-many-media {
-    margin-bottom: $sul-media-index-height;
+  .#{$namespace}-media-file {
+    height: 100%;
+
+    &.#{$namespace}-many-media {
+      height: calc(100% - #{$sul-media-index-height}) !important;
+      padding-bottom: $sul-media-index-height;
+    }
   }
 }
 
 .#{$namespace}-media-wrapper {
   display: inline-block;
+  height: 100%;
   position: relative;
   text-align: center;
   width: 100%;

--- a/app/assets/stylesheets/modules/thumb_slider.scss
+++ b/app/assets/stylesheets/modules/thumb_slider.scss
@@ -17,9 +17,9 @@ $thumb-slider-background-color: $sul-background;
 
 .#{$namespace}-hidden-slider-object,
 .#{$namespace}-hidden-slider-object * {
-  height: 0;
-  visibility: hidden;
-  width: 0;
+  height: 0 !important;
+  visibility: hidden !important;
+  width: 0 !important;
 }
 
 .#{$namespace}-thumb-slider-open-close {

--- a/app/assets/stylesheets/virtex_3d.scss
+++ b/app/assets/stylesheets/virtex_3d.scss
@@ -25,6 +25,7 @@ $loader-black-bg: 'data:image/gif;base64,R0lGODlhFAAUAMQSAGxsbFpaWnh4eEZGRhwcHD8
   }
 
   .virtex {
+    height: 100%;
     width: 100%;
 
     // scss-lint:disable ImportantRule SelectorDepth

--- a/app/assets/stylesheets/was_seed.scss
+++ b/app/assets/stylesheets/was_seed.scss
@@ -4,15 +4,23 @@
 @import 'modules/slider';
 @import 'modules/shadows';
 
+$sly-slider-height: 10px;
+
 .#{$namespace}-was-seed {
   background-color: $sul-background;
+  height: calc(100% - #{$sly-slider-height});
   padding: 0;
  }
- 
+
 .#{$namespace}-was-thumb-list {
+  height: calc(100% - (#{$sly-slider-height} + 10px));
   list-style: none;
   padding: 10px;
  }
+
+.#{$namespace}-was-thumb-item-img {
+  height: calc(100% - (#{$sly-slider-height} + 30px));
+}
 
 .#{$namespace}-was-thumb-item-date a {
   &:after {
@@ -23,6 +31,7 @@
 
 .#{$namespace}-was-thumb-item {
   float: left;
+  height: 100%;
   margin: 2px 2px 10px 2px; //top right bottom left
 
   &:hover {
@@ -34,7 +43,7 @@
   &.active {
     @include shadow(2);
     background-color: $white-color;
-    
+
     a {
       font-size: 1.2em;
       font-weight: 400;
@@ -43,6 +52,7 @@
 }
 
 .#{$namespace}-was-thumb-item-div {
+  height: 100%;
   margin: 5px;
   text-align: center;
 }

--- a/app/viewers/embed/viewer/common_viewer.rb
+++ b/app/viewers/embed/viewer/common_viewer.rb
@@ -30,7 +30,7 @@ module Embed
       end
 
       def height
-        @request.maxheight || calculate_height
+        @request.maxheight || default_height
       end
 
       def width
@@ -80,18 +80,6 @@ module Embed
         self.class.show_download_count?
       end
 
-      # Set a specific height for the body. We need to subtract
-      # the header and footer heights from the consumer
-      # requested maxheight, otherwise we set a default
-      # which can be set by the specific viewers.
-      def body_height
-        if @request.maxheight
-          @request.maxheight.to_i - (header_height + footer_height)
-        else
-          default_body_height
-        end
-      end
-
       def self.show_download?
         false
       end
@@ -99,12 +87,6 @@ module Embed
       # default is to show the download file count (when download toolbar is shown)
       def self.show_download_count?
         true
-      end
-
-      def container_styles
-        return unless height_style.present? || width_style.present?
-
-        [height_style, width_style].compact.join(' ').to_s
       end
 
       def tooltip_text(file)
@@ -132,43 +114,11 @@ module Embed
 
       private
 
-      def height_style
-        return 'max-height:100%;' if @request.fullheight?
-
-        "max-height:#{height}px;" if height
-      end
-
-      def width_style
-        "max-width:#{width_style_attribute};"
-      end
-
-      def width_style_attribute
-        return '100%' unless width
-
-        "#{width}px"
-      end
-
-      def header_height
-        return 0 unless display_header?
-
-        63
-      end
-
-      def footer_height
-        30
-      end
-
-      def calculate_height
-        return nil unless body_height
-
-        body_height + header_height + footer_height
+      def default_height
+        520
       end
 
       def default_width
-        nil
-      end
-
-      def default_body_height
         nil
       end
     end

--- a/app/viewers/embed/viewer/file.rb
+++ b/app/viewers/embed/viewer/file.rb
@@ -15,26 +15,6 @@ module Embed
         end
       end
 
-      def default_body_height
-        file_specific_body_height - (header_height + footer_height)
-      end
-
-      # This is neccessary because the file viewer's height is meant to be dynamic,
-      # however we need to specify the exact height of the containing iframe (which
-      # will give us extra whitespace below the embed viewer unless we do this)
-      def file_specific_body_height
-        case @purl_object.all_resource_files.count
-        when 1
-          200
-        when 2
-          275
-        when 3
-          375
-        else
-          400
-        end
-      end
-
       def self.supported_types
         [:file]
       end
@@ -51,7 +31,7 @@ module Embed
 
       def display_file_search?
         @display_file_search ||= begin
-          @request.params[:hide_search] != 'true' &&
+          !@request.hide_search? &&
             @purl_object.contents.map(&:files).flatten.length >= min_files_to_search
         end
       end
@@ -78,6 +58,33 @@ module Embed
       end
 
       private
+
+      def default_height
+        file_specific_height + header_height
+      end
+
+      def header_height
+        return 68 if !request.hide_title? && display_file_search?
+        return 40 if !request.hide_title? || display_file_search?
+
+        0
+      end
+
+      # This is neccessary because the file viewer's height is meant to be dynamic,
+      # however we need to specify the exact height of the containing iframe (which
+      # will give us extra whitespace below the embed viewer unless we do this)
+      def file_specific_height
+        case @purl_object.all_resource_files.count
+        when 1
+          92
+        when 2
+          191
+        when 3
+          226
+        else
+          330
+        end
+      end
 
       ##
       # Creates a pretty date for display

--- a/app/viewers/embed/viewer/file.rb
+++ b/app/viewers/embed/viewer/file.rb
@@ -7,6 +7,12 @@ module Embed
         'embed/template/file'
       end
 
+      def height
+        return default_height if @request.maxheight.to_i > default_height
+
+        super
+      end
+
       def file_type_icon(mimetype)
         if Constants::FILE_ICON[mimetype].nil?
           'sul-i-file-new-1'

--- a/app/viewers/embed/viewer/geo.rb
+++ b/app/viewers/embed/viewer/geo.rb
@@ -13,7 +13,7 @@ module Embed
       def map_element_options
         options = {
           id: 'sul-embed-geo-map',
-          style: "height: #{body_height}px",
+          style: 'height: 100%',
           'data-bounding-box' => @purl_object.bounding_box.to_s
         }
         if @purl_object.public?
@@ -22,10 +22,6 @@ module Embed
         end
         options['data-index-map'] = file_url('index_map.json') if index_map?
         options
-      end
-
-      def default_body_height
-        400
       end
 
       def self.supported_types
@@ -46,6 +42,12 @@ module Embed
 
       def external_url_text
         'View this in EarthWorks'
+      end
+
+      private
+
+      def default_height
+        493
       end
     end
   end

--- a/app/viewers/embed/viewer/m3_viewer.rb
+++ b/app/viewers/embed/viewer/m3_viewer.rb
@@ -21,21 +21,6 @@ module Embed
         @manifest_json ||= JSON.parse(@purl_object.manifest_json_response)
       end
 
-      ##
-      # Sets the default body height
-      def default_body_height
-        420
-      end
-
-      # The Mirador UI provides its own header and footer integrated into the viewer height itself.
-      def header_height
-        0
-      end
-
-      def footer_height
-        0
-      end
-
       def show_attribution_panel?
         purl_object.collections.any? do |druid|
           Settings.collections_to_show_attribution.include?(druid)

--- a/app/viewers/embed/viewer/media.rb
+++ b/app/viewers/embed/viewer/media.rb
@@ -24,8 +24,8 @@ module Embed
 
       private
 
-      def default_body_height
-        400 - (header_height + footer_height)
+      def default_height
+        400
       end
     end
   end

--- a/app/viewers/embed/viewer/pdf_viewer.rb
+++ b/app/viewers/embed/viewer/pdf_viewer.rb
@@ -31,12 +31,6 @@ module Embed
 
       private
 
-      ##
-      # Sets the default body height
-      def default_body_height
-        420 - (header_height + footer_height)
-      end
-
       def document_resource_files
         purl_object.contents.select { |content| content.type == 'document' }.map(&:files).flatten
       end

--- a/app/viewers/embed/viewer/virtex_3d_viewer.rb
+++ b/app/viewers/embed/viewer/virtex_3d_viewer.rb
@@ -13,12 +13,6 @@ module Embed
         end
       end
 
-      ##
-      # Sets the default body height
-      def default_body_height
-        420
-      end
-
       def fullscreen?
         true
       end
@@ -29,6 +23,12 @@ module Embed
 
       def self.supported_types
         %i[3d]
+      end
+
+      private
+
+      def default_height
+        513
       end
     end
   end

--- a/app/viewers/embed/viewer/was_seed.rb
+++ b/app/viewers/embed/viewer/was_seed.rb
@@ -27,16 +27,12 @@ module Embed
         'View this in the Stanford Web Archive Portal'
       end
 
-      def default_body_height
-        260
-      end
+      private
 
-      def item_size
-        [body_height - 60, body_height - 60]
-      end
+      def default_height
+        return 274 if request.hide_title?
 
-      def image_height
-        item_size[0] - 24
+        353
       end
     end
   end

--- a/app/views/embed/body/_file.html.erb
+++ b/app/views/embed/body/_file.html.erb
@@ -1,7 +1,6 @@
 <div class='sul-embed-body sul-embed-file'
       data-sul-embed-theme="<%= viewer.asset_url('file.css') %>"
-      data-sul-icons="<%= viewer.asset_url('sul_icons.css') %>"
-      style="max-height: <%= viewer.body_height %>px">
+      data-sul-icons="<%= viewer.asset_url('sul_icons.css') %>">
   <div class='sul-embed-file-list'>
     <% if viewer.purl_object.embargoed? %>
       <div class='sul-embed-embargo-message'>

--- a/app/views/embed/body/_geo.html.erb
+++ b/app/views/embed/body/_geo.html.erb
@@ -1,12 +1,11 @@
 <div class='sul-embed-body sul-embed-geo'
-     style="max-height: <%= viewer.body_height %>px"
      data-sul-embed-theme="<%= asset_url('geo.css') %>"
      data-sul-icons="<%= viewer.asset_url('sul_icons.css') %>">
-  <div id="sul-embed-geo-sidebar" class="" style="display: none; max-height: <%= viewer.body_height %>;">
+  <div id="sul-embed-geo-sidebar" class="" style="display: none;">
   </div>
   <%= content_tag :div, viewer.map_element_options do %>
-  
+
   <% end %>
-  
+
   <script>;jQuery.ajax({url: "<%= asset_url('geo.js') %>", cache: true, dataType: 'script'});</script>
 </div>

--- a/app/views/embed/body/_m3_viewer.html.erb
+++ b/app/views/embed/body/_m3_viewer.html.erb
@@ -1,4 +1,4 @@
-<div class='sul-embed-body sul-embed-m3' style="max-height: <%= viewer.body_height %>px" data-sul-embed-theme="<%= asset_url('m3.css') %>">
+<div class='sul-embed-body sul-embed-m3' data-sul-embed-theme="<%= asset_url('m3.css') %>">
   <div
     id='sul-embed-m3'
     class='m3'
@@ -8,8 +8,7 @@
     data-hide-title='<%= viewer.request.hide_title? %>'
     data-show-attribution='<%= viewer.show_attribution_panel? %>'
     data-search='<%= viewer.search %>'
-    data-suggested-search='<%= viewer.suggested_search %>'
-    style='height: <%= viewer.body_height%>px; width:100%'>
+    data-suggested-search='<%= viewer.suggested_search %>'>
   </div>
 
   <script>;jQuery.ajax({url: "<%= asset_pack_url('m3.js') %>", cache: true, dataType: 'script'});</script>

--- a/app/views/embed/body/_media.html.erb
+++ b/app/views/embed/body/_media.html.erb
@@ -1,6 +1,6 @@
-<div class='sul-embed-body sul-embed-media' style="height: <%= viewer.body_height %>px"
-  data-sul-embed-theme="<%= asset_url('media.css') %>"
-  data-sul-icons="<%= viewer.asset_url('sul_icons.css') %>">
+<div class='sul-embed-body sul-embed-media'
+     data-sul-embed-theme="<%= asset_url('media.css') %>"
+     data-sul-icons="<%= viewer.asset_url('sul_icons.css') %>">
   <%= Embed::MediaTag.new(viewer).to_html.html_safe %>
   <script>;jQuery.ajax({url: "<%= asset_url('media.js') %>", cache: true, dataType: 'script'});</script>
 </div>

--- a/app/views/embed/body/_pdf_viewer.html.erb
+++ b/app/views/embed/body/_pdf_viewer.html.erb
@@ -1,8 +1,7 @@
 <% # removing 5 pixels from the body height to account for being embedded %>
 <div class='sul-embed-body sul-embed-pdf'
       data-sul-embed-theme="<%= viewer.asset_url('pdf.css') %>"
-      data-sul-icons="<%= viewer.asset_url('sul_icons.css') %>"
-      style="height: <%= viewer.body_height - 5 %>px">
+      data-sul-icons="<%= viewer.asset_url('sul_icons.css') %>">
   <button aria-label="Zoom in" class="button zoom-in">+</button>
   <button aria-label="Zoom out" class="button zoom-out">-</button>
   <button aria-label="Previous page" class="button prev-page">

--- a/app/views/embed/body/_virtex_3d_viewer.html.erb
+++ b/app/views/embed/body/_virtex_3d_viewer.html.erb
@@ -1,4 +1,4 @@
-<div class="sul-embed-3d">
+<div class="sul-embed-3d sul-embed-body">
   <div class="buttons">
     <button aria-label="Zoom in" class="zoom-in">+</button>
     <button aria-label="Zoom out" class="zoom-out">-</button>
@@ -6,7 +6,6 @@
   <div
     id="virtex-3d-viewer"
     class="virtex"
-    style="height: <%= viewer.body_height %>px"
     data-sul-embed-theme="<%= viewer.asset_url('virtex_3d.css') %>"
     data-sul-icons="<%= viewer.asset_url('sul_icons.css') %>"
     data-three-dimensional-file="<%= viewer.three_dimensional_files.first %>"

--- a/app/views/embed/body/_was_seed.html.erb
+++ b/app/views/embed/body/_was_seed.html.erb
@@ -1,13 +1,12 @@
-<div class='sul-embed-body'
+<div class='sul-embed-body sul-embed-was-seed-container'
       data-sul-embed-theme="<%= viewer.asset_url('was_seed.css') %>"
-      data-sul-icons="<%= viewer.asset_url('sul_icons.css') %>"
-      style="max-height: <%= viewer.body_height %>px">
+      data-sul-icons="<%= viewer.asset_url('sul_icons.css') %>">
   <div class='sul-embed-was-seed' data-sul-thumbs-list-count="<%= viewer.thumbs_list.length %>">
     <ul class='sul-embed-was-thumb-list'>
       <% viewer.thumbs_list.each do |thumb_record| %>
         <li class='sul-embed-was-thumb-item'>
-          <div class='sul-embed-was-thumb-item-div' style="height: <%= viewer.item_size[0] %>px; width: <%= viewer.item_size[1] %>px;">
-            <img class='sul-embed-was-thumb-item-img' style="height: <%= viewer.image_height %>px;" src="<%= thumb_record['thumbnail_uri'] %>">
+          <div class='sul-embed-was-thumb-item-div'>
+            <img class='sul-embed-was-thumb-item-img' src="<%= thumb_record['thumbnail_uri'] %>">
             <div class='sul-embed-was-thumb-item-date'>
               <a href="<%= thumb_record['memento_uri'] %>" target='_parent'>
                 <%= viewer.format_memento_datetime(thumb_record['memento_datetime']) %>

--- a/app/views/embed/iiif.html.erb
+++ b/app/views/embed/iiif.html.erb
@@ -16,7 +16,7 @@
     </style>
   </head>
   <body>
-    <div class="sul-embed-container sul-embed-fullheight" id='sul-embed-object' style='display:none;'>
+    <div class="sul-embed-container" id='sul-embed-object' style='display:none;'>
       <div class='sul-embed-body sul-embed-m3' style="max-height:100%;" data-sul-embed-theme="<%= asset_url('m3.css') %>">
         <div
           id='sul-embed-m3'

--- a/app/views/embed/template/_file.html.erb
+++ b/app/views/embed/template/_file.html.erb
@@ -1,5 +1,4 @@
-<div class="sul-embed-container<%= ' sul-embed-fullheight' if viewer.request.fullheight? %>"
-  id='sul-embed-object' style='display:none; <%= viewer.container_styles %>'>
+<div class="sul-embed-container" id='sul-embed-object' style='display:none;'>
   <%= render 'header/file', viewer: viewer if viewer.display_header? %>
   <%= render 'body/file', viewer: viewer %>
   <%= render 'metadata_panel', viewer: viewer %>

--- a/app/views/embed/template/_geo.html.erb
+++ b/app/views/embed/template/_geo.html.erb
@@ -1,5 +1,4 @@
-<div class="sul-embed-container <%= 'sul-embed-fullheight' if viewer.request.fullheight? %>"
-  id='sul-embed-object' style='display:none; <%= viewer.container_styles %>'>
+<div class="sul-embed-container" id='sul-embed-object' style='display:none;'>
   <%= render 'header/geo', viewer: viewer if viewer.display_header? %>
   <%= render 'body/geo', viewer: viewer %>
   <%= render 'metadata_panel', viewer: viewer %>

--- a/app/views/embed/template/_m3_viewer.html.erb
+++ b/app/views/embed/template/_m3_viewer.html.erb
@@ -1,4 +1,3 @@
-<div class="sul-embed-container <%= 'sul-embed-fullheight' if viewer.request.fullheight? %>"
-  id='sul-embed-object' style='display:none; <%= viewer.container_styles %>'>
+<div class="sul-embed-container" id='sul-embed-object' style='display:none;'>
   <%= render 'body/m3_viewer', viewer: viewer %>
- </div>
+</div>

--- a/app/views/embed/template/_media.html.erb
+++ b/app/views/embed/template/_media.html.erb
@@ -1,5 +1,4 @@
-<div class="sul-embed-container<%= ' sul-embed-fullheight' if viewer.request.fullheight? %>"
-  id='sul-embed-object' style='display:none; <%= viewer.container_styles %>'>
+<div class="sul-embed-container" id='sul-embed-object' style='display:none;'>
   <%= render 'header/media', viewer: viewer if viewer.display_header? %>
   <%= render 'body/media', viewer: viewer %>
   <%= render 'metadata/media', viewer: viewer %>

--- a/app/views/embed/template/_pdf_viewer.html.erb
+++ b/app/views/embed/template/_pdf_viewer.html.erb
@@ -1,5 +1,4 @@
-<div class="sul-embed-container<%= ' sul-embed-fullheight' if viewer.request.fullheight? %>"
-  id='sul-embed-object' style='display:none; <%= viewer.container_styles %>'>
+<div class="sul-embed-container" id='sul-embed-object' style='display:none;'>
   <%= render 'header/pdf_viewer', viewer: viewer if viewer.display_header? %>
   <%= render 'body/pdf_viewer', viewer: viewer %>
   <%= render 'metadata_panel', viewer: viewer %>

--- a/app/views/embed/template/_virtex_3d_viewer.html.erb
+++ b/app/views/embed/template/_virtex_3d_viewer.html.erb
@@ -1,5 +1,4 @@
-<div class="sul-embed-container<%= ' sul-embed-fullheight' if viewer.request.fullheight? %>"
-  id='sul-embed-object' style='display:none; <%= viewer.container_styles %>'>
+<div class="sul-embed-container" id='sul-embed-object' style='display:none;'>
   <%= render 'header/virtex_3d_viewer', viewer: viewer if viewer.display_header? %>
   <%= render 'body/virtex_3d_viewer', viewer: viewer %>
   <%= render 'metadata_panel', viewer: viewer %>

--- a/app/views/embed/template/_was_seed.html.erb
+++ b/app/views/embed/template/_was_seed.html.erb
@@ -1,5 +1,4 @@
-<div class="sul-embed-container <%= 'sul-embed-fullheight' if viewer.request.fullheight? %>"
-  id='sul-embed-object' style='display:none; <%= viewer.container_styles %>'>
+<div class="sul-embed-container" id='sul-embed-object' style='display:none;'>
   <%= render 'header/was_seed', viewer: viewer if viewer.display_header? %>
   <%= render 'body/was_seed', viewer: viewer %>
   <%= render 'metadata_panel', viewer: viewer %>

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -6,7 +6,6 @@ module Embed
   # and HLS is used as a <source> within the <video> or <audio> tag.
   class MediaTag
     SUPPORTED_MEDIA_TYPES = %i[audio video].freeze
-    MEDIA_INDEX_CONTROL_HEIGHT = 24
 
     include Embed::StacksImage
 
@@ -49,9 +48,9 @@ module Embed
             #{poster_attribute(file)}
             controls='controls'
             aria-labelledby="access-restricted-message-div-#{file_index}"
-            class="#{'sul-embed-many-media' if many_primary_files?}"
-            style="height: #{media_element_height}; display:none;"
-            height="#{media_element_height}">
+            class="sul-embed-media-file #{'sul-embed-many-media' if many_primary_files?}"
+            style="display:none; height: 100%;"
+            height="100%">
             #{enabled_streaming_sources(file)}
           </#{type}>
         HTML
@@ -63,14 +62,14 @@ module Embed
         "<img
           src='#{stacks_thumb_url(@purl_document.druid, file.title)}'
           class='sul-embed-media-thumb #{'sul-embed-many-media' if many_primary_files?}'
-          style='max-height: #{media_element_height}'
         />"
       end
     end
 
     def media_wrapper(thumbnail: '', file: nil, &block)
       <<-HTML.strip_heredoc
-        <div data-stanford-only="#{file.try(:stanford_only?)}"
+        <div style="height: 100%"
+             data-stanford-only="#{file.try(:stanford_only?)}"
              data-location-restricted="#{file.try(:location_restricted?)}"
              data-file-label="#{file.label}"
              data-slider-object="#{file_index}"
@@ -90,12 +89,6 @@ module Embed
            type='#{streaming_settings_for(streaming_type)[:mimetype]}'>
         </source>"
       end.join
-    end
-
-    def media_element_height
-      return "#{viewer.body_height}px" unless many_primary_files?
-
-      "#{viewer.body_height.to_i - MEDIA_INDEX_CONTROL_HEIGHT}px"
     end
 
     def many_primary_files?

--- a/lib/embed/request.rb
+++ b/lib/embed/request.rb
@@ -67,7 +67,6 @@ module Embed
 
     def as_url_params
       p = params.slice(
-        :maxheight, :maxwidth, :fullheight,
         :hide_title, :hide_embed, :hide_search, :hide_download,
         :min_files_to_search,
         :canvas_id, :canvas_index,

--- a/spec/features/embed_this_panel_spec.rb
+++ b/spec/features/embed_this_panel_spec.rb
@@ -24,7 +24,7 @@ describe 'embed this panel', js: true do
     end
     it 'includes height and width attributes' do
       page.find('[data-sul-embed-toggle="sul-embed-embed-this-panel"]', match: :first).click
-      expect(page.find('.sul-embed-embed-this-panel textarea').value).to match(%r{<iframe.*height="200px".*/>}m)
+      expect(page.find('.sul-embed-embed-this-panel textarea').value).to match(%r{<iframe.*height="132px".*/>}m)
       expect(page.find('.sul-embed-embed-this-panel textarea').value).to match(%r{<iframe.*width="100%".*/>}m)
     end
 

--- a/spec/features/was_seed_viewer_spec.rb
+++ b/spec/features/was_seed_viewer_spec.rb
@@ -25,13 +25,30 @@ describe 'was seed viewer public', js: true do
       end
     end
     it 'selects the one before the last to be active' do
-      expect(page).to have_css('.active', count: 1)
-      expect(page.find('.active').text).to eq('12-Oct-2013')
+      expect(page).to have_css('.active', count: 1, visible: true)
+
+      within '.active' do
+        expect(page).to have_css('.sul-embed-was-thumb-item-date', text: '12-Oct-2013')
+      end
     end
+
     it 'changes the active one with the select' do
-      expect(page.find('.active').text).to eq('12-Oct-2013')
-      page.first('.sul-embed-was-thumb-item').click
-      expect(page.find('.active').text).to eq('29-Nov-2012')
+      expect(page).to have_css('.active', count: 1, visible: true)
+
+      within '.active' do
+        expect(page).to have_css('.sul-embed-was-thumb-item-date', text: '12-Oct-2013', visible: true)
+      end
+
+      first_item = page.first('.sul-embed-was-thumb-item')
+      first_item_text = first_item.find('.sul-embed-was-thumb-item-date').text
+
+      expect(first_item_text).not_to eq('12-Oct-2013') # Make sure the first one is not the one we're already on
+
+      first_item.click
+
+      within '.active' do
+        expect(page).to have_css('.sul-embed-was-thumb-item-date', text: first_item_text, visible: true)
+      end
     end
 
     it 'links to the memento URI with a _parent target' do

--- a/spec/lib/embed/embed_this_panel_spec.rb
+++ b/spec/lib/embed/embed_this_panel_spec.rb
@@ -121,10 +121,14 @@ describe Embed::EmbedThisPanel do
 
       it 'includes the relevant request parameters' do
         src = subject.find('iframe')['src']
-        expect(src).to match(/&maxheight=555/)
-        expect(src).to match(/&maxwidth=666/)
         expect(src).to match(/&hide_embed=true/)
         expect(src).to match(/&hide_title=true/)
+      end
+
+      it 'does not include the maxheight / maxwidth parameters (these are handled in the iframe)' do
+        src = subject.find('iframe')['src']
+        expect(src).not_to match(/maxheight/)
+        expect(src).not_to match(/maxwidth/)
       end
     end
   end

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -43,8 +43,8 @@ describe Embed::MediaTag do
 
     context 'single video' do
       let(:purl) { single_video_purl }
-      it 'includes a height attribute equal to the body height' do
-        expect(subject).to have_css("video[height='#{viewer.body_height}px']", visible: false)
+      it 'includes a 100% height attribute' do
+        expect(subject).to have_css("video[height='100%']", visible: false)
       end
 
       it 'shows location restricted messages to the screen reader' do
@@ -61,12 +61,6 @@ describe Embed::MediaTag do
       let(:purl) { video_purl_unrestricted }
       it 'does not show any location restricted messages' do
         expect(subject).not_to have_css('.sul-embed-media-access-restricted .line1', text: 'Restricted media cannot be played in your location')
-      end
-    end
-
-    context 'multiple videos' do
-      it 'includes a height attribute equal to the body height minus some px to make way for the thumb slider' do
-        expect(subject).to have_css('video[height="276px"]', visible: false)
       end
     end
 
@@ -224,10 +218,6 @@ describe Embed::MediaTag do
         expect(previewable_element).to match(
           %r{src='https://stacks.*/iiif/.*abc123/full/\!400,400.*'}
         )
-      end
-
-      it 'defines a max-height on the image that is equal to the viewer body height' do
-        expect(previewable_element).to match(/style='max-height: 276px'/)
       end
 
       it 'includes a class that indicates that there is are many media objects (to make room for the slider control)' do

--- a/spec/lib/embed/viewer/common_viewer_spec.rb
+++ b/spec/lib/embed/viewer/common_viewer_spec.rb
@@ -81,16 +81,4 @@ describe Embed::Viewer::CommonViewer do
       expect(file_viewer.iframe_title).to eq 'File viewer'
     end
   end
-
-  describe '#body_height' do
-    it 'is the default_body_height when no maxheight is provided' do
-      expect(file_viewer).to receive(:default_body_height).and_return(200)
-      expect(file_viewer.body_height).to eq 200
-    end
-
-    it 'subtracts the header and footer height' do
-      expect(request).to receive(:maxheight).at_least(:once).and_return(200)
-      expect(file_viewer.body_height).to be < 200
-    end
-  end
 end

--- a/spec/lib/embed/viewer/common_viewer_spec.rb
+++ b/spec/lib/embed/viewer/common_viewer_spec.rb
@@ -19,6 +19,7 @@ describe Embed::Viewer::CommonViewer do
       expect(request).to receive(:maxheight).at_least(:once).and_return(100)
       expect(request).to receive(:maxwidth).at_least(:once).and_return(200)
       stub_request(request)
+      stub_purl_response_with_fixture(multi_file_purl)
       expect(file_viewer.height).to eq 100
       expect(file_viewer.width).to eq 200
     end

--- a/spec/lib/embed/viewer/file_spec.rb
+++ b/spec/lib/embed/viewer/file_spec.rb
@@ -19,6 +19,33 @@ describe Embed::Viewer::File do
       expect(Embed::Viewer::File.supported_types).to eq [:file]
     end
   end
+
+  describe 'height' do
+    before { stub_purl_response_with_fixture(multi_file_purl) }
+
+    context 'when the requested maxheight is larger than the default height' do
+      let(:request) { Embed::Request.new(url: 'http://purl.stanford.edu/abc123', maxheight: 600) }
+
+      it 'is the default height (max is a maximum, we can be smaller)' do
+        expect(file_viewer.height).to eq 231 # 2 files + header
+      end
+    end
+
+    context 'when the requested maxheight is smaller than the default height' do
+      let(:request) { Embed::Request.new(url: 'http://purl.stanford.edu/abc123', maxheight: 200) }
+
+      it 'is the requested maxheight' do
+        expect(file_viewer.height).to eq 200
+      end
+    end
+
+    context 'whne there is no requseted maxheight' do
+      it 'is the default height' do
+        expect(file_viewer.height).to eq 231 # 2 files + header
+      end
+    end
+  end
+
   describe 'default_height' do
     context 'when title and search is hidden' do
       before do

--- a/spec/lib/embed/viewer/geo_spec.rb
+++ b/spec/lib/embed/viewer/geo_spec.rb
@@ -13,13 +13,6 @@ describe Embed::Viewer::Geo do
     end
   end
 
-  describe '.default_body_height' do
-    it 'returns the default_body_height' do
-      stub_request(request)
-      expect(geo_viewer.default_body_height).to eq 400
-    end
-  end
-
   describe '.external_url' do
     it 'should build the external url based on settings and druid value' do
       stub_request(request)
@@ -31,7 +24,7 @@ describe Embed::Viewer::Geo do
     it 'for public content' do
       stub_purl_response_and_request(geo_purl_public, request)
       expect(geo_viewer.map_element_options).to be_an Hash
-      expect(geo_viewer.map_element_options).to include style: 'height: 400px'
+      expect(geo_viewer.map_element_options).to include style: 'height: 100%'
       expect(geo_viewer.map_element_options).to include id: 'sul-embed-geo-map'
       expect(geo_viewer.map_element_options).to include 'data-bounding-box' => '[["-1.478794", "29.572742"], ["4.234077", "35.000308"]]'
       expect(geo_viewer.map_element_options).to include 'data-wms-url' => 'https://geowebservices.stanford.edu/geoserver/wms/'
@@ -41,7 +34,7 @@ describe Embed::Viewer::Geo do
     it 'for restricted content' do
       stub_purl_response_and_request(geo_purl_restricted, request)
       expect(geo_viewer.map_element_options).to be_an Hash
-      expect(geo_viewer.map_element_options).to include style: 'height: 400px'
+      expect(geo_viewer.map_element_options).to include style: 'height: 100%'
       expect(geo_viewer.map_element_options).to include id: 'sul-embed-geo-map'
       expect(geo_viewer.map_element_options).to include 'data-bounding-box' => '[["38.298673", "-123.387626"], ["39.399103", "-122.528843"]]'
       expect(geo_viewer.map_element_options).to_not include 'data-layers'

--- a/spec/lib/embed/viewer/m3_viewer_spec.rb
+++ b/spec/lib/embed/viewer/m3_viewer_spec.rb
@@ -16,8 +16,6 @@ describe Embed::Viewer::M3Viewer do
     end
   end
 
-  it { is_expected.to have_attributes(header_height: 0, footer_height: 0) }
-
   describe '#canvas_index' do
     context 'with an explicit index' do
       let(:request) { Embed::Request.new(url: 'http://purl.stanford.edu/abc123', canvas_index: 5) }

--- a/spec/lib/embed/viewer/was_seed_spec.rb
+++ b/spec/lib/embed/viewer/was_seed_spec.rb
@@ -46,29 +46,25 @@ describe Embed::Viewer::WasSeed do
     end
   end
 
+  describe 'default_height' do
+    it 'defaults to 353' do
+      stub_request(request)
+
+      expect(was_seed_viewer.send(:default_height)).to eq 353
+    end
+
+    it 'is smaller when the title is hidden' do
+      expect(request).to receive(:hide_title?).and_return(true)
+      stub_request(request)
+
+      expect(was_seed_viewer.send(:default_height)).to eq 274
+    end
+  end
+
   describe '.external_url' do
     it 'should build the external url based on wayback url as extracted from prul' do
       stub_purl_response_and_request(was_seed_purl, request)
       expect(was_seed_viewer.external_url).to eq('https://swap.stanford.edu/*/http://naca.central.cranfield.ac.uk/')
-    end
-  end
-
-  describe '.item_size' do
-    it 'returns the item_size based on the default_body_height' do
-      expect(was_seed_viewer.item_size).to eq([200, 200])
-    end
-    it 'returns the item_size based on defined body_height' do
-      request_with_max_height = Embed::Request.new(maxheight: 500, url: purl)
-      customized_was_seed_viewer = Embed::Viewer::WasSeed.new(request_with_max_height)
-
-      expect(customized_was_seed_viewer.item_size).to eq([347, 347])
-    end
-  end
-
-  describe '.image_height' do
-    it 'returns the image_height based on the item_size' do
-      allow(was_seed_viewer).to receive(:item_size).and_return([100, 100])
-      expect(was_seed_viewer.image_height).to eq(76)
     end
   end
 end

--- a/spec/views/embed/template/_file.html.erb_spec.rb
+++ b/spec/views/embed/template/_file.html.erb_spec.rb
@@ -41,15 +41,7 @@ RSpec.describe 'embed/template/_file.html.erb' do
     stub_template 'header/_file.html.erb' => '<div class="sul-embed-header"></div>'
     stub_template '_metadata_panel.html.erb' => '<div class="ul-embed-panel-container"></div>'
     stub_template 'footer/_generic.html.erb' => '<div class="sul-embed-footer"></div>'
-    expect(rendered).to have_css '.sul-embed-container[style="display:none; max-height:200px; max-width:200px;"]', visible: false
-  end
-
-  context 'when the fullheight option is passed' do
-    it 'includes the sul-embed-fullheight class' do
-      allow(request).to receive(:fullheight?).at_least(:once).and_return(true)
-      render
-      expect(rendered).to have_css('.sul-embed-fullheight[style="display:none; max-height:100%; max-width:100%;"]', visible: false)
-    end
+    expect(rendered).to have_css '.sul-embed-container[style="display:none;"]', visible: false
   end
 
   context 'multi_resource_multi_type_purl' do

--- a/spec/views/embed/template/_geo.html.erb_spec.rb
+++ b/spec/views/embed/template/_geo.html.erb_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'embed/template/_geo.html.erb' do
     # visible false because we display:none the container until we've loaded the CSS.
     expect(rendered).to have_css '.sul-embed-geo', visible: false
     expect(rendered).to have_css '#sul-embed-geo-map', visible: false
-    expect(rendered).to have_css('#sul-embed-geo-map[style="height: 400px"]', visible: false)
+    expect(rendered).to have_css('#sul-embed-geo-map[style="height: 100%"]', visible: false)
     expect(rendered).to have_css('#sul-embed-geo-map[data-bounding-box=\'[["-1.478794", "29.572742"], ["4.234077", "35.000308"]]\']', visible: false)
     expect(rendered).to have_css('#sul-embed-geo-map[data-wms-url="https://geowebservices.stanford.edu/geoserver/wms/"]', visible: false)
     expect(rendered).to have_css('#sul-embed-geo-map[data-layers="druid:12345"]', visible: false)

--- a/spec/views/embed/template/_was_seed.html.erb_spec.rb
+++ b/spec/views/embed/template/_was_seed.html.erb_spec.rb
@@ -26,14 +26,11 @@ RSpec.describe 'embed/template/_was_seed.html.erb' do
     expect(rendered).to have_css '.sul-embed-was-thumb-list', visible: false, count: 1
     expect(rendered).to have_css '.sul-embed-was-thumb-item', visible: false, count: 4
     expect(rendered).to have_css '.sul-embed-was-thumb-item-div', visible: false, count: 4
-    expect(rendered).to have_css '.sul-embed-was-thumb-item-div[style="height: 200px; width: 200px;"]', visible: false, count: 4
     expect(rendered).to have_css '.sul-embed-was-seed[data-sul-thumbs-list-count="4"]', visible: false
 
     expect(rendered).to have_css '.sul-embed-was-thumb-item-div a[href="https://swap.stanford.edu/20121129060351/http://naca.central.cranfield.ac.uk/"]', visible: false
     expect(rendered).to have_css '.sul-embed-was-thumb-item-date', text: '29-Nov-2012', visible: false
     expect(rendered).to have_css '.sul-embed-was-thumb-item img[src="https://stacks.stanford.edu/image/iiif/gb089bd2251%2F20121129060351/full/200,/0/default.jpg"]', visible: false
-
-    expect(rendered).to have_css '.sul-embed-was-thumb-item img[style="height: 176px;"]', visible: false
 
     expect(rendered).to have_css '.sul-embed-was-thumb-item-div a[href="https://swap.stanford.edu/20130412231301/http://naca.central.cranfield.ac.uk/"]', visible: false
     expect(rendered).to have_css '.sul-embed-was-thumb-item-date', text: '12-Apr-2013', visible: false


### PR DESCRIPTION
…and only constrain the size in the iframe.

Closes sul-dlss/exhibits#1563

## Background
When our Embed service first launched we did not "sandbox" our content in an iframe like we do today and instead served up the raw HTML through the oEmbed API.  Because the [oEmbed spec](https://oembed.com/) dictates that a maxheight and maxwidth parameter must be obeyed by the content, we have and continue to set dimensions in the content of the viewer based on these parameters sent through the API.  This has always necessitated some pretty annoying pixel math to happen in various places to ensure that our content was the correct size with various combinations of header/footer present (as well as retaining knowledge of how many pixels various elements were).

Some time in 2016 we switched the oEmbed response to return an iframe instead of the raw content (#609).  When this was done, we had the iframe obey the maxheight/maxwidth parameters, but retrained all the height/width calculations in the content that was being rendered in the iframe (under the `/iframe?url={purl}` response).  This all worked out since the height/widths were the same and our math was accurate(-ish).

## Suggested Solution
Only constrain the height/width of the viewer via the iframe and let the content that is delivered in the iframe take up the full height/width of the container.  

## Rationale
As mentioned above, making this change simplifies our viewer code in a few ways.
* We no longer have to handle pixel math
* We no longer have to have knowledge of the size of particular. viewer elements
  * _Note: There is still some knowledge about these elements in the viewer CSS, but this is where that kind of knowledge should live IMO._

Any time a non-default height is specified for the iframe we currently need to also send that height through the URL as the maxheight attribute.  This isn't obvious to a user who may be hand-modifying the size of the iframe (and makes things like the the M3 download plugin have to have knowledge of this possibility)

Other oEmbed implementers (e.g. Youtube) follow this same pattern with their oEmbed service (full-size content w/i the iframe, constrain the size in the iframe itself, and serve the iframe up through the oEmbed API).

## Changes / Improvements
The end goal is that this change will not be obvious at all to _most_ consumers of the oEmbed service.  I've tried to match the current heights that were being used by default (and when users provided their own maxheight then that takes over anyway).  

If users were cutting off the bottom of the embed by manipulating the height parameters sent (to avoid our attribution/copyright statements etc) then this would also prevent them from doing that any longer (not that I have evidence of this happening).

In some cases we were cutting off the bottom of our own viewer w/o realizing it.  In the case of our M3 viewer we have applied box shadow to the right/bottom of the viewer.  However; it appears that we've typically been cutting off the bottom shadow.  Having the viewer always take up 100% space (and then applying padding to match the size of the shadow) allows us to more easily ensure that the styling we intend to apply is visible in all embedded scenarios.

### Before (fw090jw3474)
<img width="1181" alt="fw090jw3474-before" src="https://user-images.githubusercontent.com/96776/77560789-20e2f900-6e7b-11ea-92d7-959f284cf251.png">

### After (fw090jw3474)
<img width="1190" alt="fw090jw3474-after" src="https://user-images.githubusercontent.com/96776/77560813-250f1680-6e7b-11ea-8109-0ba5a74e60f0.png">


One caveat to note is that the File viewer worked a bit differently that the rest of the viewers.  It returned different default heights based on the number of files present.  There were already some incorrect calculations happening there that was always assuming the header was present.  This caused some extra space below the viewer in environments like PURL and SearchWorks (who use the default dimensions but hide the title).

### Before (wt101ks3240)
<img width="214" alt="wt101ks3240-before" src="https://user-images.githubusercontent.com/96776/77477717-00af2d80-6dda-11ea-8130-8eb64569f39f.png">

### After (wt101ks3240)
<img width="346" alt="wt101ks3240-after" src="https://user-images.githubusercontent.com/96776/77477719-0147c400-6dda-11ea-93d8-cbf1065a809b.png">

This was particularly noticeable when File viewers were given a taller maxheight (e.g. Exhibits @ 600px).  We currently display the viewer at the height needed to display the files and then have the reaming space left as white/blank space (which can be confusing as to where that space is coming from).  With this change, the viewer will no longer take up the full space in the maxheight parameter for smaller file lists (when the parameter is larger than necessary).  This should remove this extraneous space where present (sul-dlss/exhibits#1563).  I believe this is still in the spirit of the spec given that we never deliver content **larger** than the requested maximum.

### Before (wt101ks3240 in an exhibit)
<img width="354" alt="Screen Shot 2020-03-24 at 5 31 19 PM" src="https://user-images.githubusercontent.com/96776/77489645-fa2eaf00-6df5-11ea-99b1-c719ce8f1c25.png">

### After (wt101ks3240 in an exhibit)
<img width="611" alt="Screen Shot 2020-03-24 at 5 28 56 PM" src="https://user-images.githubusercontent.com/96776/77489654-00249000-6df6-11ea-820f-79f840ec4926.png">

