### PR TITLE
Prefilter resources to ensure they have primary files

### DIFF
--- a/app/components/embed/legacy_media_component.html.erb
+++ b/app/components/embed/legacy_media_component.html.erb
@@ -4,7 +4,7 @@
      data-behavior="legacy-media"
      data-sul-embed-theme="<%= stylesheet_path('media.css') %>"
      data-sul-icons="<%= stylesheet_path('sul_icons.css') %>">
-    <%= render Embed::MediaTagComponent.with_collection(purl_object.contents,
+    <%= render Embed::MediaTagComponent.with_collection(resources_with_primary_file,
                                                         include_transcripts:,
                                                         druid:,
                                                         many_primary_files:) %>

--- a/app/components/embed/legacy_media_component.rb
+++ b/app/components/embed/legacy_media_component.rb
@@ -16,8 +16,12 @@ module Embed
     end
 
     def primary_files_count
-      purl_object.contents.count do |resource|
-        resource.primary_file.present?
+      resources_with_primary_file.count
+    end
+
+    def resources_with_primary_file
+      @resources_with_primary_file ||= purl_object.contents.select do |purl_resource|
+        purl_resource.primary_file.present?
       end
     end
 

--- a/app/components/embed/media_tag_component.rb
+++ b/app/components/embed/media_tag_component.rb
@@ -6,6 +6,7 @@ module Embed
     with_collection_parameter :resource
     SUPPORTED_MEDIA_TYPES = %i[audio video].freeze
 
+    # @param [Purl::Resource] resource This resource is expected to have a primary file.
     def initialize(resource:, resource_iteration:, druid:, include_transcripts:, many_primary_files:)
       @resource = resource
       @resource_iteration = resource_iteration
@@ -15,10 +16,6 @@ module Embed
     end
 
     delegate :primary_file, :type, to: :@resource
-
-    def render?
-      primary_file.present?
-    end
 
     def call
       if SUPPORTED_MEDIA_TYPES.include?(type.to_sym)

--- a/app/components/embed/media_with_companion_windows_component.html.erb
+++ b/app/components/embed/media_with_companion_windows_component.html.erb
@@ -36,7 +36,7 @@
     <div class='sul-embed-body sul-embed-media'
       data-sul-embed-theme="<%= stylesheet_path('media.css') %>"
       data-sul-icons="<%= stylesheet_path('sul_icons.css') %>">
-      <%= render Embed::MediaTagComponent.with_collection(purl_object.contents,
+      <%= render Embed::MediaTagComponent.with_collection(resources_with_primary_file,
                                                     include_transcripts:,
                                                     druid:,
                                                     many_primary_files:) %>

--- a/app/components/embed/media_with_companion_windows_component.rb
+++ b/app/components/embed/media_with_companion_windows_component.rb
@@ -16,8 +16,12 @@ module Embed
     end
 
     def primary_files_count
-      purl_object.contents.count do |resource|
-        resource.primary_file.present?
+      resources_with_primary_file.count
+    end
+
+    def resources_with_primary_file
+      @resources_with_primary_file ||= purl_object.contents.select do |purl_resource|
+        purl_resource.primary_file.present?
       end
     end
 


### PR DESCRIPTION
Otherwise the index in MediaTagComponent might skip the sequence.  This is a problem because the `thumb_slider.js` expects sequential indexes.

Fixes #1627
