### PR TITLE
Add message for citation-only to the media viewer

### DIFF
--- a/app/components/embed/media_with_companion_windows_component.html.erb
+++ b/app/components/embed/media_with_companion_windows_component.html.erb
@@ -40,6 +40,13 @@
       <button data-media-tag-target="embargoLoginButton" data-action="media-tag#logIn">Log in</button>
     </div>
   </div>
+  <% if citation_only? %>
+    <div class="authLinkWrapper">
+      <svg class="MuiSvgIcon-root" focusable="false" aria-hidden="true" viewBox="0 0 24 24"><path d="m14.5 14.2 2.9 1.7-.8 1.3L13 15v-5h1.5v4.2zM22 14c0 4.41-3.59 8-8 8-2.02 0-3.86-.76-5.27-2H4c-1.15 0-2-.85-2-2V9c0-1.12.89-1.96 2-2v-.5C4 4.01 6.01 2 8.5 2c2.34 0 4.24 1.79 4.46 4.08.34-.05.69-.08 1.04-.08 4.41 0 8 3.59 8 8zM6 7h5v-.74C10.88 4.99 9.8 4 8.5 4 7.12 4 6 5.12 6 6.5V7zm14 7c0-3.31-2.69-6-6-6s-6 2.69-6 6 2.69 6 6 6 6-2.69 6-6z"></path></svg>
+      <p class="loginMessage">This media cannot be accessed online. See access conditions for more information.</p>
+    </div>
+  <% end %>
+
 
   <div class="media-component-body">
     <aside class="left-drawer collapse" data-media-target="leftDrawer" id="left-drawer">

--- a/app/components/embed/media_with_companion_windows_component.rb
+++ b/app/components/embed/media_with_companion_windows_component.rb
@@ -9,7 +9,7 @@ module Embed
     attr_reader :viewer
 
     delegate :purl_object, to: :viewer
-    delegate :druid, to: :purl_object
+    delegate :druid, :citation_only?, to: :purl_object
 
     def include_transcripts
       Settings.enabled_features.transcripts || params[:transcripts] == 'true'

--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -5,7 +5,7 @@ module Embed
   class Purl
     require 'embed/media_duration'
     require 'dor/rights_auth'
-    delegate :embargoed?, :stanford_only_unrestricted?, :world_unrestricted?,
+    delegate :embargoed?, :citation_only?, :stanford_only_unrestricted?, :world_unrestricted?,
              :world_downloadable_file?, :stanford_only_downloadable_file?, to: :rights
     attr_reader :druid
 

--- a/spec/components/embed/media_with_companion_windows_component_spec.rb
+++ b/spec/components/embed/media_with_companion_windows_component_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Embed::MediaWithCompanionWindowsComponent, type: :component do
     instance_double(Embed::Purl,
                     title: 'foo',
                     purl_url: 'https://purl.stanford.edu/123',
+                    citation_only?: false,
                     use_and_reproduction: '',
                     copyright: '',
                     license: '',
@@ -28,5 +29,24 @@ RSpec.describe Embed::MediaWithCompanionWindowsComponent, type: :component do
     expect(page).to have_content 'Access is restricted to the reading room. See Access conditions for more information.'
     expect(page).to have_content 'Stanford users: log in to access all available features'
     expect(page).to have_content 'Access is restricted until the embargo has elapsed'
+  end
+
+  context 'when citation_only access' do
+    let(:purl_object) do
+      instance_double(Embed::Purl,
+                      title: 'foo',
+                      purl_url: 'https://purl.stanford.edu/123',
+                      citation_only?: true,
+                      use_and_reproduction: '',
+                      copyright: '',
+                      license: '',
+                      druid: '123',
+                      contents: [],
+                      downloadable_files: [])
+    end
+
+    it 'displays citation only message' do
+      expect(page).to have_content 'This media cannot be accessed online.'
+    end
   end
 end


### PR DESCRIPTION
Citation-only is a object-level access level, so we're checking it on the backend rather than on the front end as we do for the various file-acess restrictions. Fixes #1551