### PR TITLE
Use VTT transcript

### DIFF
--- a/app/models/embed/purl/resource.rb
+++ b/app/models/embed/purl/resource.rb
@@ -48,6 +48,11 @@ module Embed
       def thumbnail
         files.find(&:thumbnail?)
       end
+
+      # @return [ResourceFile]
+      def vtt
+        files.find(&:vtt?)
+      end
     end
   end
 end

--- a/app/models/embed/purl/resource_file.rb
+++ b/app/models/embed/purl/resource_file.rb
@@ -48,7 +48,7 @@ module Embed
       end
 
       def vtt?
-        mimetype == 'text/vtt' && title.end_with?('.vtt')
+        mimetype == 'text/vtt'
       end
 
       def pdf?

--- a/app/models/embed/purl/resource_file.rb
+++ b/app/models/embed/purl/resource_file.rb
@@ -43,6 +43,14 @@ module Embed
         Settings.resource_types_that_contain_thumbnails.include?(resource.type)
       end
 
+      def vtt
+        resource.files.find(&:vtt?)
+      end
+
+      def vtt?
+        mimetype == 'text/plain' && title.end_with?('.vtt')
+      end
+
       def pdf?
         mimetype == 'application/pdf'
       end

--- a/app/models/embed/purl/resource_file.rb
+++ b/app/models/embed/purl/resource_file.rb
@@ -48,7 +48,7 @@ module Embed
       end
 
       def vtt?
-        mimetype == 'text/plain' && title.end_with?('.vtt')
+        mimetype == 'text/vtt' && title.end_with?('.vtt')
       end
 
       def pdf?

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -4,6 +4,7 @@ module Embed
   # Utility class to handle generating HTML <video> and <audio> tags
   # Currently, MPEG-DASH is used at the <video> element level (in a data attribute to be picked up by javascript)
   # and HLS is used as a <source> within the <video> or <audio> tag.
+  # rubocop:disable Metrics/ClassLength
   class MediaTag
     SUPPORTED_MEDIA_TYPES = %i[audio video].freeze
 
@@ -51,6 +52,7 @@ module Embed
             class="sul-embed-media-file #{'sul-embed-many-media' if many_primary_files?}"
             height="100%">
             #{enabled_streaming_sources(file)}
+            #{transcript(file)}
           </#{type}>
         HTML
       end
@@ -89,6 +91,14 @@ module Embed
            type='#{streaming_settings_for(streaming_type)[:mimetype]}'>
         </source>"
       end.join
+    end
+
+    def transcript(file)
+      return unless file.vtt
+
+      <<~HTML
+        <track default src="#{viewer.stacks_url}/#{file.vtt.title}" />
+      HTML
     end
 
     def many_primary_files?
@@ -165,4 +175,5 @@ module Embed
       Settings.streaming.auth_url % attributes
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -972,7 +972,7 @@ module PurlFixtures
         <contentMetadata type="media">
           <resource sequence="1" id="abc123_1" type="video">
             <file id="abc_123.mp4" mimetype="video/mp4" size="152000000"></file>
-            <file id="abc_123_cap.vtt" mimetype="text/vtt" size="176218"></file>
+            <file id="abc_123_cap.webvtt" mimetype="text/vtt" size="176218"></file>
           </resource>
         </contentMetadata>
         <rightsMetadata>

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -972,7 +972,7 @@ module PurlFixtures
         <contentMetadata type="media">
           <resource sequence="1" id="abc123_1" type="video">
             <file id="abc_123.mp4" mimetype="video/mp4" size="152000000"></file>
-            <file id="abc_123_cap.vtt" mimetype="text/plain" size="176218"></file>
+            <file id="abc_123_cap.vtt" mimetype="text/vtt" size="176218"></file>
           </resource>
         </contentMetadata>
         <rightsMetadata>

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -963,6 +963,32 @@ module PurlFixtures
     XML
   end
 
+  def video_purl_with_vtt
+    <<-XML
+      <publicObject>
+        <identityMetadata>
+          <objectLabel>Title of the single video</objectLabel>
+        </identityMetadata>
+        <contentMetadata type="media">
+          <resource sequence="1" id="abc123_1" type="video">
+            <file id="abc_123.mp4" mimetype="video/mp4" size="152000000"></file>
+            <file id="abc_123_cap.vtt" mimetype="text/plain" size="176218"></file>
+          </resource>
+        </contentMetadata>
+        <rightsMetadata>
+          <access type="read">
+            <machine>
+              <location>spec</location>
+            </machine>
+          </access>
+        </rightsMetadata>
+        <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+          <dc:title>title of video with vtt</dc:title>
+        </oai_dc>
+      </publicObject>
+    XML
+  end
+
   def video_purl
     <<-XML
       <publicObject>

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Embed::MediaTag do
   let(:purl) { video_purl }
   let(:viewer) do
     instance_double(Embed::Viewer::Media,
-                    purl_object: Embed::Purl.new('druid'))
+                    purl_object: Embed::Purl.new('druid'),
+                    stacks_url: '/file/druid')
   end
 
   let(:subject_klass) { described_class.new(viewer) }
