### PR TITLE
Update link colors to use Stanford Libraries defaults

### DIFF
--- a/app/assets/stylesheets/common.scss.erb
+++ b/app/assets/stylesheets/common.scss.erb
@@ -50,8 +50,12 @@ body {
   a:hover,
   a:focus {
     border-bottom: 1px dotted $sul-link-border-color;
-    color: $sul-font-color;
+    color: $sul-link-color;
     text-decoration: none;
+  }
+
+  a:hover {
+    color: $sul-link-hover-color;
   }
 
   .#{$namespace}-header {

--- a/app/assets/stylesheets/sul_variables.scss.erb
+++ b/app/assets/stylesheets/sul_variables.scss.erb
@@ -63,6 +63,8 @@ $sul-input-border: $gray-80-percent;
 $sul-title-size: floor(($font-size-base * 1.29));
 $sul-header-weight: $headings-font-weight;
 $sul-link-border-color: $color-pantone-401;
+$sul-link-color: #006CB8;
+$sul-link-hover-color: #00548f;
 $sul-media-index-height: 24px;
 $sul-metadata-bg: $color-beige-05;
 $sul-metadata-heading-color: $gray-54-percent;


### PR DESCRIPTION
Paired w/ @jvine on this. This is the recommendation going forward.

![image](https://user-images.githubusercontent.com/1656824/88591281-59f1cc80-d019-11ea-8435-fe64d6df31a6.png)
![Screen Shot 2020-07-27 at 2 56 02 PM](https://user-images.githubusercontent.com/1656824/88591286-5c542680-d019-11ea-83d6-7462b152814c.png)

## New WAS viewer
![Screen Shot 2020-07-27 at 2 55 57 PM](https://user-images.githubusercontent.com/1656824/88591289-5e1dea00-d019-11ea-9970-a47b0602c218.png)
