### PR TITLE
Set a min height for the file viewer

### DIFF
--- a/app/assets/stylesheets/file.scss
+++ b/app/assets/stylesheets/file.scss
@@ -77,6 +77,8 @@ body {
 
 .#{$namespace}-file-list {
   @include well-container;
+
+  min-height: 189px;
 }
 
 .#{$namespace}-media-list {

--- a/app/viewers/embed/viewer/file.rb
+++ b/app/viewers/embed/viewer/file.rb
@@ -66,7 +66,11 @@ module Embed
       private
 
       def default_height
-        file_specific_height + embargo_message_height + header_height
+        [file_specific_height + embargo_message_height + header_height, min_height].max
+      end
+
+      def min_height
+        189
       end
 
       def header_height

--- a/spec/lib/embed/viewer/file_spec.rb
+++ b/spec/lib/embed/viewer/file_spec.rb
@@ -58,9 +58,9 @@ describe Embed::Viewer::File do
         expect(file_viewer.send(:default_height)).to eq 323
       end
 
-      it 'reduces the height based on the number of files in the object (1 file)' do
+      it 'reduces the height based on the number of files in the object (1 file), but no lower than our min height' do
         stub_purl_response_and_request(file_purl, request)
-        expect(file_viewer.send(:default_height)).to eq 122
+        expect(file_viewer.send(:default_height)).to eq 189
       end
 
       it 'reduces the height based on the number of files in the object (2 files)' do
@@ -69,7 +69,7 @@ describe Embed::Viewer::File do
       end
     end
 
-    context 'when the item is emargoed' do
+    context 'when the item is embargoed' do
       before do
         expect(request).to receive(:hide_title?).at_least(:once).and_return(true)
         expect(request).to receive(:hide_search?).at_least(:once).and_return(true)
@@ -78,7 +78,7 @@ describe Embed::Viewer::File do
       it 'adds 44 pixels to the height (to avoid unnecessary scroll)' do
         stub_purl_response_and_request(embargoed_stanford_file_purl, request)
 
-        expect(file_viewer.send(:default_height)).to eq 166 # 122 + 44
+        expect(file_viewer.send(:default_height)).to eq 189 # minimum height
       end
     end
 


### PR DESCRIPTION
Fixes #453 by forcing the 1-file viewer to be no smaller than 2 files high, which is at least a little more usable?

<img width="753" alt="Screen Shot 2020-04-17 at 08 34 36" src="https://user-images.githubusercontent.com/111218/79586689-5350d200-8086-11ea-99c5-4d02884742e0.png">


