### PR TITLE
Enable book view for everything 🤷‍♂️

### DIFF
--- a/app/assets/javascripts/modules/m3_viewer.js
+++ b/app/assets/javascripts/modules/m3_viewer.js
@@ -90,6 +90,12 @@ export default {
         sideBarOpen: (data.showAttribution === true || data.search.length > 0),
         imageToolsEnabled: true,
         imageToolsOpen: false,
+        views: [
+          { key: 'single', behaviors: [null, 'individuals'] },
+          { key: 'book', behaviors: [null, 'paged'] },
+          { key: 'scroll', behaviors: ['continuous'] },
+          { key: 'gallery' },
+        ],
       },
       workspace: {
         showZoomControls: true,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@rails/webpacker": "^4.0.7",
     "fscreen": "^1.0.2",
     "list.js": "1.1.1",
-    "mirador": "^3.0.0-rc.4",
+    "mirador": "^3.0.0-rc.6",
     "mirador-dl-plugin": "^0.12.0",
     "mirador-image-tools": "^0.8.0",
     "mirador-share-plugin": "^0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5045,10 +5045,10 @@ mirador-share-plugin@^0.9.0:
   resolved "https://registry.yarnpkg.com/mirador-share-plugin/-/mirador-share-plugin-0.9.0.tgz#c8742507e90bf3262c0b775ffeb56ac35f98309e"
   integrity sha512-o013pXA94sDATpNWwOaVm9Psv0f5Rs/j9r5V1BaPDyMOBHnCdiglLhHJMMt7ka0vEZBd9+okVab+ZsxS2lp9Bg==
 
-mirador@^3.0.0-rc.4:
-  version "3.0.0-rc.5"
-  resolved "https://registry.yarnpkg.com/mirador/-/mirador-3.0.0-rc.5.tgz#55d0fe39e4f5e8962a1ce89e88f614221390f4da"
-  integrity sha512-3PkpKTynQGo/Q6p878BaRogIGxg/GeBmiWjbikrmh93hRyuFQs0MnxIy4OSEL6duNd5KbIZoMdadsjcBRKmd8Q==
+mirador@^3.0.0-rc.6:
+  version "3.0.0-rc.6"
+  resolved "https://registry.yarnpkg.com/mirador/-/mirador-3.0.0-rc.6.tgz#e908321068c11d4fb5cc2df137b9fe2c0b4987c6"
+  integrity sha512-NVqxLwH0xUvBqtCFdiNH5RYilAvEwLY5z8U8RNCjfEoLhw1jnKBaCbBFaHfuzRn3eg28D3Rlh67sCsKQUqMAhA==
   dependencies:
     "@material-ui/core" "^4.11.0"
     "@material-ui/icons" "^4.9.1"


### PR DESCRIPTION
This is a stop-gap measure to provide 2-up views for SDR items that were scanned as books, but not accessioned with that content type. It will appear on all image resources, not just things that resemble books (e.g. postcards, individual images, etc) where the book-style 2-up view probably will not display in a useful way for users.
