### PR TITLE
Use the same jquery version and cdn as used by Searchworks

### DIFF
--- a/app/views/embed/iframe.html.erb
+++ b/app/views/embed/iframe.html.erb
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src='https://ajax.googleapis.com/ajax/libs/jquery/<%= Settings.jquery_version %>/jquery.min.js'></script>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"
+        integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
+        crossorigin="anonymous"></script>
     <script>
       <%= 'if (window.jQuery) { jQuery.fx.off = true; }' if Rails.env.test? %>
     </script>

--- a/app/views/embed/iiif.html.erb
+++ b/app/views/embed/iiif.html.erb
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src='https://ajax.googleapis.com/ajax/libs/jquery/<%= Settings.jquery_version %>/jquery.min.js'></script>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"
+            integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
+            crossorigin="anonymous"></script>
     <script>
       <%= 'if (window.jQuery) { jQuery.fx.off = true; }' if Rails.env.test? %>
     </script>

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src='https://ajax.googleapis.com/ajax/libs/jquery/<%= Settings.jquery_version %>/jquery.min.js'></script>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"
+        integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
+        crossorigin="anonymous"></script>
   </head>
   <body>
     <%= yield %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,7 +6,6 @@ purl_feedback_email: ''
 stacks_url: 'https://stacks.stanford.edu'
 iiif_info_url: 'https://library.stanford.edu/iiif/viewers'
 enable_media_viewer?: <%= true %>
-jquery_version: '3.4.1'
 geo_external_url: 'https://earthworks.stanford.edu/catalog/stanford-'
 geo_wms_url: 'https://geowebservices.stanford.edu/geoserver/wms/'
 resource_types_that_contain_thumbnails:


### PR DESCRIPTION
This means visitors don't have to download two copies of jquery