### PR TITLE
Add our own check for stanford-only rights 

### DIFF
--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -301,7 +301,9 @@ module Embed
         end
 
         def stanford_only?
-          @rights.stanford_only_unrestricted_file?(title)
+          value, _rule = @rights.stanford_only_rights_for_file(title)
+
+          value
         end
 
         def location_restricted?

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -306,6 +306,28 @@ module PURLFixtures
       </publicObject>
     XML
   end
+  def stanford_no_download_restricted_file_purl
+    <<-XML
+      <publicObject>
+        <identityMetadata>
+          <objectLabel>Title of the object</objectLabel>
+        </identityMetadata>
+        <contentMetadata type="file">
+          <resource sequence="1" type="file">
+            <attr name="label">PDF1</attr>
+            <file size="12345" mimetype="application/pdf" id="Title_of_the_PDF.pdf" />
+          </resource>
+        </contentMetadata>
+        <rightsMetadata>
+          <access type="read">
+            <machine>
+              <group rule="no-download">stanford</group>
+            </machine>
+          </access>
+        </rightsMetadata>
+      </publicObject>
+    XML
+  end
   def stanford_restricted_image_purl
     <<-XML
       <publicObject>

--- a/spec/models/embed/purl_spec.rb
+++ b/spec/models/embed/purl_spec.rb
@@ -339,6 +339,10 @@ describe Embed::PURL do
             stub_purl_response_with_fixture(stanford_restricted_file_purl)
             expect(Embed::PURL.new('12345').contents.first.files.all?(&:stanford_only?)).to be true
           end
+          it 'should identify stanford_only no-download objects' do
+            stub_purl_response_with_fixture(stanford_no_download_restricted_file_purl)
+            expect(Embed::PURL.new('12345').contents.first.files.all?(&:stanford_only?)).to be true
+          end
           it 'should identify world accessible objects as not stanford only' do
             stub_purl_response_with_fixture(file_purl)
             expect(Embed::PURL.new('12345').contents.first.files.all?(&:stanford_only?)).to be false


### PR DESCRIPTION
that considers an item stanford-only even if it is no-download

Believed to fix https://github.com/sul-dlss/media/issues/151