### PR TITLE
Remove import of unused translations

### DIFF
--- a/app/javascript/empty_translation.js
+++ b/app/javascript/empty_translation.js
@@ -1,0 +1,1 @@
+{ translation: {}}

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const { environment } = require('@rails/webpacker')
+const webpack = require('webpack');
 
 environment.config.merge({
   resolve: {
@@ -13,5 +14,16 @@ environment.config.merge({
 })
 
 environment.splitChunks();
+
+environment.plugins.prepend(
+  // Plugin to only load english translations to reduce bundle size
+  'NormalModuleReplacement',
+  new webpack.NormalModuleReplacementPlugin(
+    /locales\/((?!en).)*$/,
+    (resource) => {
+      resource.request = 'empty_translation.js'
+    }
+  )
+)
 
 module.exports = environment


### PR DESCRIPTION
No need to provide to browsers translations that they will never see. I wanted to be able to establish this pattern for others.

Before: 2.01 MB / 513.08 KB transferred
After: 1.96 MB / 501.26 KB transferred

2.3% reduction in JavaScript transferred

I've tested this on UAT. Currently deployed there.