### PR TITLE
Use nil alt attr for locked media image

### DIFF
--- a/app/components/embed/media_with_companion_windows_component.html.erb
+++ b/app/components/embed/media_with_companion_windows_component.html.erb
@@ -90,7 +90,8 @@
     <div class='sul-embed-body sul-embed-media' id='sul-embed-body'>
       <div data-controller="locked-media-poster" data-action="auth-success@window->locked-media-poster#hide auth-denied@window->locked-media-poster#show" tabindex="-1" role="presentation" style="display: none; flex: 1 0 100%;">
         <picture class="locked-media">
-          <%= image_tag 'locked-media-poster.svg', loading: 'lazy' %>
+          <%# The explicitly empty alt is preferred here, since this image merely adds visual decoration. %>
+          <%= image_tag 'locked-media-poster.svg', loading: 'lazy', alt: '' %>
         </picture>
       </div>
 


### PR DESCRIPTION
Fixes #1738

The explicitly empty alt is preferred here, since this image merely adds visual decoration.
