### PR TITLE
Render an icon in the media player for audio files that lack a poster

### DIFF
--- a/app/assets/images/waveform-audio-poster.svg
+++ b/app/assets/images/waveform-audio-poster.svg
@@ -1,0 +1,41 @@
+<svg width="624" height="497" viewBox="0 0 624 497" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="624" height="497" fill="url(#paint0_linear_5_108)"/>
+<g filter="url(#filter0_i_5_108)">
+<circle cx="312" cy="248" r="94" stroke="#E6E6E6" stroke-width="12"/>
+</g>
+<g filter="url(#filter1_i_5_108)">
+<rect x="246" y="234" width="12" height="25" rx="6" fill="#E6E6E6"/>
+<rect x="266" y="219" width="12" height="55" rx="6" fill="#E6E6E6"/>
+<rect x="286" y="191.5" width="12" height="110" rx="6" fill="#E6E6E6"/>
+<rect x="306" y="216.5" width="12" height="60" rx="6" fill="#E6E6E6"/>
+<rect x="326" y="204" width="12" height="85" rx="6" fill="#E6E6E6"/>
+<rect x="346" y="226.5" width="12" height="40" rx="6" fill="#E6E6E6"/>
+<rect x="366" y="234" width="12" height="25" rx="6" fill="#E6E6E6"/>
+</g>
+<defs>
+<filter id="filter0_i_5_108" x="208" y="148" width="204" height="200" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_5_108"/>
+</filter>
+<filter id="filter1_i_5_108" x="242" y="145" width="136" height="203" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_5_108"/>
+</filter>
+<linearGradient id="paint0_linear_5_108" x1="312" y1="0" x2="312" y2="497" gradientUnits="userSpaceOnUse">
+<stop stop-color="#323232"/>
+<stop offset="1" stop-color="#D9D9D9"/>
+</linearGradient>
+</defs>
+</svg>

--- a/app/components/embed/media_tag_component.rb
+++ b/app/components/embed/media_tag_component.rb
@@ -41,7 +41,7 @@ module Embed
                  auth_url: authentication_url(file),
                  media_tag_target: 'mediaTag'
                },
-               poster: poster_attribute(file),
+               poster: poster_url_for(file),
                controls: 'controls',
                crossorigin: 'anonymous',
                aria: { labelledby: "access-restricted-message-div-#{@resource_iteration.index}" },
@@ -73,16 +73,6 @@ module Embed
       return unless @include_transcripts && file.vtt
 
       tag.track(src: file.vtt.file_url, kind: 'captions', srclang: 'en', label: 'English')
-    end
-
-    def poster_attribute(file)
-      return unless file.thumbnail
-
-      if file.thumbnail.world_downloadable?
-        stacks_thumb_url(@druid, file.thumbnail.title, size: '!800,600')
-      else
-        stacks_thumb_url(@druid, file.thumbnail.title)
-      end
     end
 
     def access_restricted_message(stanford_only, location_restricted)
@@ -121,8 +111,12 @@ module Embed
       Settings.streaming[:source_types]
     end
 
+    def poster_url_for(file)
+      Embed::StacksMediaStream.new(druid: @druid, file:).to_thumbnail_url
+    end
+
     def streaming_url_for(file, type)
-      stacks_media_stream = Embed::StacksMediaStream.new(druid: @druid, file_name: file.title)
+      stacks_media_stream = Embed::StacksMediaStream.new(druid: @druid, file:)
       case type.to_sym
       when :hls
         stacks_media_stream.to_playlist_url

--- a/spec/components/embed/media_tag_component_spec.rb
+++ b/spec/components/embed/media_tag_component_spec.rb
@@ -203,8 +203,26 @@ RSpec.describe Embed::MediaTagComponent, type: :component do
   context 'with audio' do
     let(:purl) { audio_purl }
 
-    it 'renders an audo tag in the provided document' do
+    it 'renders an audio tag in the provided document' do
       expect(page).to have_css('audio', visible: :all)
+    end
+
+    context 'when a file-level thumbnail is present' do
+      let(:purl) { audio_purl_with_thumbnail }
+
+      it 'includes a poster attribute pointing at the thumbnail' do
+        expect(page).to have_css('audio[poster]', visible: :all)
+        audio = page.find('audio[poster]', visible: :all)
+        expect(audio['poster']).to match(%r{/bc123df4567%2Fabc_123_thumb/full/})
+      end
+    end
+
+    context 'when a file level thumbnail is not present' do
+      it 'includes the default poster attribute' do
+        expect(page).to have_css('audio[poster]', visible: :all)
+        audio = page.find('audio[poster]', visible: :all)
+        expect(audio['poster']).to match(/waveform-audio-poster/)
+      end
     end
   end
 

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -1200,6 +1200,27 @@ module PurlFixtures
     XML
   end
 
