### PR TITLE
Add feature flag for transcripts

### DIFF
--- a/app/views/embed/body/_media.html.erb
+++ b/app/views/embed/body/_media.html.erb
@@ -1,6 +1,6 @@
 <div class='sul-embed-body sul-embed-media'
      data-sul-embed-theme="<%= stylesheet_path('media.css') %>"
      data-sul-icons="<%= stylesheet_path('sul_icons.css') %>">
-  <%= Embed::MediaTag.new(viewer).to_html.html_safe %>
+  <%= Embed::MediaTag.new(viewer, include_transcripts: Settings.enabled_features.transcripts || params[:transcripts] == 'true').to_html.html_safe %>
   <%= javascript_pack_tag('media') %>
 </div>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -64,3 +64,5 @@ collections_to_show_attribution:
 # in shared_configs for embed-prod, we set this value to 0  
 analytics_debug: true
 min_files_to_search_default: 10
+enabled_features:
+  transcripts: false

--- a/lib/embed/media_tag.rb
+++ b/lib/embed/media_tag.rb
@@ -12,8 +12,9 @@ module Embed
 
     attr_accessor :file_index
 
-    def initialize(viewer)
+    def initialize(viewer, include_transcripts: false)
       @viewer = viewer
+      @include_transcripts = include_transcripts
       @purl_document = viewer.purl_object
       @file_index = 0
     end
@@ -94,7 +95,7 @@ module Embed
     end
 
     def transcript(file)
-      return unless file.vtt
+      return unless @include_transcripts && file.vtt
 
       <<~HTML
         <track default src="#{viewer.stacks_url}/#{file.vtt.title}" />

--- a/spec/lib/embed/media_tag_spec.rb
+++ b/spec/lib/embed/media_tag_spec.rb
@@ -233,10 +233,24 @@ RSpec.describe Embed::MediaTag do
     end
 
     describe '#transcript' do
-      before { stub_purl_response_with_fixture(video_purl_with_vtt) }
+      context 'with transcripts enabled' do
+        before { stub_purl_response_with_fixture(video_purl_with_vtt) }
 
-      it 'has a track element' do
-        expect(subject).to have_css('track[src="/file/druid/abc_123_cap.webvtt"]')
+        let(:subject_klass) { described_class.new(viewer, include_transcripts: true) }
+
+        it 'has a track element' do
+          expect(subject).to have_css('track[src="/file/druid/abc_123_cap.webvtt"]')
+        end
+      end
+
+      context 'with transcripts disabled in settings (default)' do
+        before do
+          stub_purl_response_with_fixture(video_purl_with_vtt)
+        end
+
+        it 'does not have a track element' do
+          expect(subject).not_to have_css('track')
+        end
       end
     end
 


### PR DESCRIPTION
The `Settings.enabled_features.transcripts` flag has been added to control
whether the viewer will display a `<track>` element containing the transcript for a
video.

The setting can be forcibly turned on by adding `trascripts=true` to the URL
query parameter for the embed viewer. Note, this will require you to look at
the view directly instead of in an embedded frame in PURL or SearchWorks.

Until these shared_configs changes are merged the feature will be on by default:

- https://github.com/sul-dlss/shared_configs/pull/1997
- https://github.com/sul-dlss/shared_configs/pull/1998

Resolves #1497
