### PR TITLE
Remove the sassc-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,8 +49,6 @@ end
 # Use honeybadger for exception handling
 gem 'honeybadger'
 
-gem 'sassc-rails'
-
 gem 'filesize'
 
 gem 'leaflet-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,6 @@ GEM
     faraday-follow_redirects (0.3.0)
       faraday (>= 1, < 3)
     faraday-net_http (3.0.2)
-    ffi (1.15.5)
     filesize (0.2.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -303,14 +302,6 @@ GEM
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     selenium-webdriver (4.7.1)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -384,7 +375,6 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
-  sassc-rails
   selenium-webdriver (~> 4.2)
   sprockets-rails
   webdrivers


### PR DESCRIPTION
We no longer use this (since https://github.com/sul-dlss/sul-embed/pull/1414)