### PR TITLE
Clarify text of accessibility modal

### DIFF
--- a/app/components/embed/media_with_companion_windows_component.html.erb
+++ b/app/components/embed/media_with_companion_windows_component.html.erb
@@ -156,7 +156,7 @@
       please send a request along with a link to this item to
       <a href="mailto:purl-feedback@lists.stanford.edu">purl-feedback@lists.stanford.edu</a>.</p>
 
-    <p>OR click the Share & download icon to download a transcript.</p>
+    <p>A transcript may be available for download. Click the share & download icon to see if a download is available.</p>
     <form method="dialog">
       <button>Close</button>
     </form>


### PR DESCRIPTION
This clarifies the text in the accessibility modal as suggested in https://github.com/sul-dlss/sul-embed/issues/1666#issuecomment-1802182948 while we investigate the logic available for determining IF a transcript is actually available and if any data remediation is required for that work.

![Screenshot 2023-11-13 at 2 43 55 PM](https://github.com/sul-dlss/sul-embed/assets/2294288/4d70916b-c018-425f-8d23-39ca3547707c)
