### PR TITLE
Remove development config

### DIFF
--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,1 +1,0 @@
-stacks_url: 'https://sul-stacks-stage.stanford.edu'


### PR DESCRIPTION
We need the stacks URL to match the environment of the purl url