### PR TITLE
Add download-all for File objects

### DIFF
--- a/app/assets/javascripts/file.js
+++ b/app/assets/javascripts/file.js
@@ -6,6 +6,7 @@
 //= require modules/file_preview
 //= require modules/popup_panels
 //= require modules/embed_this
+//= require modules/download_all
 
 CssInjection.injectFontIcons();
 CssInjection.appendToHead();
@@ -13,3 +14,4 @@ CommonViewerBehavior.initializeViewer();
 FilePreview.init();
 PopupPanels.init();
 EmbedThis.init();
+DownloadAll.init();

--- a/app/assets/javascripts/modules/download_all.js
+++ b/app/assets/javascripts/modules/download_all.js
@@ -1,0 +1,39 @@
+// This module ensures Download All button doesn't get clicked repeatedly. The first
+// click on Download button will cause the button text to be changed to
+// "Initializing download" and disabled, then the download will start.
+//
+// An <a> element is used to enclose the <button> because Chrome and
+// Stanford's SingleSignOn don't seem to like creating <a> tags dynamically and
+// then clicking on them--maybe this a security feature? So the first click
+// will also replace the <a> element in the DOM with the <button> which will
+// prevent further clicks on the <a> since it will no longer exist.
+
+(function(global) {
+  var Module = (function() {
+    return {
+
+      init: function() {
+        const a = document.getElementById('sul-embed-footer-download-all');
+        if (a) {
+          a.addEventListener('click', e => this.download(e));
+        }
+      },
+
+      download: function(event) {
+        const el = event.target;
+        if (el.localName == 'button') {
+          el.disabled = true;
+          el.innerText = " Initializing download...";
+
+          // replace the anchor tag with the button to prevent further clicks
+          const a = el.parentElement;
+          a.replaceWith(el);
+        }
+      }
+
+    }
+  })();
+
+  global.DownloadAll = Module;
+
+})(this);

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -110,6 +110,7 @@ body {
     .#{$namespace}-footer-toolbar {
       padding-top: 0;
       vertical-align: middle;
+      color: $white-color;
     }
 
     .sul-i-download-3 {

--- a/app/assets/stylesheets/file.scss
+++ b/app/assets/stylesheets/file.scss
@@ -45,6 +45,18 @@ body {
     max-width: 100%;
   }
 
+  .#{$namespace}-footer-toolbar .sul-i-download-3 {
+    padding: 0px 5px 0px 5px;
+  }
+
+  .#{$namespace}-footer-toolbar .sul-embed-location-restricted-text {
+    background-color: $white-color;
+  }
+
+  .#{$namespace}-footer-toolbar a {
+    color: $white-color;
+  }
+
   .#{$namespace}-download {
     display: inline;
     font-size: .9em;

--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Embed
+  # rubocop:disable Metrics/ClassLength
   class Purl
     require 'embed/media_duration'
     require 'dor/rights_auth'
@@ -39,6 +40,10 @@ module Embed
 
     def hierarchical?
       @hierarchical ||= hierarchical_contents.files.length != contents.sum { |resource| resource.files.length }
+    end
+
+    def size
+      contents.sum(&:size)
     end
 
     def rights
@@ -167,6 +172,7 @@ module Embed
           nil
         end
     end
+    # rubocop:enable Metrics/ClassLength
 
     class ResourceNotAvailable < StandardError
       def initialize(msg = 'The requested PURL resource was not available')

--- a/app/models/embed/purl/resource.rb
+++ b/app/models/embed/purl/resource.rb
@@ -38,6 +38,10 @@ module Embed
         end
       end
 
+      def size
+        files.sum(&:size)
+      end
+
       def primary_file
         files.find(&:primary?)
       end

--- a/app/viewers/embed/viewer/file.rb
+++ b/app/viewers/embed/viewer/file.rb
@@ -61,6 +61,25 @@ module Embed
         super || display_file_search?
       end
 
+      # Returns true or false whether the viewer should display the Download All
+      # link. The limits were determined in testing and may need to be adjusted
+      # based on experience with download performance and any changes in the
+      # Stacks API. It returns false when there is just one file because the
+      # file download link will suffice for that.
+      def display_download_all?
+        @purl_object.size < 10_737_418_240 &&
+          @purl_object.downloadable_files.length > 1 &&
+          @purl_object.downloadable_files.length < 3000
+      end
+
+      def any_stanford_only_files?
+        @purl_object.all_resource_files.any?(&:stanford_only?)
+      end
+
+      def download_url
+        "#{Settings.stacks_url}/object/#{@purl_object.druid}"
+      end
+
       private
 
       def default_height

