### PR TITLE
Remove the sync height dimension config being sent to the Mirador…

### DIFF
--- a/app/assets/javascripts/modules/m3_viewer.js
+++ b/app/assets/javascripts/modules/m3_viewer.js
@@ -34,9 +34,6 @@ export default {
             /.*\.edu\/(\w+)\/iiif\/manifest/,
             'https://embed.stanford.edu/iframe?url=https://purl.stanford.edu/$1',
           ],
-          syncIframeDimensions: {
-            height: { param: 'maxheight' },
-          },
         },
         dragAndDropInfoLink: 'https://library.stanford.edu/projects/international-image-interoperability-framework/viewers',
         shareLink: {


### PR DESCRIPTION
… share plugin

(no longer necessary since the iframe height is all that is needed)