### PR TITLE
Surface containing directory information in file embed view

### DIFF
--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -33,6 +33,13 @@ module Embed
       end
     end
 
+    def containing_directories
+      all_resource_files
+        .map(&:containing_directory)
+        .compact_blank
+        .uniq
+    end
+
     def rights
       @rights ||= ::Dor::RightsAuth.parse(rights_xml)
     end
@@ -229,8 +236,11 @@ module Embed
           title
         end
 
-        def title
-          @file.attributes['id'].try(:value)
+        def title(basename: false)
+          filename = @file.attributes['id'].try(:value)
+          return filename unless basename
+
+          filename.delete_prefix("#{containing_directory}/")
         end
 
         def primary?
@@ -283,6 +293,12 @@ module Embed
         def duration
           md = Embed::MediaDuration.new(@file.xpath('./*[@duration]').first) if @file.xpath('./*/@duration').present?
           md&.to_s
+        end
+
+        def containing_directory
+          title
+            .split('/')[...-1]
+            .join('/')
         end
 
         # unused (9/2016) - candidate for removal?

--- a/app/views/embed/body/_file.html.erb
+++ b/app/views/embed/body/_file.html.erb
@@ -9,8 +9,15 @@
     <% end %>
     <ul class='sul-embed-media-list'>
       <% file_count = 0 %>
+      <% containing_directories = viewer.purl_object.containing_directories %>
       <% viewer.purl_object.contents.each do |resource| %>
         <% resource.files.each do |file| %>
+          <% if containing_directories.include?(file.containing_directory) %>
+            <i class="sul-i-1x sul-i-arrow-down-8"> <%= file.containing_directory %></i>
+            <% containing_directories.delete(file.containing_directory) %>
+          <% elsif file.containing_directory.blank? %>
+            <i class="sul-i-1x sul-i-arrow-down-8"> .</i>
+          <% end %>
           <li class='sul-embed-media'>
             <div class='sul-embed-count sul-embed-pull-left'>
               <%= file_count += 1 %>
@@ -30,7 +37,7 @@
                   <a href="<%= viewer.file_url(file.title) %>"
                      title="<%= viewer.tooltip_text(file) %>"
                      target='_blank'
-                     rel='noopener noreferrer'><%= file.title %></a>
+                     rel='noopener noreferrer'><%= file.title(basename: true) %></a>
                   <%= render 'restrictions_text_for_file', file: file %>
                 </div>
               <% end %>


### PR DESCRIPTION
Connects to #1380

This commit is WIP towards implementing a small change to surface containing directory information in the file embed view, intended to provide more context around files that were stored with path information.

![Screenshot from 2022-12-15 16-27-58](https://user-images.githubusercontent.com/131982/207994692-382801ac-c588-46f2-a905-7edb3fde31b5.png)
![Screenshot from 2022-12-15 16-28-17](https://user-images.githubusercontent.com/131982/207994694-8cfca9bb-706e-4377-89a9-556bb47e92a7.png)



NOTE: No tests have been written or run. Also, there is a bug in the current implementation causing the JavaScript item counter to overcount (likely due to the HTML elements added to show directory info).
