### PR TITLE
Change params for Selenium move_to method

### DIFF
--- a/spec/features/geo_viewer_spec.rb
+++ b/spec/features/geo_viewer_spec.rb
@@ -51,7 +51,7 @@ describe 'geo viewer public', js: true do
     end
 
     it 'shows the sidebar with attribute information after map is clicked' do
-      page.driver.browser.action.move_to(find(:css, '#sul-embed-geo-map').native, 380, 245).click.perform
+      page.driver.browser.action.move_to(find(:css, '#sul-embed-geo-map').native).click.perform
       using_wait_time 20 do
         expect(page).to have_css '.sul-embed-geo-sidebar-header h3', text: 'Features', visible: true
         expect(page).to have_css '.sul-embed-geo-sidebar-content dt', text: 's_02_id', visible: true


### PR DESCRIPTION
We have a test failing on main:
```
Failures:
  1) geo viewer public loading geo viewer shows the sidebar with attribute information after map is clicked
     Failure/Error: expect(page).to have_css '.sul-embed-geo-sidebar-content dt', text: 's_02_id', visible: true
       expected to find css ".sul-embed-geo-sidebar-content dt" but there were no matches
     # ./spec/features/geo_viewer_spec.rb:57:in `block (4 levels) in <top (required)>'
     # ./spec/features/geo_viewer_spec.rb:55:in `block (3 levels) in <top (required)>'
```

The reason is because the click for the `move_to` method has the wrong coordinates now, due to a change in Selenium 4.2, so click is not actually clicking with the geo map area, and no data is getting passed.

Here is the [changelog](https://github.com/SeleniumHQ/selenium/blob/trunk/rb/CHANGES) and warning from Selenium. I guess the WARN is actually failing:

```
2022-06-10 12:11:18 WARN Selenium moving to an element with offset currently tries to use
the top left corner of the element as the origin; in Selenium 4.3 it will use the in-view
center point of the element as the origin.
```