### PR TITLE
Time is fun

### DIFF
--- a/app/assets/javascripts/components/CdlAuthenticationControl.js
+++ b/app/assets/javascripts/components/CdlAuthenticationControl.js
@@ -62,18 +62,35 @@ class CdlAuthenticationControl extends Component {
   /** */
   authLabel(isInFailureState) {
     const {
-      available, failureHeader, label, loanPeriod, nextUp, status,
+      available, failureHeader, label, nextUp, status,
     } = this.props;
     if (isInFailureState) return failureHeader;
     if (available === undefined) return label;
 
     if (available || nextUp) {
-      return `Available for ${Math.floor(loanPeriod / 3600)}-hour loan`;
+      return `Available for ${this.distanceOfLoanPeriod()} loan`;
     }
 
     if (status === 'ok') return null;
 
     return 'Checked out';
+  }
+
+  /** */
+  distanceOfLoanPeriod() {
+    const { loanPeriod } = this.props;
+    const minutes = loanPeriod / 60;
+    if (minutes < 60) {
+      return `${Math.floor(minutes)}-minute`;
+    }
+    const hours = loanPeriod / 3600;
+    if (hours < 23) {
+      return `${Math.floor(hours)}-hour`;
+    }
+    if (hours >= 23 && hours < 167) {
+      return `${Math.floor(hours / 24)}-day`;
+    }
+    return `${Math.floor(hours / 24 / 7)}-week`;
   }
 
   /** */

--- a/app/assets/javascripts/components/DueDate.js
+++ b/app/assets/javascripts/components/DueDate.js
@@ -5,6 +5,28 @@ import Typography from '@material-ui/core/Typography';
 /** */
 export default class DueDate extends Component {
   /** */
+  static isToday(dueDate) {
+    const today = new Date();
+    if (today.getDate() === dueDate.getDate()
+        && today.getMonth() === dueDate.getMonth()
+        && today.getFullYear() === dueDate.getFullYear()) {
+      return true;
+    }
+    return false;
+  }
+
+  /** */
+  static isTomorrow(dueDate) {
+    const tomorrow = new Date(new Date().getTime() + 86400000);
+    if (tomorrow.getDate() === dueDate.getDate()
+        && tomorrow.getMonth() === dueDate.getMonth()
+        && tomorrow.getFullYear() === dueDate.getFullYear()) {
+      return true;
+    }
+    return false;
+  }
+
+  /** */
   render() {
     const { className, timestamp } = this.props;
 
@@ -12,15 +34,32 @@ export default class DueDate extends Component {
 
     const dueDateObject = new Date(timestamp);
 
+    const dueDateDisplay = [];
+
+    if (!DueDate.isToday(dueDateObject)) {
+      if (DueDate.isTomorrow(dueDateObject)) {
+        dueDateDisplay.push('Tomorrow');
+      } else {
+        dueDateDisplay.push(dueDateObject.toLocaleDateString(
+          'en-US',
+          {
+            day: 'numeric', month: 'numeric', year: 'numeric',
+          },
+        ));
+      }
+    }
+
+    dueDateDisplay.push(dueDateObject.toLocaleTimeString(
+      'en-US',
+      {
+        hour: '2-digit', minute: '2-digit', timeZoneName: 'short',
+      },
+    ).replace(' PM', ' p.m.').replace(' AM', ' a.m.'));
+
     return (
       <Typography className={className} variant="body1">
         Due:&nbsp;
-        {dueDateObject.toLocaleTimeString(
-          'en-US',
-          {
-            hour: '2-digit', minute: '2-digit', timeZoneName: 'short',
-          },
-        ).replace(' PM', 'pm').replace(' AM', 'am')}
+        {dueDateDisplay.join(' at ')}
       </Typography>
     );
   }


### PR DESCRIPTION
Fixes #1216

**Note** this assumes that the CDL loan period is defined in terms we would expect (minutes -> hours -> days -> weeks. So a loan period that say is 17 days, it would display as `1-week`. We could change this, but I'm not 💯 clear on when / why we should fall back to that.

## Due today
![Screen Shot 2020-11-23 at 12 45 40 PM](https://user-images.githubusercontent.com/1656824/100007929-048cb880-2d8a-11eb-8e4a-d538bd600410.png)

## 1-week loan
![Screen Shot 2020-11-23 at 12 44 32 PM](https://user-images.githubusercontent.com/1656824/100007934-05254f00-2d8a-11eb-8fd9-b0d93f185119.png)

## Faked not today or tomorrow display
![Screen Shot 2020-11-23 at 12 15 31 PM](https://user-images.githubusercontent.com/1656824/100007937-05254f00-2d8a-11eb-98dc-abb121e0f91d.png)

## Due today
![Screen Shot 2020-11-23 at 12 15 03 PM](https://user-images.githubusercontent.com/1656824/100007941-05bde580-2d8a-11eb-834c-14fc3d6614a9.png)

## Faked due tomorrow
![Screen Shot 2020-11-23 at 12 14 41 PM](https://user-images.githubusercontent.com/1656824/100007947-06567c00-2d8a-11eb-9415-e0d0ce7118bc.png)

## Other loan periods
![Screen Shot 2020-11-23 at 12 49 00 PM](https://user-images.githubusercontent.com/1656824/100008175-4cabdb00-2d8a-11eb-9f0e-d54b4c453424.png)
![Screen Shot 2020-11-23 at 12 48 55 PM](https://user-images.githubusercontent.com/1656824/100008179-4d447180-2d8a-11eb-9243-5394b6ef8bcd.png)
