### PR TITLE
Update height calculations for file viewer

### DIFF
--- a/app/assets/stylesheets/file.scss
+++ b/app/assets/stylesheets/file.scss
@@ -77,8 +77,6 @@ body {
 
 .#{$namespace}-file-list {
   @include well-container;
-
-  height: 100%;
 }
 
 .#{$namespace}-media-list {

--- a/app/viewers/embed/viewer/file.rb
+++ b/app/viewers/embed/viewer/file.rb
@@ -70,8 +70,8 @@ module Embed
       end
 
       def header_height
-        return 68 if !request.hide_title? && display_file_search?
-        return 40 if !request.hide_title? || display_file_search?
+        return 68 unless request.hide_title?
+        return 40 if display_file_search?
 
         0
       end
@@ -79,17 +79,16 @@ module Embed
       # This is neccessary because the file viewer's height is meant to be dynamic,
       # however we need to specify the exact height of the containing iframe (which
       # will give us extra whitespace below the embed viewer unless we do this)
+      # Each item is 67px tall w/ a base of 55px we determine heights by: (item count * 67px) + 55px
       def file_specific_height
-        case @purl_object.all_resource_files.count
-        when 1
-          92
-        when 2
-          191
-        when 3
-          226
-        else
-          330
-        end
+        file_count = @purl_object.all_resource_files.count
+        items_to_account_for = if file_count >= 4
+                                 4
+                               else
+                                 file_count
+                               end
+
+        55 + (items_to_account_for * 67)
       end
 
       ##

--- a/app/viewers/embed/viewer/file.rb
+++ b/app/viewers/embed/viewer/file.rb
@@ -66,12 +66,18 @@ module Embed
       private
 
       def default_height
-        file_specific_height + header_height
+        file_specific_height + embargo_message_height + header_height
       end
 
       def header_height
         return 68 unless request.hide_title?
         return 40 if display_file_search?
+
+        0
+      end
+
+      def embargo_message_height
+        return 44 if purl_object.embargoed?
 
         0
       end

--- a/spec/features/embed_this_panel_spec.rb
+++ b/spec/features/embed_this_panel_spec.rb
@@ -24,7 +24,7 @@ describe 'embed this panel', js: true do
     end
     it 'includes height and width attributes' do
       page.find('[data-sul-embed-toggle="sul-embed-embed-this-panel"]', match: :first).click
-      expect(page.find('.sul-embed-embed-this-panel textarea').value).to match(%r{<iframe.*height="132px".*/>}m)
+      expect(page.find('.sul-embed-embed-this-panel textarea').value).to match(%r{<iframe.*height="190px".*/>}m)
       expect(page.find('.sul-embed-embed-this-panel textarea').value).to match(%r{<iframe.*width="100%".*/>}m)
     end
 

--- a/spec/lib/embed/viewer/file_spec.rb
+++ b/spec/lib/embed/viewer/file_spec.rb
@@ -69,6 +69,19 @@ describe Embed::Viewer::File do
       end
     end
 
+    context 'when the item is emargoed' do
+      before do
+        expect(request).to receive(:hide_title?).at_least(:once).and_return(true)
+        expect(request).to receive(:hide_search?).at_least(:once).and_return(true)
+      end
+
+      it 'adds 44 pixels to the height (to avoid unnecessary scroll)' do
+        stub_purl_response_and_request(embargoed_stanford_file_purl, request)
+
+        expect(file_viewer.send(:default_height)).to eq 166 # 122 + 44
+      end
+    end
+
     context 'when the title bar is present' do
       before do
         expect(request).to receive(:hide_title?).at_least(:once).and_return(false)

--- a/spec/lib/embed/viewer/file_spec.rb
+++ b/spec/lib/embed/viewer/file_spec.rb
@@ -27,7 +27,7 @@ describe Embed::Viewer::File do
       let(:request) { Embed::Request.new(url: 'http://purl.stanford.edu/abc123', maxheight: 600) }
 
       it 'is the default height (max is a maximum, we can be smaller)' do
-        expect(file_viewer.height).to eq 231 # 2 files + header
+        expect(file_viewer.height).to eq 257 # 2 files + header
       end
     end
 
