### PR TITLE
'reset' the authentication request so we actually fire the access token request

### DIFF
--- a/app/assets/javascripts/components/CdlAuthenticationControl.js
+++ b/app/assets/javascripts/components/CdlAuthenticationControl.js
@@ -12,7 +12,7 @@ import {
   getWindow,
   selectCurrentAuthServices,
 } from 'mirador/dist/es/src/state/selectors';
-import { requestAccessToken } from 'mirador/dist/es/src/state/actions';
+import { requestAccessToken, resolveAuthenticationRequest } from 'mirador/dist/es/src/state/actions';
 import DueDate from './DueDate';
 import CdlLogout from './CdlLogout';
 
@@ -330,9 +330,12 @@ const mapStateToProps = (state, { targetProps }) => {
 };
 
 /** */
-const mapDispatchToProps = {
-  requestAccessToken,
-};
+const mapDispatchToProps = (dispatch) => ({
+  requestAccessToken: (accessTokenServiceId, authServiceId) => {
+    dispatch(resolveAuthenticationRequest(authServiceId, accessTokenServiceId, { ok: undefined }))
+    dispatch(requestAccessToken(accessTokenServiceId, authServiceId));
+  },
+});
 
 const CdlAuthenticationControlPlugin = {
   mapDispatchToProps,


### PR DESCRIPTION
fixed upstream in https://github.com/ProjectMirador/mirador/pull/3289