### PR TITLE
Extract EmbedThisFormComponent

### DIFF
--- a/app/components/embed_panel_component.html.erb
+++ b/app/components/embed_panel_component.html.erb
@@ -8,39 +8,9 @@
               <div class='sul-embed-panel-title'>Embed</div>
             </div>
             <div class='sul-embed-panel-body'>
-              <div class='sul-embed-embed-this-form'>
-                <span class='sul-embed-options-label' id="select-options">Select options:</span>
-                <div class='sul-embed-section sul-embed-embed-title-section'>
-                  <input
-                    type='checkbox'
-                    id='sul-embed-embed-title'
-                    data-embed-attr='hide_title'
-                    <%= 'checked' unless request.hide_title? %>
-                  />
-                  <label for='sul-embed-embed-title'>
-                    title
-                    <span class='sul-embed-embed-title'> (<%= purl_object_title %>)</span>
-                  </label>
-                </div>
+              <%= render EmbedThisFormComponent.new(viewer:) do %>
                 <%= content %>
-                <div class='sul-embed-section'>
-                  <input
-                    type='checkbox'
-                    id='sul-embed-embed'
-                    data-embed-attr='hide_embed'
-                    <%= 'checked' unless request.hide_embed_this? %>
-                  />
-                  <label for='sul-embed-embed'>embed</label>
-                </div>
-                <div>
-                  <div class='sul-embed-options-label'>
-                    <label for='sul-embed-iframe-code'>Embed code:</label>
-                  </div>
-                  <div class='sul-embed-section'>
-                    <textarea id='sul-embed-iframe-code' data-behavior='iframe-code' rows=4><%= render IframeComponent.new(viewer:) %></textarea>
-                  </div>
-                </div>
-              </div>
+              <% end %>
             </div>
           </div>
         </div>

--- a/app/components/embed_panel_component.rb
+++ b/app/components/embed_panel_component.rb
@@ -5,8 +5,5 @@ class EmbedPanelComponent < ViewComponent::Base
     @viewer = viewer
   end
 
-  delegate :request, :purl_object, to: :viewer
-  delegate :title, to: :purl_object, prefix: true
-
   attr_reader :viewer
 end

--- a/app/components/embed_this_form_component.html.erb
+++ b/app/components/embed_this_form_component.html.erb
@@ -1,0 +1,33 @@
+<div class='sul-embed-embed-this-form'>
+  <span class='sul-embed-options-label' id="select-options">Select options:</span>
+  <div class='sul-embed-section sul-embed-embed-title-section'>
+    <input
+      type='checkbox'
+      id='sul-embed-embed-title'
+      data-embed-attr='hide_title'
+      <%= 'checked' unless request.hide_title? %>
+    />
+    <label for='sul-embed-embed-title'>
+      title
+      <span class='sul-embed-embed-title'> (<%= purl_object_title %>)</span>
+    </label>
+  </div>
+  <%= content %>
+  <div class='sul-embed-section'>
+    <input
+      type='checkbox'
+      id='sul-embed-embed'
+      data-embed-attr='hide_embed'
+      <%= 'checked' unless request.hide_embed_this? %>
+    />
+    <label for='sul-embed-embed'>embed</label>
+  </div>
+  <div>
+    <div class='sul-embed-options-label'>
+      <label for='sul-embed-iframe-code'>Embed code:</label>
+    </div>
+    <div class='sul-embed-section'>
+      <textarea id='sul-embed-iframe-code' data-behavior='iframe-code' rows=4><%= render IframeComponent.new(viewer:) %></textarea>
+    </div>
+  </div>
+</div>

--- a/app/components/embed_this_form_component.rb
+++ b/app/components/embed_this_form_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class EmbedThisFormComponent < ViewComponent::Base
+  def initialize(viewer:)
+    @viewer = viewer
+  end
+
+  delegate :request, :purl_object, to: :viewer
+  delegate :title, to: :purl_object, prefix: true
+
+  attr_reader :viewer
+end

--- a/spec/components/embed_this_form_component_spec.rb
+++ b/spec/components/embed_this_form_component_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EmbedThisFormComponent, type: :component do
+  let(:request) do
+    Embed::Request.new(url: 'http://purl.stanford.edu/abc123')
+  end
+  let(:object) { instance_double(Embed::Purl, title: '', druid: '', all_resource_files: [], embargoed?: false) }
+  let(:viewer) { Embed::Viewer::File.new(request) }
+
+  before do
+    allow(request).to receive(:purl_object).and_return(object)
+  end
+
+  context 'without any content' do
+    before do
+      render_inline(described_class.new(viewer:))
+    end
+
+    it 'has the form elements for updating the embed code' do
+      expect(page.find('.sul-embed-options-label#select-options')).to have_content('Select options:')
+      expect(page).to have_css('input#sul-embed-embed-title[type="checkbox"]')
+      expect(page).to have_css('input#sul-embed-embed[type="checkbox"]')
+      expect(page).to have_css('textarea#sul-embed-iframe-code')
+    end
+  end
+
+  context 'with content' do
+    before do
+      with_controller_class EmbedController do
+        render_inline(described_class.new(viewer:)) do
+          vc_test_controller.helpers.tag :input, type: 'checkbox', id: 'sul-embed-embed-search'
+        end
+      end
+    end
+
+    it 'has the form elements for updating the embed code' do
+      expect(page.find('.sul-embed-options-label#select-options')).to have_content('Select options:')
+      expect(page).to have_css('input#sul-embed-embed-title[type="checkbox"]')
+      expect(page).to have_css('input#sul-embed-embed-search[type="checkbox"]')
+      expect(page).to have_css('input#sul-embed-embed[type="checkbox"]')
+      expect(page).to have_css('textarea#sul-embed-iframe-code')
+    end
+  end
+end

--- a/spec/features/embed_this_panel_spec.rb
+++ b/spec/features/embed_this_panel_spec.rb
@@ -47,15 +47,6 @@ RSpec.describe 'embed this panel', :js do
       expect(page).to have_css('.sul-embed-embed-this-panel', visible: :hidden)
     end
 
-    it 'have the form elements for updating the embed code' do
-      page.find('[data-sul-embed-toggle="sul-embed-embed-this-panel"]', match: :first).click
-      expect(page.find('.sul-embed-options-label#select-options', visible: :all)).to have_content('SELECT OPTIONS:')
-      expect(page).to have_css('input#sul-embed-embed-title[type="checkbox"]')
-      expect(page).to have_css('input#sul-embed-embed-search[type="checkbox"]')
-      expect(page).to have_css('input#sul-embed-embed[type="checkbox"]')
-      expect(page).to have_css('textarea#sul-embed-iframe-code')
-    end
-
     it 'update the textarea when the checkboxes are selected' do
       page.find('[data-sul-embed-toggle="sul-embed-embed-this-panel"]', match: :first).click
       expect(page.find('.sul-embed-embed-this-panel textarea').value).not_to match(/&hide_search=true/)


### PR DESCRIPTION
This will allow us to use the existing EmbedThisForm outside of the panel (i.e. in the new media widget).