### PR TITLE
Implement share/download popover as buttons

### DIFF
--- a/app/assets/stylesheets/media.scss
+++ b/app/assets/stylesheets/media.scss
@@ -154,57 +154,27 @@
       background-color: var(--background-color);
     }
 
-    ul {
-      padding-top: 8px;
-      padding-bottom: 8px;
-      outline: 0;
-      margin: 0;
-      position: relative;
-      list-style: none;
+    .modal-component-button {
+      border: 0;
+      background-color: var(--background-color);
+      display: block;
+      width: 100%;
+      padding: 1.2rem;
+      text-align: left;
 
-      li {
-        display: flex;
-        position: relative;
-        text-align: left;
-        align-items: center;
-        justify-content: flex-start;
-        text-decoration: none;
-        vertical-align: middle;
-        width: auto;
-        overflow: hidden;
+      .modal-component-label {
         font-size: 1rem;
-        box-sizing: border-box;
-        min-height: 48px;
-        font-weight: 400;
         line-height: 1.6em;
-        white-space: nowrap;
-        letter-spacing: 0em;
-        padding-top: 6px;
-        padding-bottom: 6px;
-        padding-left: 16px;
-        padding-right: 16px;
+      }
 
-        &:hover {
-          cursor: pointer;
-          background-image: linear-gradient(rgb(0 0 0/10%) 0 0);
-        }
+      .modal-component-icon {
+        min-width: 32px;
+        vertical-align: middle;
+      }
 
-        div {
-          list-style: none;
-        }
-
-        .modal-component-text {
-          flex: 1 1 auto;
-          min-width: 0;
-          margin-top: 4px;
-          margin-bottom: 4px;
-        }
-
-        .modal-component-icon {
-          display: inline-flex;
-          min-width: 32px;
-          flex-shrink: 0;
-        }
+      &:hover {
+        cursor: pointer;
+        background-image: linear-gradient(rgb(0 0 0/10%) 0 0);
       }
     }
   }

--- a/app/components/embed/media_with_companion_windows_component.html.erb
+++ b/app/components/embed/media_with_companion_windows_component.html.erb
@@ -13,7 +13,7 @@
       </button>
     </nav>
   </header>
-  
+
   <div data-controller="auth-restriction" data-action="auth-denied@window->auth-restriction#displayMessage auth-success@window->auth-restriction#hideMessage">
     <div data-auth-restriction-target="locationRestriction" hidden="true">
       <div class="authLinkWrapper">
@@ -103,24 +103,14 @@
     <%= render Embed::Download::LegacyMediaComponent.new viewer: viewer %>
   </div>
   <dialog class="modal-components-popover" data-media-target="modalComponentsPopover" data-action="click->media#closePopover" id="share_and_download">
-    <ul role="menu">
-      <li role="menuitem" data-action="click->media#openShareModal" aria-label="Share" aria-controls="share">
-        <div class="modal-component-icon">
-          <svg class="MuiSvgIcon-root" focusable="false" viewBox="0 0 24 24" aria-hidden="true"><path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92s2.92-1.31 2.92-2.92-1.31-2.92-2.92-2.92z"></path></svg>
-        </div>
-        <div class="modal-component-text">
-          <span>Share</span>
-        </div>
-      </li>
-      <li role="menuitem" data-action="click->media#openDownloadModal" aria-label="Download" aria-controls="download">
-        <div class="modal-component-icon">
-          <svg class="MuiSvgIcon-root" focusable="false" aria-hidden="true" viewBox="0 0 24 24"><path d="M5 20h14v-2H5v2zM19 9h-4V3H9v6H5l7 7 7-7z"></path></svg>
-        </div>
-        <div class="modal-component-text">
-          <span>Download</span>
-        </div>
-      </li>
-    </ul>
+    <button class="modal-component-button" data-action="click->media#openShareModal" aria-label="Share" aria-controls="share" tabindex="0">
+      <svg class="MuiSvgIcon-root modal-component-icon" focusable="false" viewBox="0 0 24 24" aria-hidden="true"><path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92s2.92-1.31 2.92-2.92-1.31-2.92-2.92-2.92z"></path></svg>
+      <span class="modal-component-label">Share</span>
+    </button>
+    <button class="modal-component-button" data-action="click->media#openDownloadModal" aria-label="Download" aria-controls="download" tabindex="0">
+      <svg class="MuiSvgIcon-root modal-component-icon" focusable="false" aria-hidden="true" viewBox="0 0 24 24"><path d="M5 20h14v-2H5v2zM19 9h-4V3H9v6H5l7 7 7-7z"></path></svg>
+      <span class="modal-component-label">Download</span>
+    </button>
   </dialog>
 
   <dialog class="modal-container" data-media-target="shareModal" data-action="click->media#handleBackdropClicks" id="share">


### PR DESCRIPTION
Fixes #1727

This commit makes the share/download popover widget more accessible (because more easily keyboard-navigable), while retaining the prior look & feel.
