### PR TITLE
Allow media to adjust to the changing container height

### DIFF
--- a/app/assets/stylesheets/media.scss
+++ b/app/assets/stylesheets/media.scss
@@ -99,7 +99,7 @@
   }
 
   .sul-embed-media-file {
-    height: 100%;
+    height: 100cqh;
     max-width: 100%;
   }
   


### PR DESCRIPTION
When the drawer slides out, we want to ensure the video scales to it's new container size rather than trying to maintain the initial size