### PR TITLE
Update flex stying of media objects for safari support.

### DIFF
--- a/app/assets/stylesheets/media.scss
+++ b/app/assets/stylesheets/media.scss
@@ -4,6 +4,7 @@
 @import 'video.js/video-js';
 
 .#{$namespace}-media {
+  display: flex;
   min-height: 175px;
   overflow-y: hidden !important;
   position: relative;

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -68,7 +68,7 @@ module Embed
 
     def media_wrapper(thumbnail: '', file: nil, &block)
       <<-HTML.strip_heredoc
-        <div style="height: 100%"
+        <div style="flex: 1 0 100%"
              data-stanford-only="#{file.try(:stanford_only?)}"
              data-location-restricted="#{file.try(:location_restricted?)}"
              data-file-label="#{file.label}"


### PR DESCRIPTION
Potentially part of sul-dlss/media#154

## Before in Safari (bb025pz8001)
<img width="751" alt="bb025pz8001-before-safari" src="https://user-images.githubusercontent.com/96776/78415511-13deac00-75d7-11ea-975e-5b9e6178aaa1.png">


## After in Safari (bb025pz8001)
<img width="749" alt="bb025pz8001-after-safari" src="https://user-images.githubusercontent.com/96776/78414464-fc042980-75d0-11ea-87bc-3209980eff78.png">
