### PR TITLE
Add honeybadger to the frontend

### DIFF
--- a/app/views/embed/iframe.html.erb
+++ b/app/views/embed/iframe.html.erb
@@ -5,6 +5,15 @@
     <script>
       <%= 'if (window.jQuery) { jQuery.fx.off = true; }' if Rails.env.test? %>
     </script>
+    <script src="//js.honeybadger.io/v6.5/honeybadger.min.js" type="text/javascript"></script>
+    <script type="text/javascript">
+      Honeybadger.configure({
+        apiKey: '<%= Honeybadger.config.get(:api_key) %>',
+        environment: '<%= Honeybadger.config.get(:env) %>',
+        debug: false,
+        onerror: true
+      });
+    </script>
     <%= tag :link, rel: "up", href: Embed::Purl.new(@embed_response.request.purl_object.collections.first).purl_url if @embed_response && @embed_response.request.purl_object.collections.any? %>
   </head>
   <%= render 'analytics' %>


### PR DESCRIPTION
This allows developers to be informed of errors without relying on users to file a bug report.