+  def audio_purl_with_thumbnail
+    <<-XML
+      <publicObject>
+        <identityMetadata>
+          <objectLabel>Title of the video</objectLabel>
+        </identityMetadata>
+        <contentMetadata type="media">
+          <resource sequence="1" id="abc123_1" type="audio">
+            <file id="abc_123.mp3" mimetype="audio/mpeg" size="770433"></file>
+            <file id="abc_123_thumb.jp2" mimetype="image/jp2" size="329964" publish="yes" shelve="yes" preserve="yes">
+              <imageData height="678" width="678"/>
+            </file>
+          </resource>
+        </contentMetadata>
+        <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+          <dc:title>DC title of audio</dc:title>
+        </oai_dc>
+      </publicObject>
+    XML
+  end
+
   def audio_purl_multiple
     <<-XML
       <publicObject>
@@ -1279,7 +1300,6 @@ module PurlFixtures
       </publicObject>
     XML
   end
-
 
   def pdf_document_purl
     <<-XML

--- a/spec/lib/embed/stacks_media_stream_spec.rb
+++ b/spec/lib/embed/stacks_media_stream_spec.rb
@@ -5,26 +5,68 @@ require 'rails_helper'
 RSpec.describe Embed::StacksMediaStream do
   let(:streaming_base_url) { Settings.stream.url }
 
+  describe '#to_thumbnail_url' do
+    let(:stream) { described_class.new(druid: 'ab012cd3456', file:) }
+
+    context 'when file has a world-downloadable thumbnail' do
+      let(:file) { instance_double(Embed::Purl::ResourceFile, title: 'def.mp4', thumbnail:) }
+      let(:thumbnail) { instance_double(Embed::Purl::ResourceFile, title: 'thumb.jp2', world_downloadable?: true) }
+
+      it 'uses a high-resolution thumbnail' do
+        expect(stream.to_thumbnail_url).to match(%r{ab012cd3456%2Fthumb/full/!800,600})
+      end
+    end
+
+    context 'when file has a non-world-downloadable thumbnail' do
+      let(:file) { instance_double(Embed::Purl::ResourceFile, title: 'def.mp4', thumbnail:) }
+      let(:thumbnail) { instance_double(Embed::Purl::ResourceFile, title: 'thumb.jp2', world_downloadable?: false) }
+
+      it 'uses a standard thumbnail' do
+        expect(stream.to_thumbnail_url).to match(%r{ab012cd3456%2Fthumb/full/!400,400})
+      end
+    end
+
+    context 'when file has no thumbnail' do
+      context 'when file is audio' do
+        let(:file) { instance_double(Embed::Purl::ResourceFile, title: 'def.m4a', thumbnail:) }
+        let(:thumbnail) { nil }
+
+        it 'uses the default audio thumbnail' do
+          expect(stream.to_thumbnail_url).to match(/waveform-audio-poster/)
+        end
+      end
+
+      context 'when file is not audio' do
+        let(:file) { instance_double(Embed::Purl::ResourceFile, title: 'def.mp4', thumbnail:) }
+        let(:thumbnail) { nil }
+
+        it 'returns nil' do
+          expect(stream.to_thumbnail_url).to be_nil
+        end
+      end
+    end
+  end
+
   describe '#to_playlist_url' do
     context 'video' do
       it 'mp4 extension' do
