### PR TITLE
Migrate Google Analytics to GA4

### DIFF
--- a/app/assets/javascripts/plugins/analyticsPlugin.js
+++ b/app/assets/javascripts/plugins/analyticsPlugin.js
@@ -7,7 +7,6 @@ import { getManifest, getCompanionWindow } from 'mirador/dist/es/src/state/selec
 function* onSetCanvas({ type, windowId, canvasId }) {
   const { id: manifestId } = yield select(getManifest, { windowId });
   yield put({ type: 'mirador/analytics', payload: {
-    hitType: 'event',
     eventCategory: manifestId,
     eventAction: type,
     eventLabel: canvasId,
@@ -16,7 +15,6 @@ function* onSetCanvas({ type, windowId, canvasId }) {
 
 function* onAddResource({ type, manifestId }) {
   yield put({ type: 'mirador/analytics', payload: {
-    hitType: 'event',
     eventCategory: manifestId,
     eventAction: type,
   }});
@@ -28,7 +26,6 @@ function* onAddCompanionWindow({ payload: { position, content }, type, windowId 
   const { id: manifestId } = yield select(getManifest, { windowId });
 
   yield put({ type: 'mirador/analytics', payload: {
-    hitType: 'event',
     eventCategory: manifestId,
     eventAction: type,
     eventLabel: `${content}/${position}`,
@@ -42,7 +39,6 @@ function* onUpdateCompanionWindow({ id, payload: { position, content }, type, wi
   const { content: existingContent } = yield select(getCompanionWindow, { companionWindowId: id });
 
   yield put({ type: 'mirador/analytics', payload: {
-    hitType: 'event',
     eventCategory: manifestId,
     eventAction: type,
     eventLabel: `${content || existingContent}/${position}`,
@@ -52,7 +48,6 @@ function* onUpdateCompanionWindow({ id, payload: { position, content }, type, wi
 
 function* onReceiveManifest({ manifestId, type }) {
   yield put({ type: 'mirador/analytics', payload: {
-    hitType: 'event',
     eventCategory: manifestId,
     eventAction: type,
   }});
@@ -62,7 +57,6 @@ function* onRequestSearch({ query, type, windowId }) {
   const { id: manifestId } = yield select(getManifest, { windowId });
 
   yield put({ type: 'mirador/analytics', payload: {
-    hitType: 'event',
     eventCategory: manifestId,
     eventAction: type,
     eventLabel: query,
@@ -71,7 +65,6 @@ function* onRequestSearch({ query, type, windowId }) {
 
 function* onAddWindow({ type, window: { canvasId, manifestId } }) {
   yield put({ type: 'mirador/analytics', payload: {
-    hitType: 'event',
     eventCategory: manifestId,
     eventAction: type,
     eventLabel: canvasId,
@@ -82,7 +75,6 @@ function* onMaximizeWindow({ type, windowId }) {
   const { id: manifestId } = yield select(getManifest, { windowId });
 
   yield put({ type: 'mirador/analytics', payload: {
-    hitType: 'event',
     eventCategory: manifestId,
     eventAction: type,
   }});
@@ -92,7 +84,6 @@ function* onSetWindowViewType({ type, viewType, windowId }) {
   const { id: manifestId } = yield select(getManifest, { windowId });
 
   yield put({ type: 'mirador/analytics', payload: {
-    hitType: 'event',
     eventCategory: manifestId,
     eventAction: type,
     eventLabel: viewType,
@@ -103,7 +94,6 @@ function* onSelectAnnotation({ annotationId, type, windowId }) {
   const { id: manifestId } = yield select(getManifest, { windowId });
 
   yield put({ type: 'mirador/analytics', payload: {
-    hitType: 'event',
     eventCategory: manifestId,
     eventAction: type,
     eventLabel: annotationId,
@@ -112,14 +102,12 @@ function* onSelectAnnotation({ annotationId, type, windowId }) {
 
 function* onSetWorkspaceAction({ type }) {
   yield put({ type: 'mirador/analytics', payload: {
-    hitType: 'event',
     eventAction: type,
   }});
 }
 
 function* onSetWorkspaceActionLayout({ layout, type }) {
   yield put({ type: 'mirador/analytics', payload: {
-    hitType: 'event',
     eventCategory: layout,
     eventAction: type,
   }});
@@ -133,7 +121,6 @@ function* onAddAuthRequest({ id, type, windowId }) {
   authTimes[id] = Date.now();
 
   yield put({ type: 'mirador/analytics', payload: {
-    hitType: 'event',
     eventCategory: manifestId,
     eventAction: type,
     eventLabel: id,
@@ -145,7 +132,6 @@ function* onResetAuthState({ id, type }) {
   authTimes[id] = undefined;
 
   yield put({ type: 'mirador/analytics', payload: {
-    hitType: 'event',
     eventAction: type,
     eventLabel: id,
     eventValue: sessionMinutes,
@@ -161,7 +147,6 @@ function* onTokenRequest({ type, authId }) {
   tokenRequests[authId] = (tokenRequests[authId] || 0) + 1;
 
   yield put({ type: 'mirador/analytics', payload: {
-    hitType: 'event',
     eventAction: type,
     eventLabel: authId,
     eventValue: tokenRequests[authId],
@@ -177,16 +162,19 @@ function* onTokenFailure({ type, authId }) {
   }
 
   yield put({ type: 'mirador/analytics', payload: {
-    hitType: 'event',
     eventAction: type,
     eventCategory: newOrExpired,
     eventLabel: authId,
   }});
 }
 
-
-function* sendAnalyticsEvent({ payload }) {
-  window.ga && window.ga('send', payload);
+// This function sends events in the required format for GA4
+function* sendAnalyticsEvent({ payload: { eventAction, eventCategory, eventLabel, eventValue } }) {
+  window.gtag && window.gtag('event', eventAction, {
+    event_category: eventCategory,
+    event_label: eventLabel,
+    event_value: eventValue
+  });  
 }
 
 /** */

--- a/app/views/embed/_analytics.html.erb
+++ b/app/views/embed/_analytics.html.erb
@@ -1,0 +1,12 @@
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-80J719XWE5"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-80J719XWE5', {
+    'debug_mode': <%= Settings.analytics_debug %>,
+    <%# collection is a custom event parameter for getting an item's parent collection.
+    It is sent with every event if populated with a value %>
+    'collection': document.querySelector('link[rel="up"]')?.getAttribute('href')
+  });
+</script>

--- a/app/views/embed/iframe.html.erb
+++ b/app/views/embed/iframe.html.erb
@@ -7,20 +7,8 @@
     </script>
     <%= tag :link, rel: "up", href: Embed::Purl.new(@embed_response.request.purl_object.collections.first).purl_url if @embed_response && @embed_response.request.purl_object.collections.any? %>
   </head>
+  <%= render 'analytics' %>
   <body>
     <%= render 'embed_response', embed_response: @embed_response %>
-    <% if Settings.analytics_id %>
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-        ga('set', 'anonymizeIp', true);
-        ga('set', 'dimension1', $('link[rel="up"]').attr('href'));
-        ga('create', '<%= Settings.analytics_id %>', 'auto');
-        ga('send', 'pageview');
-      </script>
-    <% end %>
   </body>
 </html>

--- a/app/views/embed/iiif.html.erb
+++ b/app/views/embed/iiif.html.erb
@@ -15,6 +15,7 @@
       }
     </style>
   </head>
+  <%= render 'analytics' %>
   <body>
     <div class="sul-embed-container" id='sul-embed-object' style='display:none;'>
       <div class='sul-embed-body sul-embed-m3' style="max-height:100%;" data-sul-embed-theme="<%= asset_url('m3.css') %>">
@@ -35,17 +36,5 @@
         <%= javascript_packs_with_chunks_tag('m3') %>
       </div>
     </div>
-    <% if Settings.analytics_id %>
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-        ga('set', 'anonymizeIp', true);
-        ga('create', '<%= Settings.analytics_id %>', 'auto');
-        ga('send', 'pageview');
-      </script>
-    <% end %>
   </body>
 </html>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -61,4 +61,6 @@ use_custom_pdf_viewer: true
 use_custom_3d_viewer: true
 collections_to_show_attribution:
   - dc876nn4469
-analytics_id:
+# Google Analytics will report in debug mode by default
+# in shared_configs for embed-prod, we set this value to 0  
+analytics_debug: true


### PR DESCRIPTION
Ref https://github.com/sul-dlss/sul-embed/issues/1383

Following the pattern of other recent GA4 implementations, I put the Google identifier directly into the code.
Debug mode will remain on unless on the production server (see https://github.com/sul-dlss/shared_configs/pull/1881)

This code successfully translates the existing custom Mirador events from UA to GA4, as verified in the GA4 admin panel (debug mode):
<img width="380" alt="Screenshot 2023-01-11 at 18 31 47" src="https://user-images.githubusercontent.com/1328900/211940452-64bf665d-a57b-4ed6-a24b-e924de71a858.png">

It also sends the automatically-collected new GA4 events (see https://support.google.com/analytics/answer/9234069?hl=en)

I found it weird to put the script between `<head>` and `<body>` but that is what the migration [guide](https://support.google.com/analytics/answer/9744165?hl=en#zippy=%2Cin-this-article%2Cinstall-a-google-tag) seemed to say!

> copy and paste your entire Google tag in the code of every page of your website, immediately after the head element. 