### PR TITLE
Remove embed_iframe_url from settings in favor of controller data

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ An [oEmbed](http://oembed.com/) provider for embedding resources from the Stanfo
 
 There is an embedded static page available at `/pages/sandbox` in your development and test environments. Make sure that you use the same host on the service input (first text field) as you are accessing the site from (e.g. localhost or 127.0.0.1).
 
-You'll also want to configure the `Settings.embed_iframe_url` to be the same host/port as you are accessing the site from to ensure that the iframe being embedded is pointing locally and not remotely (as is the default).
-
 ## oEmbed specification details
 
 URL scheme: `http://purl.stanford.edu/*`

--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -29,7 +29,7 @@ class EmbedController < ApplicationController
   end
 
   def embed_request
-    @embed_request ||= Embed::Request.new(params, request)
+    @embed_request ||= Embed::Request.new(params, self)
   end
 
   rescue_from Embed::Request::NoURLProvided do |e|

--- a/app/viewers/embed/viewer/common_viewer.rb
+++ b/app/viewers/embed/viewer/common_viewer.rb
@@ -14,18 +14,6 @@ module Embed
         @purl_object = request.purl_object
       end
 
-      def asset_url(file)
-        "#{asset_host}#{ActionController::Base.helpers.asset_url(file)}"
-      end
-
-      def asset_host
-        if Rails.env.production?
-          Settings.static_assets_base
-        else
-          "//#{@request.rails_request.host_with_port}"
-        end
-      end
-
       def stacks_url
         "#{Settings.stacks_url}/file/druid:#{@purl_object.druid}"
       end

--- a/app/views/embed/body/_file.html.erb
+++ b/app/views/embed/body/_file.html.erb
@@ -1,6 +1,6 @@
 <div class='sul-embed-body sul-embed-file'
-      data-sul-embed-theme="<%= viewer.asset_url('file.css') %>"
-      data-sul-icons="<%= viewer.asset_url('sul_icons.css') %>">
+      data-sul-embed-theme="<%= asset_url('file.css') %>"
+      data-sul-icons="<%= asset_url('sul_icons.css') %>">
   <div class='sul-embed-file-list'>
     <% if viewer.purl_object.embargoed? %>
       <div class='sul-embed-embargo-message'>

--- a/app/views/embed/body/_geo.html.erb
+++ b/app/views/embed/body/_geo.html.erb
@@ -1,6 +1,6 @@
 <div class='sul-embed-body sul-embed-geo'
      data-sul-embed-theme="<%= asset_url('geo.css') %>"
-     data-sul-icons="<%= viewer.asset_url('sul_icons.css') %>">
+     data-sul-icons="<%= asset_url('sul_icons.css') %>">
   <div id="sul-embed-geo-sidebar" class="" style="display: none;">
   </div>
   <%= content_tag :div, viewer.map_element_options do %>

--- a/app/views/embed/body/_media.html.erb
+++ b/app/views/embed/body/_media.html.erb
@@ -1,6 +1,6 @@
 <div class='sul-embed-body sul-embed-media'
      data-sul-embed-theme="<%= asset_url('media.css') %>"
-     data-sul-icons="<%= viewer.asset_url('sul_icons.css') %>">
+     data-sul-icons="<%= asset_url('sul_icons.css') %>">
   <%= Embed::MediaTag.new(viewer).to_html.html_safe %>
   <%= javascript_packs_with_chunks_tag('media') %>
 </div>

--- a/app/views/embed/body/_pdf_viewer.html.erb
+++ b/app/views/embed/body/_pdf_viewer.html.erb
@@ -1,7 +1,7 @@
 <% # removing 5 pixels from the body height to account for being embedded %>
 <div class='sul-embed-body sul-embed-pdf'
-      data-sul-embed-theme="<%= viewer.asset_url('pdf.css') %>"
-      data-sul-icons="<%= viewer.asset_url('sul_icons.css') %>">
+      data-sul-embed-theme="<%= asset_url('pdf.css') %>"
+      data-sul-icons="<%= asset_url('sul_icons.css') %>">
   <button aria-label="Zoom in" class="button zoom-in">+</button>
   <button aria-label="Zoom out" class="button zoom-out">-</button>
   <button aria-label="Previous page" class="button prev-page">

--- a/app/views/embed/body/_virtex_3d_viewer.html.erb
+++ b/app/views/embed/body/_virtex_3d_viewer.html.erb
@@ -6,8 +6,8 @@
   <div
     id="virtex-3d-viewer"
     class="virtex"
-    data-sul-embed-theme="<%= viewer.asset_url('virtex_3d.css') %>"
-    data-sul-icons="<%= viewer.asset_url('sul_icons.css') %>"
+    data-sul-embed-theme="<%= asset_url('virtex_3d.css') %>"
+    data-sul-icons="<%= asset_url('sul_icons.css') %>"
     data-three-dimensional-file="<%= viewer.three_dimensional_files.first %>"
   >
   </div>

--- a/app/views/embed/body/_was_seed.html.erb
+++ b/app/views/embed/body/_was_seed.html.erb
@@ -1,6 +1,6 @@
 <div class='sul-embed-body sul-embed-was-seed-container'
-      data-sul-embed-theme="<%= viewer.asset_url('was_seed.css') %>"
-      data-sul-icons="<%= viewer.asset_url('sul_icons.css') %>">
+      data-sul-embed-theme="<%= asset_url('was_seed.css') %>"
+      data-sul-icons="<%= asset_url('sul_icons.css') %>">
   <div class='sul-embed-was-seed'>
     <div class='sul-embed-was-seed-content'>
       <div class='sul-embed-was-seed-row'>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,7 +7,6 @@ valid_purl_url: <%= /https?:\/\/purl\.stanford\.edu\/*/ %>
 stacks_url: 'https://stacks.stanford.edu'
 iiif_info_url: 'https://library.stanford.edu/iiif/viewers'
 enable_media_viewer?: <%= true %>
-embed_iframe_url: 'https://embed.stanford.edu/iframe'
 jquery_version: '3.4.1'
 geo_external_url: 'https://earthworks.stanford.edu/catalog/stanford-'
 geo_wms_url: 'https://geowebservices.stanford.edu/geoserver/wms/'

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,1 +1,0 @@
-embed_iframe_url: 'http://localhost:3000/iframe'

--- a/lib/embed/embed_this_panel.rb
+++ b/lib/embed/embed_this_panel.rb
@@ -75,7 +75,7 @@ module Embed
                        "#{height}px"
                      end
       query_params = request.as_url_params.merge(version ? { _v: version } : {}).to_query
-      src = "#{Settings.embed_iframe_url}?url=#{Settings.purl_url}/#{druid}&#{query_params}"
+      src = "#{request.controller.iframe_url}?url=#{Settings.purl_url}/#{druid}&#{query_params}"
 
       <<~IFRAME
         <iframe src="#{src}" height="#{height_style}" width="#{width_style}" title="#{title}" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" allowfullscreen></iframe>

--- a/lib/embed/request.rb
+++ b/lib/embed/request.rb
@@ -3,11 +3,11 @@
 module Embed
   class Request
     include URLSchemes
-    attr_reader :params, :rails_request
+    attr_reader :params, :controller
 
-    def initialize(params, rails_request = nil)
+    def initialize(params, controller = nil)
       @params = params
-      @rails_request = rails_request
+      @controller = controller
     end
 
     def url

--- a/spec/features/download_panel_spec.rb
+++ b/spec/features/download_panel_spec.rb
@@ -4,7 +4,13 @@ require 'rails_helper'
 
 describe 'download panel', type: :feature, js: true do
   include PurlFixtures
-  let(:request) { Embed::Request.new(url: 'https://purl.stanford.edu/ab123cd4567') }
+
+  let(:request) do
+    Embed::Request.new(
+      { url: 'http://purl.stanford.edu/abc123' },
+      controller
+    )
+  end
 
   it 'not shown for file viewer and leaves correctly formatted filenames alone' do
     stub_purl_response_with_fixture(multi_file_purl)

--- a/spec/features/metadata_panel_spec.rb
+++ b/spec/features/metadata_panel_spec.rb
@@ -4,7 +4,13 @@ require 'rails_helper'
 
 describe 'metadata panel', js: true do
   include PurlFixtures
-  let(:request) { Embed::Request.new(url: 'http://purl.stanford.edu/abc123') }
+
+  let(:request) do
+    Embed::Request.new(
+      { url: 'http://purl.stanford.edu/abc123' },
+      controller
+    )
+  end
 
   it 'is present after a user clicks the button' do
     stub_purl_response_with_fixture(file_purl)

--- a/spec/features/sandbox_spec.rb
+++ b/spec/features/sandbox_spec.rb
@@ -13,7 +13,7 @@ describe 'embed sandbox page', js: true do
     visit_sandbox
     expect(page).not_to have_css('iframe')
     send_embed_response
-    expect(page).to have_css("iframe[src^='#{Settings.embed_iframe_url}']")
+    expect(page).to have_css('iframe')
   end
 
   it 'passes the customization URL parameters down to the iframe successfully' do

--- a/spec/lib/embed/embed_this_panel_spec.rb
+++ b/spec/lib/embed/embed_this_panel_spec.rb
@@ -2,7 +2,8 @@
 
 require 'rails_helper'
 require 'embed/embed_this_panel'
-describe Embed::EmbedThisPanel do
+
+describe Embed::EmbedThisPanel, type: 'view' do
   subject do
     Capybara.string(
       described_class.new(viewer: viewer) do
@@ -11,7 +12,7 @@ describe Embed::EmbedThisPanel do
     )
   end
 
-  let(:request) { Embed::Request.new(url: 'https://purl.stanford.edu/abc123') }
+  let(:request) { Embed::Request.new({ url: 'http://purl.stanford.edu/abc123' }, controller) }
   let(:viewer) do
     instance_double(
       Embed::Viewer::CommonViewer,
@@ -118,11 +119,14 @@ describe Embed::EmbedThisPanel do
     describe 'the src' do
       let(:request) do
         Embed::Request.new(
-          url: 'https://purl.stanford.edu/abc123',
-          maxheight: '555',
-          maxwidth: '666',
-          hide_title: 'true',
-          hide_embed: 'true'
+          {
+            url: 'https://purl.stanford.edu/abc123',
+            maxheight: '555',
+            maxwidth: '666',
+            hide_title: 'true',
+            hide_embed: 'true'
+          },
+          controller
         )
       end
 

--- a/spec/lib/embed/request_spec.rb
+++ b/spec/lib/embed/request_spec.rb
@@ -108,11 +108,11 @@ describe Embed::Request do
     end
   end
 
-  describe 'rails_request' do
-    let(:rails_request) { double('rails-request') }
+  describe 'controller' do
+    let(:controller) { double('controller') }
 
-    it 'includes the rails request (for generating asset URLs in viewer HTML)' do
-      expect(described_class.new({ url: purl }, rails_request).rails_request).to eq rails_request
+    it 'includes the controller (for generating URLs in viewer HTML)' do
+      expect(described_class.new({ url: purl }, controller).controller).to eq controller
     end
   end
 

--- a/spec/lib/embed/response_spec.rb
+++ b/spec/lib/embed/response_spec.rb
@@ -2,9 +2,9 @@
 
 require 'rails_helper'
 
-describe Embed::Response do
+describe Embed::Response, type: 'view' do
   let(:viewer) { double('viewer') }
-  let(:request) { double('request', as_url_params: {}) }
+  let(:request) { Embed::Request.new({ url: 'http://purl.stanford.edu/abc123' }, controller) }
   let(:purl_object) { double('purl_object', druid: 'abc123') }
   let(:response) { described_class.new(request) }
 
@@ -44,7 +44,7 @@ describe Embed::Response do
     end
 
     it 'is the iframe snippet pointing to the embed' do
-      expect(response.html).to match(%r{<iframe.*src="https://embed\.stanford\.edu.*".*></iframe>}m)
+      expect(response.html).to match(%r{<iframe.*src="#{controller.iframe_url}.*".*></iframe>}m)
     end
   end
 

--- a/spec/lib/embed/viewer/common_viewer_spec.rb
+++ b/spec/lib/embed/viewer/common_viewer_spec.rb
@@ -4,7 +4,9 @@ require 'rails_helper'
 
 describe Embed::Viewer::CommonViewer do
   include PurlFixtures
-  let(:request) { Embed::Request.new(url: 'http://purl.stanford.edu/abc123') }
+
+  let(:request) { Embed::Request.new({ url: 'http://purl.stanford.edu/abc123' }) }
+
   let(:file_viewer) { Embed::Viewer::File.new(request) }
   let(:geo_viewer) { Embed::Viewer::Geo.new(request) }
   let(:media_viewer) { Embed::Viewer::Media.new(request) }

--- a/spec/lib/embed/viewer/file_spec.rb
+++ b/spec/lib/embed/viewer/file_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe Embed::Viewer::File do
   include PurlFixtures
   let(:purl_object) { double('purl_object') }
-  let(:request) { Embed::Request.new(url: 'http://purl.stanford.edu/abc123') }
+  let(:request) { Embed::Request.new({ url: 'http://purl.stanford.edu/abc123' }) }
   let(:file_viewer) { described_class.new(request) }
 
   describe 'initialize' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,7 +39,7 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 RSpec.configure(&:infer_spec_type_from_file_location!)
 
 def stub_purl_response_with_fixture(fixture)
-  expect_any_instance_of(Embed::Purl).to receive(:response).at_least(:once).and_return(fixture)
+  allow_any_instance_of(Embed::Purl).to receive(:response).and_return(fixture)
 end
 
 def stub_purl_response_and_request(fixture, request)

--- a/spec/views/embed/template/_file.html.erb_spec.rb
+++ b/spec/views/embed/template/_file.html.erb_spec.rb
@@ -5,7 +5,12 @@ require 'rails_helper'
 RSpec.describe 'embed/template/_file' do
   include PurlFixtures
 
-  let(:request) { Embed::Request.new(url: 'http://purl.stanford.edu/abc123') }
+  let(:request) do
+    Embed::Request.new(
+      { url: 'http://purl.stanford.edu/abc123' },
+      controller
+    )
+  end
   let(:object) { Embed::Purl.new('12345') }
   let(:viewer) { Embed::Viewer::File.new(request) }
   let(:response) { file_purl }

--- a/spec/views/embed/template/_geo.html.erb_spec.rb
+++ b/spec/views/embed/template/_geo.html.erb_spec.rb
@@ -5,7 +5,12 @@ require 'rails_helper'
 RSpec.describe 'embed/template/_geo' do
   include PurlFixtures
 
-  let(:request) { Embed::Request.new(url: 'http://purl.stanford.edu/abc123') }
+  let(:request) do
+    Embed::Request.new(
+      { url: 'http://purl.stanford.edu/abc123' },
+      controller
+    )
+  end
   let(:object) { Embed::Purl.new('12345') }
   let(:viewer) { Embed::Viewer::Geo.new(request) }
 

--- a/spec/views/embed/template/_media.html.erb_spec.rb
+++ b/spec/views/embed/template/_media.html.erb_spec.rb
@@ -5,7 +5,12 @@ require 'rails_helper'
 RSpec.describe 'embed/template/_media' do
   include PurlFixtures
 
-  let(:request) { Embed::Request.new(url: 'http://purl.stanford.edu/abc123') }
+  let(:request) do
+    Embed::Request.new(
+      { url: 'http://purl.stanford.edu/abc123' },
+      controller
+    )
+  end
   let(:object) { Embed::Purl.new('12345') }
   let(:viewer) { Embed::Viewer::Media.new(request) }
   let(:response) { video_purl }

--- a/spec/views/embed/template/_was_seed.html.erb_spec.rb
+++ b/spec/views/embed/template/_was_seed.html.erb_spec.rb
@@ -6,7 +6,12 @@ RSpec.describe 'embed/template/_was_seed' do
   include PurlFixtures
   include WasTimeMapFixtures
 
-  let(:request) { Embed::Request.new(url: 'http://purl.stanford.edu/abc123') }
+  let(:request) do
+    Embed::Request.new(
+      { url: 'http://purl.stanford.edu/abc123' },
+      controller
+    )
+  end
   let(:object) { Embed::Purl.new('12345') }
   let(:viewer) { Embed::Viewer::WasSeed.new(request) }
 


### PR DESCRIPTION
We get `iframe_url` for free from the embed controller's `iframe` route.

This PR also removes any references to an unneeded asset_url method we'd put into the viewer code, and falls back to the rails `asset_url` helper.