-        sms = described_class.new(druid: 'ab012cd3456', file_name: 'def.mp4')
+        sms = described_class.new(druid: 'ab012cd3456', file: instance_double(Embed::Purl::ResourceFile, title: 'def.mp4'))
         expect(sms.to_playlist_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp4:def.mp4/playlist.m3u8"
       end
 
       it 'mov extension' do
-        sms = described_class.new(druid: 'ab012cd3456', file_name: 'def.mov')
+        sms = described_class.new(druid: 'ab012cd3456', file: instance_double(Embed::Purl::ResourceFile, title: 'def.mov'))
         expect(sms.to_playlist_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp4:def.mov/playlist.m3u8"
       end
     end
 
     it 'audio - mp3' do
-      sms = described_class.new(druid: 'ab012cd3456', file_name: 'def.mp3')
+      sms = described_class.new(druid: 'ab012cd3456', file: instance_double(Embed::Purl::ResourceFile, title: 'def.mp3'))
       expect(sms.to_playlist_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp3:def.mp3/playlist.m3u8"
     end
 
     it 'unknown' do
-      sms = described_class.new(druid: 'ab012cd3456', file_name: 'def.xxx')
+      sms = described_class.new(druid: 'ab012cd3456', file: instance_double(Embed::Purl::ResourceFile, title: 'def.xxx'))
       expect(sms.to_playlist_url).to be_nil
     end
   end
@@ -32,28 +74,28 @@ RSpec.describe Embed::StacksMediaStream do
   describe '#to_manifest_url' do
     context 'video' do
       it 'mp4 extension' do
-        sms = described_class.new(druid: 'ab012cd3456', file_name: 'def.mp4')
+        sms = described_class.new(druid: 'ab012cd3456', file: instance_double(Embed::Purl::ResourceFile, title: 'def.mp4'))
         expect(sms.to_manifest_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp4:def.mp4/manifest.mpd"
       end
 
       it 'mov extension' do
-        sms = described_class.new(druid: 'ab012cd3456', file_name: 'def.mov')
+        sms = described_class.new(druid: 'ab012cd3456', file: instance_double(Embed::Purl::ResourceFile, title: 'def.mov'))
         expect(sms.to_manifest_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp4:def.mov/manifest.mpd"
       end
     end
 
     it 'audio - mp3' do
-      sms = described_class.new(druid: 'ab012cd3456', file_name: 'def.mp3')
+      sms = described_class.new(druid: 'ab012cd3456', file: instance_double(Embed::Purl::ResourceFile, title: 'def.mp3'))
       expect(sms.to_manifest_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp3:def.mp3/manifest.mpd"
     end
 
     it 'audio - m4a' do
-      sms = described_class.new(druid: 'ab012cd3456', file_name: 'def.m4a')
+      sms = described_class.new(druid: 'ab012cd3456', file: instance_double(Embed::Purl::ResourceFile, title: 'def.m4a'))
       expect(sms.to_manifest_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp4:def.m4a/manifest.mpd"
     end
 
     it 'unknown' do
-      sms = described_class.new(druid: 'ab012cd3456', file_name: 'def.xxx')
+      sms = described_class.new(druid: 'ab012cd3456', file: instance_double(Embed::Purl::ResourceFile, title: 'def.xxx'))
       expect(sms.to_manifest_url).to be_nil
     end
   end

--- a/spec/lib/embed/stacks_media_stream_spec.rb
+++ b/spec/lib/embed/stacks_media_stream_spec.rb
@@ -3,23 +3,23 @@
 require 'rails_helper'
 
 RSpec.describe Embed::StacksMediaStream do
+  subject(:stream) { described_class.new(druid: 'ab012cd3456', file:) }
+
+  let(:file) { instance_double(Embed::Purl::ResourceFile, title: media_filename, thumbnail:) }
+  let(:media_filename) { 'def.mp4' }
   let(:streaming_base_url) { Settings.stream.url }
+  let(:thumbnail) { instance_double(Embed::Purl::ResourceFile, title: 'thumb.jp2', world_downloadable?: world_downloadable) }
+  let(:world_downloadable) { true }
 
   describe '#to_thumbnail_url' do
-    let(:stream) { described_class.new(druid: 'ab012cd3456', file:) }
-
     context 'when file has a world-downloadable thumbnail' do
-      let(:file) { instance_double(Embed::Purl::ResourceFile, title: 'def.mp4', thumbnail:) }
-      let(:thumbnail) { instance_double(Embed::Purl::ResourceFile, title: 'thumb.jp2', world_downloadable?: true) }
-
       it 'uses a high-resolution thumbnail' do
         expect(stream.to_thumbnail_url).to match(%r{ab012cd3456%2Fthumb/full/!800,600})
       end
     end
 
     context 'when file has a non-world-downloadable thumbnail' do
-      let(:file) { instance_double(Embed::Purl::ResourceFile, title: 'def.mp4', thumbnail:) }
-      let(:thumbnail) { instance_double(Embed::Purl::ResourceFile, title: 'thumb.jp2', world_downloadable?: false) }
+      let(:world_downloadable) { false }
 
       it 'uses a standard thumbnail' do
         expect(stream.to_thumbnail_url).to match(%r{ab012cd3456%2Fthumb/full/!400,400})
@@ -27,9 +27,10 @@ RSpec.describe Embed::StacksMediaStream do
     end
 
     context 'when file has no thumbnail' do
+      let(:thumbnail) { nil }
+
       context 'when file is audio' do
-        let(:file) { instance_double(Embed::Purl::ResourceFile, title: 'def.m4a', thumbnail:) }
-        let(:thumbnail) { nil }
+        let(:media_filename) { 'def.m4a' }
 
         it 'uses the default audio thumbnail' do
           expect(stream.to_thumbnail_url).to match(/waveform-audio-poster/)
@@ -37,8 +38,7 @@ RSpec.describe Embed::StacksMediaStream do
       end
 
       context 'when file is not audio' do
-        let(:file) { instance_double(Embed::Purl::ResourceFile, title: 'def.mp4', thumbnail:) }
-        let(:thumbnail) { nil }
+        let(:media_file) { 'def.mp4' }
 
         it 'returns nil' do
           expect(stream.to_thumbnail_url).to be_nil
@@ -48,55 +48,74 @@ RSpec.describe Embed::StacksMediaStream do
   end
 
   describe '#to_playlist_url' do
-    context 'video' do
-      it 'mp4 extension' do
-        sms = described_class.new(druid: 'ab012cd3456', file: instance_double(Embed::Purl::ResourceFile, title: 'def.mp4'))
-        expect(sms.to_playlist_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp4:def.mp4/playlist.m3u8"
-      end
-
-      it 'mov extension' do
-        sms = described_class.new(druid: 'ab012cd3456', file: instance_double(Embed::Purl::ResourceFile, title: 'def.mov'))
-        expect(sms.to_playlist_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp4:def.mov/playlist.m3u8"
+    context 'with mp4 video' do
+      it 'has the expected URL' do
+        expect(stream.to_playlist_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp4:def.mp4/playlist.m3u8"
       end
     end
 
-    it 'audio - mp3' do
-      sms = described_class.new(druid: 'ab012cd3456', file: instance_double(Embed::Purl::ResourceFile, title: 'def.mp3'))
-      expect(sms.to_playlist_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp3:def.mp3/playlist.m3u8"
+    context 'with mov video' do
+      let(:media_filename) { 'def.mov' }
+
+      it 'has the expected URL' do
+        expect(stream.to_playlist_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp4:def.mov/playlist.m3u8"
+      end
     end
 
-    it 'unknown' do
-      sms = described_class.new(druid: 'ab012cd3456', file: instance_double(Embed::Purl::ResourceFile, title: 'def.xxx'))
-      expect(sms.to_playlist_url).to be_nil
+    context 'with mp3 audio' do
+      let(:media_filename) { 'def.mp3' }
+
+      it 'has the expected URL' do
+        expect(stream.to_playlist_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp3:def.mp3/playlist.m3u8"
+      end
+    end
+
+    context 'with an unknown file type' do
+      let(:media_filename) { 'def.xxx' }
+
+      it 'returns nil' do
+        expect(stream.to_playlist_url).to be_nil
+      end
     end
   end
 
   describe '#to_manifest_url' do
-    context 'video' do
-      it 'mp4 extension' do
-        sms = described_class.new(druid: 'ab012cd3456', file: instance_double(Embed::Purl::ResourceFile, title: 'def.mp4'))
-        expect(sms.to_manifest_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp4:def.mp4/manifest.mpd"
-      end
-
-      it 'mov extension' do
-        sms = described_class.new(druid: 'ab012cd3456', file: instance_double(Embed::Purl::ResourceFile, title: 'def.mov'))
-        expect(sms.to_manifest_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp4:def.mov/manifest.mpd"
+    context 'with mp4 video' do
+      it 'has the expected URL' do
+        expect(stream.to_manifest_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp4:def.mp4/manifest.mpd"
       end
     end
 
-    it 'audio - mp3' do
-      sms = described_class.new(druid: 'ab012cd3456', file: instance_double(Embed::Purl::ResourceFile, title: 'def.mp3'))
-      expect(sms.to_manifest_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp3:def.mp3/manifest.mpd"
+    context 'with mov video' do
+      let(:media_filename) { 'def.mov' }
+
+      it 'has the expected URL' do
+        expect(stream.to_manifest_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp4:def.mov/manifest.mpd"
+      end
     end
 
-    it 'audio - m4a' do
-      sms = described_class.new(druid: 'ab012cd3456', file: instance_double(Embed::Purl::ResourceFile, title: 'def.m4a'))
-      expect(sms.to_manifest_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp4:def.m4a/manifest.mpd"
+    context 'with mp3 audio' do
+      let(:media_filename) { 'def.mp3' }
+
+      it 'has the expected URL' do
+        expect(stream.to_manifest_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp3:def.mp3/manifest.mpd"
+      end
     end
 
-    it 'unknown' do
-      sms = described_class.new(druid: 'ab012cd3456', file: instance_double(Embed::Purl::ResourceFile, title: 'def.xxx'))
-      expect(sms.to_manifest_url).to be_nil
+    context 'with m4a audio' do
+      let(:media_filename) { 'def.m4a' }
+
+      it 'has the expected URL' do
+        expect(stream.to_manifest_url).to eq "https://#{streaming_base_url}/ab/012/cd/3456/mp4:def.m4a/manifest.mpd"
+      end
+    end
+
+    context 'with an unknown file type' do
+      let(:media_filename) { 'def.xxx' }
+
+      it 'returns nil' do
+        expect(stream.to_manifest_url).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #1532

Example (in UAT): https://sul-purl-uat.stanford.edu/bb106zh8988

![Screenshot from 2023-10-31 12-18-57](https://github.com/sul-dlss/sul-embed/assets/131982/0cb13dbf-6537-4d21-a95b-760a178a9350)
