### PR TITLE
Render video tags for Safari when an audio has captions

### DIFF
--- a/app/components/embed/media_tag_component.rb
+++ b/app/components/embed/media_tag_component.rb
@@ -40,8 +40,16 @@ module Embed
       end
     end
 
+    def media_tag_name
+      safari_wants_audio_with_captions? ? 'video' : type
+    end
+
+    def safari_wants_audio_with_captions?
+      type == 'audio' && request.headers['User-Agent'].include?('Safari') && render_captions?
+    end
+
     def media_tag # rubocop:disable Metrics/MethodLength
-      tag.send(type,
+      tag.send(media_tag_name,
                id: "sul-embed-media-#{@resource_iteration.index}",
                data: {
                  src: streaming_url_for(:dash),
@@ -79,9 +87,13 @@ module Embed
     end
 
     def transcript
-      return unless @include_transcripts && file.vtt
+      return unless render_captions?
 
       tag.track(src: file.vtt.file_url, kind: 'captions', srclang: 'en', label: 'English')
+    end
+
+    def render_captions?
+      @include_transcripts && file.vtt
     end
 
     def access_restricted_message

--- a/test/components/previews/embed/media_with_companion_windows_component_preview.rb
+++ b/test/components/previews/embed/media_with_companion_windows_component_preview.rb
@@ -6,7 +6,7 @@
 module Embed
   class MediaWithCompanionWindowsComponentPreview < ViewComponent::Preview
     def with_audio
-      embed_request = Embed::Request.new(url: 'https://purl.stanford.edu/bb169jj6514')
+      embed_request = Embed::Request.new(url: 'https://purl.stanford.edu/gj753wr1198')
       viewer = Embed::Viewer::Media.new(embed_request)
       render(MediaWithCompanionWindowsComponent.new(viewer:))
     end


### PR DESCRIPTION
Because Safari 16.6 doesn't show captions on an audio

Fixes #1635 