### PR TITLE
Simplify the code by removing a superflous module

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,7 +3,6 @@ purl_url: 'https://purl.stanford.edu'
 purl_read_timeout: 20
 purl_conn_timeout: 2
 purl_feedback_email: ''
-valid_purl_url: <%= /https?:\/\/purl\.stanford\.edu\/*/ %>
 stacks_url: 'https://stacks.stanford.edu'
 iiif_info_url: 'https://library.stanford.edu/iiif/viewers'
 enable_media_viewer?: <%= true %>

--- a/lib/embed.rb
+++ b/lib/embed.rb
@@ -2,7 +2,6 @@
 
 module Embed
   require 'constants'
-  require 'embed/url_schemes'
   require 'embed/request'
   require 'embed/response'
   require 'embed/stacks_media_stream'

--- a/lib/embed/request.rb
+++ b/lib/embed/request.rb
@@ -2,7 +2,6 @@
 
 module Embed
   class Request
-    include URLSchemes
     attr_reader :params, :controller
 
     def initialize(params, controller = nil)
@@ -123,9 +122,10 @@ module Embed
     end
 
     def url_scheme_is_valid?
-      url_schemes.any? do |scheme|
-        url =~ scheme
-      end && url =~ %r{/\w+$}
+      uri = URI.parse(url)
+      uri.is_a?(URI::HTTP) && # true for http or https
+        uri.hostname == URI.parse(Settings.purl_url).hostname &&
+        uri.path.size > 1 # one would just be the root path (e.g. "/")
     end
 
     def validate_format

--- a/lib/embed/url_schemes.rb
+++ b/lib/embed/url_schemes.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module URLSchemes
-  def url_schemes
-    [Regexp.new(Settings.valid_purl_url)]
-  end
-end


### PR DESCRIPTION
This makes the code easier to read by removing unnecessary indirection.