### PR TITLE
Use default thumbnail for media if dataset thumbnail URL is blank

### DIFF
--- a/app/assets/stylesheets/media.scss
+++ b/app/assets/stylesheets/media.scss
@@ -123,7 +123,7 @@
   .sul-embed-media-file {
     height: calc(100% - 54px);;
   }
-  
+
   .button-label {
     width: 100%;
     display: flex;
@@ -169,12 +169,12 @@
     background-color: var(--active-color);
     color: white;
     padding: .5rem;
-    
+
     .loginMessage {
       margin-left: 1rem;
     }
 
-    button { 
+    button {
       margin-left: 0.75rem;
       background-color: white;
       color: var(--active-color);
@@ -250,7 +250,7 @@
       padding: var(--drawer-content-padding);
       font-family: "Roboto", "Helvetica", "Arial", sans-serif;
     }
-    
+
     .metadataList, .rightsList {
       dt {
         font-size: 0.878rem;
@@ -285,6 +285,10 @@
       }
     }
 
+    .default-thumbnail-icon {
+      font-size: 64px;
+    }
+
     .sul-embed-media-slider-thumb {
       list-style-type: none;
       border: 1px solid gray;
@@ -296,7 +300,7 @@
         border-bottom: none;
       }
 
-      img { 
+      img {
         margin-right: 0.5rem;
       }
 

--- a/app/components/embed/media_wrapper_component.rb
+++ b/app/components/embed/media_wrapper_component.rb
@@ -19,7 +19,7 @@ module Embed
                 location_restricted: @file.location_restricted?,
                 file_label: @file.label,
                 slider_object: @file_index,
-                thumbnail_url: @thumbnail,
+                thumbnail_url: @thumbnail.presence,
                 default_icon: @type == 'audio' ? 'sul-i-file-music-1' : 'sul-i-file-video-3',
                 duration: @file.duration
               }) do

--- a/app/javascript/src/modules/media_thumbnail_builder.js
+++ b/app/javascript/src/modules/media_thumbnail_builder.js
@@ -9,10 +9,10 @@ export default function(dataset, index) {
     }
 
     let thumbnailIcon = '';
-    if (dataset.thumbnailUrl !== '') {
+    if (dataset.thumbnailUrl) {
       thumbnailIcon = `<img class="sul-embed-media-square-icon" src="${dataset.thumbnailUrl}" />`
     } else {
-      thumbnailIcon = `<i class="${dataset.defaultIcon}"></i>`
+      thumbnailIcon = `<i class="${dataset.defaultIcon} default-thumbnail-icon"></i>`
     }
 
     const isLocationRestricted = dataset.locationRestricted === "true"


### PR DESCRIPTION
Not just an empty string.

Fixes #1640

![Screenshot from 2023-11-03 11-14-59](https://github.com/sul-dlss/sul-embed/assets/131982/4ab16973-6634-4105-ab69-a7d73ed70bb5)
