### PR TITLE
Disable debug_mode correctly for production analytics

### DIFF
--- a/app/views/embed/_analytics.html.erb
+++ b/app/views/embed/_analytics.html.erb
@@ -2,11 +2,17 @@
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
+  const debug = <%= Settings.analytics_debug %>
   gtag('js', new Date());
-  gtag('config', 'G-80J719XWE5', {
-    'debug_mode': <%= Settings.analytics_debug %>,
+  // To turn off debug mode, exclude the parameter altogether (cannot just set to false)
+  // See https://support.google.com/analytics/answer/7201382?hl=en#zippy=%2Cgoogle-tag-websites
+  const args = {
     <%# collection is a custom event parameter for getting an item's parent collection.
     It is sent with every event if populated with a value %>
     'collection': document.querySelector('link[rel="up"]')?.getAttribute('href')
-  });
+  }
+  if (debug) {
+    args["debug_mode"] = debug
+  }
+  gtag('config', 'G-80J719XWE5', args)
 </script>


### PR DESCRIPTION
This was an error on my part -- debug mode was not being turned off properly in production

Ref https://github.com/sul-dlss/sul-embed/issues/1383
This shared configs PR also needs to be merged to implement this: https://github.com/sul-dlss/shared_configs/pull/1881

