### PR TITLE
Use data attributes to bind javascript rather than classes

### DIFF
--- a/app/assets/javascripts/modules/media_viewer.js
+++ b/app/assets/javascripts/modules/media_viewer.js
@@ -46,7 +46,7 @@ export default (function() {
 
     function thumbsForSlider() {
       var thumbs = [];
-      var sliderSelector = '.sul-embed-media ' + sliderObjectSelector;
+      var sliderSelector = '[data-behavior="legacy-media"] ' + sliderObjectSelector;
       jQuery(sliderSelector).each(function(index, mediaDiv) {
         var mediaObject = $(mediaDiv).find('audio, video');
         var cssClass;
@@ -96,7 +96,7 @@ export default (function() {
     }
 
     function pauseAllMedia() {
-      var mediaObjects = jQuery('.sul-embed-media').find('.video-js');
+      var mediaObjects = jQuery('[data-behavior="legacy-media"]').find('.video-js');
       mediaObjects.each(function() {
         videojs(jQuery(this).attr('id')).pause();
       });
@@ -104,7 +104,7 @@ export default (function() {
 
     function setupThumbSlider() {
       ThumbSlider
-        .init('.sul-embed-media', { thumbClickCallback: pauseAllMedia })
+        .init('[data-behavior="legacy-media"]', { thumbClickCallback: pauseAllMedia })
         .addThumbnailsToSlider(thumbsForSlider());
     }
 
@@ -156,7 +156,7 @@ export default (function() {
         }
 
         // if the user authed successfully for the file, hide the restriction overlays
-        var sliderSelector = '.sul-embed-media ' + sliderObjectSelector;
+        var sliderSelector = '[data-behavior="legacy-media"] ' + sliderObjectSelector;
         var parentDiv = mediaObject.closest(sliderSelector);
         const isRestricted = parentDiv.dataset.stanfordOnly === "true" || 
           parentDiv.dataset.locationRestricted === "true"
@@ -200,7 +200,7 @@ export default (function() {
     }
 
     function authCheck() {
-      document.querySelectorAll('.sul-embed-media [data-auth-url]').
+      document.querySelectorAll('[data-behavior="legacy-media"] [data-auth-url]').
         forEach((mediaObject) => authCheckForMediaObject(mediaObject));
     }
 

--- a/app/assets/stylesheets/media.scss
+++ b/app/assets/stylesheets/media.scss
@@ -3,13 +3,16 @@
 @import 'modules/thumb_slider';
 @import 'video.js/video-js';
 
+// NOTE: This is overriding bootstrap_media.css
 .#{$namespace}-media {
   display: flex;
   min-height: 175px;
   overflow-y: hidden !important;
   position: relative;
   text-align: center;
+}
 
+.legacy-media-component {
   audio {
     min-width: 300px;
     width: 100%;
@@ -23,107 +26,107 @@
       padding-bottom: $sul-media-index-height;
     }
   }
-}
 
-.#{$namespace}-media-wrapper {
-  display: inline-block;
-  height: 100%;
-  position: relative;
-  text-align: center;
-  width: 100%;
-}
-
-.#{$namespace}-media-access-restricted {
-  margin: 0 auto;
-  padding: 20px 25px;
-  width: 80%;
-
-  .line1 {
-    display: block;
-    font-size: 35px;
-    font-weight: 100;
-  }
-
-  .line2 {
-    display: block;
-    font-size: 24px;
-    font-weight: 100;
-  }
-}
-
-.#{$namespace}-media-slider-thumb {
-  height: 75px;
-  text-align: left;
-
-  &.active {
-    border: 1px solid $color-cardinal-red;
-  }
-
-  i {
-    color: $color-pantone-401;
-    float: left;
-    font-size: 75px;
-    line-height: 1;
-    margin-left: -6px;
-  }
-
-  .#{$namespace}-media-square-icon {
-    float: left;
-    margin-right: 5px;
-    width: auto;
-  }
-
-  .#{$namespace}-thumb-label {
-    float: right;
-    height: 75px;
-    overflow: hidden;
-    white-space: pre-wrap;
-    white-space: -moz-pre-wrap;
-    white-space: -pre-wrap;
-    white-space: -o-pre-wrap;
-    width: 100px;
-    word-wrap: break-word;
-  }
-
-  .#{$namespace}-thumb-stanford-only {
-    @include stanford-only;
-    background-position: left 4px;
-    padding-right: 0;
-    text-indent: 17px;
-  }
-
-}
-
-// VideoJS CSS overrides for responsive layout
-// See http://andreassauer.name/experimente/video-js/demo.html
-.video-js {
-  width: 100% !important;
-
-  &::after {
-    content: '.';
-    display: block;
-    height: 0;
-    margin: 0 0 0 -100%;
-    padding: 0;
-    padding-top: 40.1%;
+  .#{$namespace}-media-wrapper {
+    display: inline-block;
+    height: 100%;
     position: relative;
-    visibility: hidden;
+    text-align: center;
+    width: 100%;
   }
 
-  // Ensure fullscreen media is as large as possible.
-  &.vjs-fullscreen {
-    audio,
-    video {
-      height: 100% !important;
-      width: 100% !important;
+  .#{$namespace}-media-access-restricted {
+    margin: 0 auto;
+    padding: 20px 25px;
+    width: 80%;
+
+    .line1 {
+      display: block;
+      font-size: 35px;
+      font-weight: 100;
+    }
+
+    .line2 {
+      display: block;
+      font-size: 24px;
+      font-weight: 100;
     }
   }
 
-  .vjs-poster {
-    bottom: 0;
-    left: 0;
-    position: absolute;
-    right: 0;
-    top: 0;
+  .#{$namespace}-media-slider-thumb {
+    height: 75px;
+    text-align: left;
+
+    &.active {
+      border: 1px solid $color-cardinal-red;
+    }
+
+    i {
+      color: $color-pantone-401;
+      float: left;
+      font-size: 75px;
+      line-height: 1;
+      margin-left: -6px;
+    }
+
+    .#{$namespace}-media-square-icon {
+      float: left;
+      margin-right: 5px;
+      width: auto;
+    }
+
+    .#{$namespace}-thumb-label {
+      float: right;
+      height: 75px;
+      overflow: hidden;
+      white-space: pre-wrap;
+      white-space: -moz-pre-wrap;
+      white-space: -pre-wrap;
+      white-space: -o-pre-wrap;
+      width: 100px;
+      word-wrap: break-word;
+    }
+
+    .#{$namespace}-thumb-stanford-only {
+      @include stanford-only;
+      background-position: left 4px;
+      padding-right: 0;
+      text-indent: 17px;
+    }
+
+  }
+
+  // VideoJS CSS overrides for responsive layout
+  // See http://andreassauer.name/experimente/video-js/demo.html
+  .video-js {
+    width: 100% !important;
+
+    &::after {
+      content: '.';
+      display: block;
+      height: 0;
+      margin: 0 0 0 -100%;
+      padding: 0;
+      padding-top: 40.1%;
+      position: relative;
+      visibility: hidden;
+    }
+
+    // Ensure fullscreen media is as large as possible.
+    &.vjs-fullscreen {
+      audio,
+      video {
+        height: 100% !important;
+        width: 100% !important;
+      }
+    }
+
+    .vjs-poster {
+      bottom: 0;
+      left: 0;
+      position: absolute;
+      right: 0;
+      top: 0;
+    }
   }
 }

--- a/app/components/embed/media_component.html.erb
+++ b/app/components/embed/media_component.html.erb
@@ -1,6 +1,7 @@
-<div class="sul-embed-container" id='sul-embed-object' style='display:none;'>
+<div class="sul-embed-container legacy-media-component" id='sul-embed-object' style='display:none;'>
   <%= render 'embed/header/media', viewer: viewer if viewer.display_header? %>
   <div class='sul-embed-body sul-embed-media'
+     data-behavior="legacy-media"
      data-sul-embed-theme="<%= stylesheet_path('media.css') %>"
      data-sul-icons="<%= stylesheet_path('sul_icons.css') %>">
     <%= Embed::MediaTag.new(viewer, include_transcripts: Settings.enabled_features.transcripts || params[:transcripts] == 'true').to_html.html_safe %>


### PR DESCRIPTION
the .sul-embed-media class was used to bind behaviors, for the bootstrap media class and for custom media styles.  This change helps separate all three of those concerns