### PR TITLE
Add a docker container to run webpacker-dev-server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM ruby:2.7
+
+# Install nodejs
+RUN apt-get update -qq && apt-get install -y nodejs
+
+# Add Yarn repository
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
+# Update
+RUN apt-get update -y
+
+# Install Yarn
+RUN apt-get install yarn -y
+
+ADD . /usr/src/app
+WORKDIR /usr/src/app
+
+# Install & run bundler
+RUN gem install bundler:'~> 2.3.0'
+
+RUN bundle
+
+CMD bin/webpack-dev-server

--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ Now visit this URL in your browser!
 
     http://localhost:3000/pages/sandbox
 
+# Webpacker in Docker
+
+Since webpacker doesn't run on modern versions of node JS, you can use the provided docker container to run webpacker.
+
+```
+docker compose webpacker
+```
+
 ## oEmbed specification details
 
 URL scheme: `https://purl.stanford.edu/*`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+# docker-compose.yml
+
+version: '3.2'
+
+services:
+  webpacker:
+    build: .
+    ports:
+    - '3035:3035'
+    environment:
+      RAILS_ENV: development
+      NODE_ENV: development
+    volumes:
+      - .:/usr/src/app


### PR DESCRIPTION
Because webpacker doesn't run on modern versions of nodejs