### PR TITLE
Use literal slashes in stacks URLs with file-type content

### DIFF
--- a/app/viewers/embed/viewer/common_viewer.rb
+++ b/app/viewers/embed/viewer/common_viewer.rb
@@ -34,11 +34,10 @@ module Embed
       # Creates a file url for stacks
       # @param [String] title
       # @param [Boolean] download
-      # @param [Boolean] allow_literal_slashes
       # @return [String]
-      def file_url(title, download: false, allow_literal_slashes: false)
-        title_parts = allow_literal_slashes ? title.split('/') : [title]
-        encoded_title = title_parts.map { |title_part| ERB::Util.url_encode(title_part) }.join('/')
+      def file_url(title, download: false)
+        # Allow literal slashes in the file URL (do not encode them)
+        encoded_title = title.split('/').map { |title_part| ERB::Util.url_encode(title_part) }.join('/')
         uri = URI.parse("#{stacks_url}/#{encoded_title}")
         uri.query = URI.encode_www_form(download: true) if download
         uri.to_s

--- a/app/viewers/embed/viewer/common_viewer.rb
+++ b/app/viewers/embed/viewer/common_viewer.rb
@@ -34,9 +34,12 @@ module Embed
       # Creates a file url for stacks
       # @param [String] title
       # @param [Boolean] download
+      # @param [Boolean] allow_literal_slashes
       # @return [String]
-      def file_url(title, download: false)
-        uri = URI.parse("#{stacks_url}/#{ERB::Util.url_encode(title)}")
+      def file_url(title, download: false, allow_literal_slashes: false)
+        title_parts = allow_literal_slashes ? title.split('/') : [title]
+        encoded_title = title_parts.map { |title_part| ERB::Util.url_encode(title_part) }.join('/')
+        uri = URI.parse("#{stacks_url}/#{encoded_title}")
         uri.query = URI.encode_www_form(download: true) if download
         uri.to_s
       end

--- a/app/views/embed/body/_file.html.erb
+++ b/app/views/embed/body/_file.html.erb
@@ -27,7 +27,7 @@
                 <span class='sul-embed-disabled'><%= file.title %></span>
               <% else %>
                 <div class='sul-embed-media-heading'>
-                  <a href="<%= viewer.file_url(file.title) %>"
+                  <a href="<%= viewer.file_url(file.title, allow_literal_slashes: true) %>"
                      title="<%= viewer.tooltip_text(file) %>"
                      target='_blank'
                      rel='noopener noreferrer'><%= file.title %></a>
@@ -46,7 +46,7 @@
                     <%= viewer.pretty_filesize(file.size) %>
                   </span>
                 <% else %>
-                  <a href="<%= viewer.file_url(file.title) %>" target='_blank' rel='noopener noreferrer' download=''>
+                  <a href="<%= viewer.file_url(file.title, allow_literal_slashes: true) %>" target='_blank' rel='noopener noreferrer' download=''>
                     <span class='sul-embed-sr-only'>
                       Download item <%= file_count %>
                     </span>

--- a/app/views/embed/body/_file.html.erb
+++ b/app/views/embed/body/_file.html.erb
@@ -27,7 +27,7 @@
                 <span class='sul-embed-disabled'><%= file.title %></span>
               <% else %>
                 <div class='sul-embed-media-heading'>
-                  <a href="<%= viewer.file_url(file.title, allow_literal_slashes: true) %>"
+                  <a href="<%= viewer.file_url(file.title) %>"
                      title="<%= viewer.tooltip_text(file) %>"
                      target='_blank'
                      rel='noopener noreferrer'><%= file.title %></a>
@@ -46,7 +46,7 @@
                     <%= viewer.pretty_filesize(file.size) %>
                   </span>
                 <% else %>
-                  <a href="<%= viewer.file_url(file.title, allow_literal_slashes: true) %>" target='_blank' rel='noopener noreferrer' download=''>
+                  <a href="<%= viewer.file_url(file.title) %>" target='_blank' rel='noopener noreferrer' download=''>
                     <span class='sul-embed-sr-only'>
                       Download item <%= file_count %>
                     </span>

--- a/spec/lib/embed/viewer/common_viewer_spec.rb
+++ b/spec/lib/embed/viewer/common_viewer_spec.rb
@@ -45,8 +45,13 @@ describe Embed::Viewer::CommonViewer do
       expect(file_viewer.file_url('cool_file', download: true)).to eq 'https://stacks.stanford.edu/file/druid:abc123/cool_file?download=true'
     end
 
-    it 'escapes special characters in the file' do
+    it 'escapes special characters in the file url' do
       expect(file_viewer.file_url('[Dissertation] micro-TEC vfinal (for submission)-augmented.pdf')).to eq 'https://stacks.stanford.edu/file/druid:abc123/%5BDissertation%5D%20micro-TEC%20vfinal%20%28for%20submission%29-augmented.pdf'
+    end
+
+    it 'allows literal slashes in the file url' do
+      expect(file_viewer.file_url('path/to/[Dissertation] micro-TEC vfinal (for submission)-augmented.pdf', allow_literal_slashes: true))
+        .to eq 'https://stacks.stanford.edu/file/druid:abc123/path/to/%5BDissertation%5D%20micro-TEC%20vfinal%20%28for%20submission%29-augmented.pdf'
     end
   end
 

--- a/spec/lib/embed/viewer/common_viewer_spec.rb
+++ b/spec/lib/embed/viewer/common_viewer_spec.rb
@@ -50,7 +50,7 @@ describe Embed::Viewer::CommonViewer do
     end
 
     it 'allows literal slashes in the file url' do
-      expect(file_viewer.file_url('path/to/[Dissertation] micro-TEC vfinal (for submission)-augmented.pdf', allow_literal_slashes: true))
+      expect(file_viewer.file_url('path/to/[Dissertation] micro-TEC vfinal (for submission)-augmented.pdf'))
         .to eq 'https://stacks.stanford.edu/file/druid:abc123/path/to/%5BDissertation%5D%20micro-TEC%20vfinal%20%28for%20submission%29-augmented.pdf'
     end
   end


### PR DESCRIPTION
Connects to sul-dlss/dor-services-app#4256

This commit supports work to support hierarchy in filenames throughout SDR. Doing this to support analysis work. Depends on https://github.com/sul-dlss/stacks/pull/925
