### PR TITLE
Reopen the component modal when closing share or download modals

### DIFF
--- a/app/components/embed/media_with_companion_windows_component.html.erb
+++ b/app/components/embed/media_with_companion_windows_component.html.erb
@@ -121,7 +121,7 @@
     <%= render Embed::Media::EmbedThisFormComponent.new(viewer:) %>
 
     <form method="dialog">
-      <button>Close</button>
+      <button data-action="click->media#openModalComponentsPopover">Close</button>
     </form>
   </dialog>
 
@@ -146,7 +146,7 @@
     </section>
 
     <form method="dialog">
-      <button>Close</button>
+      <button data-action="click->media#openModalComponentsPopover">Close</button>
     </form>
   </dialog>
 


### PR DESCRIPTION
Fixes #1736 

This re-opens the component modal that has the share and download buttons so that focus is returned to the selected button - especially when using keyboard navigation when either of the modals is closed.

![Screenshot 2023-11-13 at 10 37 10 AM](https://github.com/sul-dlss/sul-embed/assets/2294288/064a1ab8-39a5-4fb4-8dab-45ac21d13ab6)
