### PR TITLE
Update M3 border styling

### DIFF
--- a/app/assets/stylesheets/m3.scss
+++ b/app/assets/stylesheets/m3.scss
@@ -2,8 +2,16 @@
 
 .#{$namespace}-container {
   border: 0;
+  border-left: 1px solid $gray-80-percent;
   box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.2), 0 2px 1px -1px rgba(0, 0, 0, 0.2);
   height: calc(100vh - 3px); // Give a little space for the box shadow
   margin: 0 1px 3px 0;
   position: relative;
+
+  // For single-window M3 embeds, this will be overriden by Mirador 3's
+  // selected window top-bar styling, but if there are mulitple
+  // windows, it will give the unselected windows a visible border.
+  .mirador-window-top-bar {
+    border-top-color: $gray-80-percent;
+  }
 }


### PR DESCRIPTION
We currently have a styling issue where the left edge of the Mirador 3 viewer is not visually well defined when displayed on a page where the background color is white, such as on an Exhibits item show page:

<img width="1050" alt="Screen Shot 2020-06-29 at 2 42 43 PM" src="https://user-images.githubusercontent.com/101482/86059440-9b418d00-ba17-11ea-808d-26f5d69a108f.png">

This becomes more noticeable when there is more than one window in the M3 viewer, such as when adding a window for comparison (the top edge of unselected windows are not well defined):

<img width="988" alt="Screen Shot 2020-06-29 at 2 58 55 PM" src="https://user-images.githubusercontent.com/101482/86060231-2cfdca00-ba19-11ea-849b-51b03316a57c.png">


This PR adds some minor styling that addresses those issues:

### Single window in Exhibits
<img width="1050" alt="Screen Shot 2020-06-29 at 2 45 49 PM" src="https://user-images.githubusercontent.com/101482/86059684-16a33e80-ba18-11ea-8012-3659b884082d.png">

---

### Multiple windows in Exhibits

<img width="988" alt="Screen Shot 2020-06-29 at 2 59 11 PM" src="https://user-images.githubusercontent.com/101482/86060238-325b1480-ba19-11ea-9684-849a2d056476.png">

---

This styling applies to any application where we embed M3, even those that don't have white page backgrounds where the problem wasn't as noticeable due to the color contrast, but I don't think the new styling makes things any worse in those applications, such as Searchworks:


### Before (Searchworks)
<img width="988" alt="Screen Shot 2020-06-29 at 2 55 04 PM" src="https://user-images.githubusercontent.com/101482/86059891-8d403c00-ba18-11ea-83b4-978c2d81d331.png">


### After (Searchworks)
<img width="956" alt="Screen Shot 2020-06-29 at 1 56 58 PM" src="https://user-images.githubusercontent.com/101482/86059923-9cbf8500-ba18-11ea-91c3-a9427c9714f6.png">
