### PR TITLE
Use browser local timezone for due dates

### DIFF
--- a/app/assets/javascripts/components/DueDate.js
+++ b/app/assets/javascripts/components/DueDate.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 
 /** */
@@ -17,10 +18,23 @@ export default class DueDate extends Component {
         {dueDateObject.toLocaleTimeString(
           'en-US',
           {
-            hour: '2-digit', minute: '2-digit', timeZone: 'America/Los_Angeles', timeZoneName: 'short',
+            hour: '2-digit', minute: '2-digit', timeZoneName: 'short',
           },
         ).replace(' PM', 'pm').replace(' AM', 'am')}
       </Typography>
     );
   }
 }
+
+DueDate.propTypes = {
+  className: PropTypes.string,
+  timestamp: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+};
+
+DueDate.defaultProps = {
+  className: null,
+  timestamp: null,
+};

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "mirador-image-tools": "^0.8.0",
     "mirador-share-plugin": "^0.9.0",
     "pdfjs-dist": "2.2.228",
+    "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "three": "^0.112.1",


### PR DESCRIPTION
As a non-'America/LosAngeles' timezone user, just testing this I found it jarring to always having to recalculate my different due dates in my head. I am hoping that this provides a better user experience for those who may be in a non-Pacific timezone.

An example, an item with a 2-hour checkout will show due an hour ago if a user is checking this out from ET.

![Screen Shot 2020-09-10 at 6 49 16 AM](https://user-images.githubusercontent.com/1656824/92731070-daeaf600-f331-11ea-9130-5f0552261988.png)
