### PR TITLE
Guard against non-existant data-auth-link node

### DIFF
--- a/app/assets/javascripts/modules/media_viewer.js
+++ b/app/assets/javascripts/modules/media_viewer.js
@@ -160,9 +160,11 @@ export default (function() {
         var parentDiv = mediaObject.closest(sliderSelector);
         const isRestricted = parentDiv.dataset.stanfordOnly === "true" || 
           parentDiv.dataset.locationRestricted === "true"
-        if(isRestricted && data.status === 'success') {
+        if (isRestricted && data.status === 'success') {
           parentDiv.querySelector(restrictedMessageSelector).hidden = true
-          parentDiv.querySelector('[data-auth-link]').hidden = true
+          const authLink = parentDiv.querySelector('[data-auth-link]')
+          if (authLink)
+            authLink.hidden = true
         }
 
         if(data.status === 'success') {


### PR DESCRIPTION
This happens when the media is stanford only and the user is logged in