### PR TITLE
remove unnecessary dev config

### DIFF
--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,2 +1,1 @@
-purl_url: 'http://localhost:3000'
 stacks_url: 'https://sul-stacks-stage.stanford.edu'


### PR DESCRIPTION
This makes it impossible to test using live purls like http://localhost:3000/iframe?url=https://purl.stanford.edu/gx074xz5520