### PR TITLE
Ignore blueprintjs

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -1,4 +1,5 @@
 const { generateWebpackConfig, merge } = require('shakapacker')
+const webpack = require('webpack')
 
 // See the shakacode/shakapacker README and docs directory for advice on customizing your webpackConfig.
 const options = {
@@ -9,7 +10,12 @@ const options = {
   },
   module: {
     rules: [{ test: /\.hbs$/, loader: "handlebars-loader" }]
-  }
+  },
+  plugins: [
+    new webpack.IgnorePlugin({
+      resourceRegExp: /@blueprintjs\/(core|icons)/, // ignore optional UI framework dependencies
+    }),
+  ],
 }
 
 module.exports = merge({}, generateWebpackConfig(), options)


### PR DESCRIPTION
Need to ignore optional blueprintjs as done in Mirador https://github.com/ProjectMirador/mirador/blob/master/webpack.config.js#L44 (thanks @jcoyne for pointer). 

Otherwise in the local sandbox you get warnings when building and an error like this:


![Screenshot 2023-10-17 at 2 00 02 PM](https://github.com/sul-dlss/sul-embed/assets/1619369/f1ab46b1-71f0-42fb-898e-4e63b52d2420)