--- a/app/views/embed/footer/_file.html.erb
+++ b/app/views/embed/footer/_file.html.erb
@@ -1,0 +1,48 @@
+<div class='sul-embed-footer'>
+  <div class='sul-embed-footer-toolbar'>
+    <button class='sul-embed-footer-tool sul-embed-btn sul-embed-btn-toolbar sul-embed-btn-default sul-i-infomation-circle'
+      aria-expanded='false' aria-label='open metadata panel'
+      data-sul-embed-toggle='sul-embed-metadata-panel'></button>
+    <% unless viewer.request.hide_embed_this? %>
+      <button class='sul-embed-footer-tool sul-embed-btn sul-embed-btn-toolbar sul-embed-btn-default sul-i-share'
+        aria-expanded='false'
+        aria-label='open embed this panel'
+        data-sul-embed-toggle='sul-embed-embed-this-panel'></button>
+    <% end %>
+
+    <% if viewer.display_download_all? %>
+      <a id='sul-embed-footer-download-all' href='<%= viewer.download_url %>' target="_blank" rel="noopener noreferrer nofollow">
+        <button class='sul-embed-footer-tool sul-embed-btn sul-em bed-btn-toolbar sul-embed-btn-default sul-i-download-3' aria-label="download all files">
+          Download all <%= pluralize(viewer.purl_object.downloadable_files.length, "file") %>
+          (<%= viewer.pretty_filesize(viewer.purl_object.size) %>)
+          <% if viewer.any_stanford_only_files? %>
+            <span class="sul-embed-location-restricted-text sul-embed-stanford-only-text" aria-label="restricted to stanford">
+              <span class="sul-embed-text-hide"> Stanford only </span>
+            </span>
+          <% end %>
+        </button>
+      </a>
+    <% elsif viewer.purl_object.downloadable_files.length > 1 %>
+      <a rel="nofollow" href="mailto:sdr-contact@lists.stanford.edu?subject=Download%20SDR%20Object%20<%= viewer.purl_object.druid %>">
+        <button class='sul-embed-footer-tool sul-embed-btn sul-em bed-btn-toolbar sul-embed-btn-default sul-i-download-3' aria-label="Contact us to download files">
+          Contact us to download files.
+        </button>
+      </a>
+    <% end %>
+
+    <% if viewer.external_url.present? %>
+      <a class='sul-embed-footer-tool sul-embed-btn sul-embed-btn-toolbar sul-embed-btn-default sul-i-navigation-next-4'
+        href="<%= viewer.external_url.to_s %>" target='_parent'>
+        <span class='sul-embed-sr-only'><%= viewer.external_url_text %></span>
+      </a>
+    <% end %>
+
+    <% if viewer.fullscreen? %>
+      <button
+        aria-label="Full screen"
+        class="sul-embed-footer-tool sul-embed-btn sul-embed-btn-toolbar sul-embed-btn-default sul-i-expand-1 sul-fullscreen-button"
+        id="full-screen-button">
+      </button>
+    <% end %>
+  </div>
+</div>

--- a/app/views/embed/footer/_generic.html.erb
+++ b/app/views/embed/footer/_generic.html.erb
@@ -10,7 +10,6 @@
         data-sul-embed-toggle= 'sul-embed-embed-this-panel'></button>
     <% end %>
 
-
     <% if viewer.show_download? %>
       <button
         class='sul-embed-footer-tool sul-embed-btn sul-em bed-btn-toolbar sul-embed-btn-default sul-i-download-3'

--- a/app/views/embed/template/_file.html.erb
+++ b/app/views/embed/template/_file.html.erb
@@ -3,6 +3,6 @@
   <%= render 'body/file', viewer: viewer %>
   <%= render 'metadata_panel', viewer: viewer %>
   <%= render 'embed_this/file', viewer: viewer %>
-  <%= render 'footer/generic', viewer: viewer %>
+  <%= render 'footer/file', viewer: viewer %>
   <script src="<%= asset_url('tree.js') %>"></script>
 </div>

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -172,6 +172,60 @@ module PurlFixtures
       </publicObject>
     XML
   end