@@ -41,7 +41,7 @@ describe Embed::Viewer::File do
 
     context 'whne there is no requseted maxheight' do
       it 'is the default height' do
-        expect(file_viewer.height).to eq 231 # 2 files + header
+        expect(file_viewer.height).to eq 257 # 2 files + header
       end
     end
   end
@@ -53,19 +53,19 @@ describe Embed::Viewer::File do
         expect(request).to receive(:hide_search?).at_least(:once).and_return(true)
       end
 
-      it 'defaults to 400' do
+      it 'defaults to 323' do
         stub_purl_response_and_request(multi_resource_multi_type_purl, request)
-        expect(file_viewer.send(:default_height)).to eq 330
+        expect(file_viewer.send(:default_height)).to eq 323
       end
 
       it 'reduces the height based on the number of files in the object (1 file)' do
         stub_purl_response_and_request(file_purl, request)
-        expect(file_viewer.send(:default_height)).to eq 92
+        expect(file_viewer.send(:default_height)).to eq 122
       end
 
       it 'reduces the height based on the number of files in the object (2 files)' do
         stub_purl_response_and_request(image_purl, request)
-        expect(file_viewer.send(:default_height)).to eq 191
+        expect(file_viewer.send(:default_height)).to eq 189
       end
     end
 
@@ -76,20 +76,36 @@ describe Embed::Viewer::File do
 
       it 'adds the necessary height' do
         stub_purl_response_and_request(file_purl, request)
-        expect(file_viewer.send(:default_height)).to eq 132
+        expect(file_viewer.send(:default_height)).to eq 190
+      end
+    end
+  end
+
+  describe 'header_height' do
+    context 'when the title bar and search bar is hidden' do
+      before do
+        expect(request).to receive(:hide_title?).at_least(:once).and_return(true)
+        expect(request).to receive(:hide_search?).at_least(:once).and_return(true)
+      end
+
+      it { expect(file_viewer.send(:header_height)).to be_zero }
+    end
+
+    context 'when the title bar is hidden but a search is present' do
+      before do
+        stub_purl_response_and_request(multi_resource_multi_type_purl, request)
+        expect(file_viewer).to receive(:min_files_to_search).and_return(3)
+        expect(request).to receive(:hide_title?).at_least(:once).and_return(true)
+      end
+
+      it 'is 40 for the search bar' do
+        expect(file_viewer.send(:header_height)).to eq 40
       end
     end
 
-    context 'when the title and search bar are present' do
-      before do
-        expect(request).to receive(:min_files_to_search).and_return(3)
-        expect(request).to receive(:hide_title?).at_least(:once).and_return(false)
-        expect(request).to receive(:hide_search?).at_least(:once).and_return(false)
-      end
-
-      it 'adds height if the title or search is hidden' do
-        stub_purl_response_and_request(multi_resource_multi_type_purl, request)
-        expect(file_viewer.send(:default_height)).to eq 398
+    context 'when the title bar is present' do
+      it 'is 68 because it will show the title + number of items' do
+        expect(file_viewer.send(:header_height)).to eq 68
       end
     end
   end


### PR DESCRIPTION
It looks like I miscalculated some of the heights and header logic.  This also got me to notice that we should account for when an embargo note is displayed (and I've now accounted for that)

# Before

## With Titles
![embeds-before](https://user-images.githubusercontent.com/96776/77979022-5bec8e80-72b8-11ea-8d15-69336c3a0508.png)


## Without Titles
![embeds-before-wo-title](https://user-images.githubusercontent.com/96776/77978985-3f505680-72b8-11ea-9ecd-a05f31bb9ac3.png)

# After

## With Titles
![embeds-after](https://user-images.githubusercontent.com/96776/77978788-c2bd7800-72b7-11ea-8e1e-52ae62801d5d.png)

## Without Titles
![embeds-after-wo-title](https://user-images.githubusercontent.com/96776/77978796-c81ac280-72b7-11ea-961b-7806308c0d65.png)

Note, the sizing w/o the search bar isn't particularly relevant since there will always be a scroll when that is the case (since there will be 10 or more files)