@@ -228,6 +229,14 @@ RSpec.describe Embed::MediaTag do
       it 'gets the correct URL based on the passed in type' do
         expect(subject_klass.send(:streaming_url_for, file, :hls)).to match(%r{.*/playlist.m3u8$})
         expect(subject_klass.send(:streaming_url_for, file, :dash)).to match(%r{.*/manifest.mpd$})
+      end
+    end
+
+    describe '#transcript' do
+      before { stub_purl_response_with_fixture(video_purl_with_vtt) }
+
+      it 'has a track element' do
+        expect(subject).to have_css('track[src="/file/druid/abc_123_cap.vtt"]')
       end
     end
 

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe Embed::MediaTag do
       before { stub_purl_response_with_fixture(video_purl_with_vtt) }
 
       it 'has a track element' do
-        expect(subject).to have_css('track[src="/file/druid/abc_123_cap.vtt"]')
+        expect(subject).to have_css('track[src="/file/druid/abc_123_cap.webvtt"]')
       end
     end
 

--- a/spec/models/embed/purl/resource_file_spec.rb
+++ b/spec/models/embed/purl/resource_file_spec.rb
@@ -276,4 +276,24 @@ RSpec.describe Embed::Purl::ResourceFile do
       end
     end
   end
+
+  describe '#vtt?' do
+    subject { file.vtt? }
+
+    context 'when it is a vtt transcript' do
+      let(:file) { Embed::Purl.new('12345').contents.first.files.second }
+
+      before { stub_purl_response_with_fixture(video_purl_with_vtt) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when it is not a vtt transcript' do
+      let(:file) { Embed::Purl.new('12345').contents.first.files.first }
+
+      before { stub_purl_response_with_fixture(single_video_purl) }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/models/embed/purl/resource_spec.rb
+++ b/spec/models/embed/purl/resource_spec.rb
@@ -49,4 +49,24 @@ RSpec.describe Embed::Purl::Resource do
       expect(Embed::Purl.new('12345').contents.first.files.all?(Embed::Purl::ResourceFile)).to be true
     end
   end
+
+  describe '#vtt' do
+    let(:resource) { Embed::Purl.new('12345').contents.first }
+
+    context 'when it has a vtt transcript' do
+      subject { resource.vtt.title }
+
+      before { stub_purl_response_with_fixture(video_purl_with_vtt) }
+
+      it { is_expected.to eq 'abc_123_cap.vtt' }
+    end
+
+    context 'when it does not have a vtt transcript' do
+      subject { resource.vtt }
+
+      before { stub_purl_response_with_fixture(single_video_purl) }
+
+      it { is_expected.to be_nil }
+    end
+  end
 end

--- a/spec/models/embed/purl/resource_spec.rb
+++ b/spec/models/embed/purl/resource_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Embed::Purl::Resource do
 
       before { stub_purl_response_with_fixture(video_purl_with_vtt) }
 
-      it { is_expected.to eq 'abc_123_cap.vtt' }
+      it { is_expected.to eq 'abc_123_cap.webvtt' }
     end
 
     context 'when it does not have a vtt transcript' do


### PR DESCRIPTION
If an object's video or audio file has an associated VTT file, add a `<track>` element which should allow the player to display the transcript during playing of the video or audio.

You can see [some SDR objects](https://argo.stanford.edu/catalog?f%5Bexploded_tag_ssim%5D%5B%5D=SMPL+%3A+avtc) already have VTT files added. Their PURL data looks something like:

```xml
<resource id="cocina-fileSet-bd111gd4290-bd111gd4290_1" sequence="1" type="video">
  <label>Video file</label>
    <file id="bd111gd4290_sl.mp4" mimetype="video/mp4" size="1077075674" publish="yes" shelve="yes" preserve="yes">
  </file>
  <file id="bd111gd4290_thumb.jp2" mimetype="image/jp2" size="296021" publish="yes" shelve="yes" preserve="yes">
    <imageData height="480" width="640"/>
  </file>
  <file id="bd111gd4290_cap.vtt" mimetype="text/plain" size="145678" publish="yes" shelve="yes" preserve="yes">
  </file>
</resource>
```

Ideally the VTT files would have a `text/vtt` mimetype? Also it might be possible for there to be multiple language transcriptions for a media file, which is not currently handled in this PR. Handling multiple languages should be doable if there was a convention or mechanism for determining the language.

Also, I think testing/research with `<audio>` should be done. I did a bit of quick looking around and [it seems](https://iandevlin.com/blog/2015/12/html5/webvtt-and-audio/) that maybe captions don't get displayed unless you say it's video instead? That might be stale information though.

This was quick exploratory in response to questions from @pleonard212 and @dinahhandel.