+  def many_file_purl
+    files = (0..3001).map  { |file_num|
+      <<-XML
+        <resource sequence="1" type="file">
+          <label>File #{file_num} Label</label>
+          <file size="12345" mimetype="application/pdf" id="file-#{file_num}">
+            <location type="url">http://stacks.stanford.edu/file/druid:abc123/file-#{file_num}</location>
+          </file>
+        </resource>
+      XML
+    }.join("\n")
+
+    <<-XML
+      <publicObject>
+        <identityMetadata>
+          <objectLabel>Files files files</objectLabel>
+        </identityMetadata>
+        <contentMetadata type="file">
+          #{files}
+        </contentMetadata>
+        <rightsMetadata>
+          #{access_discover_world}
+          #{access_read_world}
+        </rightsMetadata>
+      </publicObject>
+    XML
+  end
+  def large_file_purl
+    <<-XML
+      <publicObject>
+        <identityMetadata>
+          <objectLabel>Files files files</objectLabel>
+        </identityMetadata>
+        <contentMetadata type="file">
+          <resource sequence="1" type="file">
+            <label>File1 Label</label>
+            <file size="12345" mimetype="application/pdf" id="Title_of_the_PDF.pdf">
+              <location type="url">http://stacks.stanford.edu/file/druid:abc123/Title_of_the_PDF.pdf</location>
+            </file>
+          </resource>
+          <resource sequence="2" type="file">
+            <label>File2 Label</label>
+            <file size="99999999999999999" mimetype="application/pdf" id="Title_of_2_PDF.pdf">
+              <location type="url">http://stacks.stanford.edu/file/druid:abc123/Title_of_2_PDF.pdf</location>
+            </file>
+          </resource>
+        </contentMetadata>
+        <rightsMetadata>
+          #{access_discover_world}
+          #{access_read_world}
+        </rightsMetadata>
+      </publicObject>
+    XML
+  end
   def wonky_filename_purl
     <<-XML
       <publicObject>

--- a/spec/lib/embed/viewer/file_spec.rb
+++ b/spec/lib/embed/viewer/file_spec.rb
@@ -40,7 +40,7 @@ describe Embed::Viewer::File do
       end
     end
 
-    context 'whne there is no requseted maxheight' do
+    context 'when there is no requested maxheight' do
       it 'is the default height' do
         expect(file_viewer.height).to eq 257 # 2 files + header
       end
@@ -134,5 +134,51 @@ describe Embed::Viewer::File do
       expect(request).to receive(:purl_object).and_return(nil)
       expect(file_viewer.file_type_icon('application/zip')).to eq 'sul-i-file-zipped'
     end
+  end
+
+  describe 'display_download_all?' do
+    subject { file_viewer.display_download_all? }
+
+    context 'when there are not many files and the size is low' do
+      before { stub_purl_response_with_fixture(multi_file_purl) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the files are too big' do
+      before { stub_purl_response_with_fixture(large_file_purl) }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when there are too many files' do
+      before { stub_purl_response_with_fixture(many_file_purl) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#any_stanford_only_files' do
+    subject { file_viewer.any_stanford_only_files? }
+
+    context 'when one or more files are stanford only' do
+      before { stub_purl_response_with_fixture(stanford_restricted_download_purl) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when no files are stanford only' do
+      before { stub_purl_response_with_fixture(multi_resource_multi_type_purl) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#download_url' do
+    subject { file_viewer.download_url }
+
+    before { stub_purl_response_with_fixture(file_purl) }
+
+    it { is_expected.to eq 'https://stacks.stanford.edu/object/abc123' }
   end
 end

--- a/spec/models/embed/purl_spec.rb
+++ b/spec/models/embed/purl_spec.rb
@@ -99,6 +99,18 @@ describe Embed::Purl do
     end
   end
 
+  describe '#size' do
+    subject { purl.size }
+
+    before do
+      stub_purl_response_with_fixture(multi_file_purl)
+    end
+
+    let(:purl) { described_class.new('12345') }
+
+    it { is_expected.to eq 12_345 * 2 }
+  end
+
   describe '#downloadable_files' do
     it 'returns a flattened array of downloadable resource files' do
       stub_purl_response_with_fixture(multi_resource_multi_type_purl)


### PR DESCRIPTION
Changes to add Download All button for objects of type File.

Closes #1381
