### PR TITLE
Rename stub methods to indicate xml

### DIFF
--- a/spec/components/embed/media_tag_component_spec.rb
+++ b/spec/components/embed/media_tag_component_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Embed::MediaTagComponent, type: :component do
   let(:many_primary_files) { false }
 
   before do
-    stub_purl_response_with_fixture(purl)
+    stub_purl_xml_response_with_fixture(purl)
     render
   end
 

--- a/spec/features/3d_viewer_spec.rb
+++ b/spec/features/3d_viewer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe '3D Viewer', :js do
   let(:purl) { threeD_object_purl }
 
   before do
-    stub_purl_response_with_fixture(purl)
+    stub_purl_xml_response_with_fixture(purl)
     visit_iframe_response
   end
 

--- a/spec/features/basic_functionality_spec.rb
+++ b/spec/features/basic_functionality_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'basic oembed functionality' do
   include PurlFixtures
   it 'returns a response with required parameters (xml)' do
-    stub_purl_response_with_fixture(file_purl)
+    stub_purl_xml_response_with_fixture(file_purl)
     visit embed_path(url: 'http://purl.stanford.edu/abc', format: 'xml')
     expect(page).to have_xpath '//oembed'
     expect(page).to have_xpath '//type'
@@ -13,7 +13,7 @@ RSpec.describe 'basic oembed functionality' do
   end
 
   it 'returns a response with correct parameter fields (xml)' do
-    stub_purl_response_with_fixture(file_purl)
+    stub_purl_xml_response_with_fixture(file_purl)
     visit embed_path(url: 'http://purl.stanford.edu/abc', format: 'xml')
     expect(page).to have_xpath '//type', text: 'rich'
     expect(page).to have_xpath('//title', text: 'File Title')

--- a/spec/features/download_panel_spec.rb
+++ b/spec/features/download_panel_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'download panel', :js do
   end
 
   it 'not shown for file viewer and leaves correctly formatted filenames alone' do
-    stub_purl_response_with_fixture(multi_file_purl)
+    stub_purl_xml_response_with_fixture(multi_file_purl)
     visit_iframe_response
     expect(page).to have_css '.sul-embed-body.sul-embed-file'
     expect(page).not_to have_css '.sul-embed-download-panel'
@@ -22,7 +22,7 @@ RSpec.describe 'download panel', :js do
   end
 
   it 'correctly encodes a wonky filename with spaces and a special character' do
-    stub_purl_response_with_fixture(wonky_filename_purl)
+    stub_purl_xml_response_with_fixture(wonky_filename_purl)
     visit_iframe_response
     link = page.find('.sul-embed-media-list a', match: :first)
     expect(link['href']).to eq('https://stacks.stanford.edu/file/druid:ignored/%23Title%20of%20the%20PDF.pdf') # this file link had a # and spaces, encoding is needed
@@ -30,7 +30,7 @@ RSpec.describe 'download panel', :js do
 
   describe 'hide download?' do
     before do
-      stub_purl_response_with_fixture(geo_purl_public)
+      stub_purl_xml_response_with_fixture(geo_purl_public)
     end
 
     it 'when selected should hide the button' do
@@ -46,7 +46,7 @@ RSpec.describe 'download panel', :js do
 
   describe 'download file count shows within download button' do
     it 'has the file count for multiple media files in the download panel' do
-      stub_purl_response_with_fixture(multi_media_purl)
+      stub_purl_xml_response_with_fixture(multi_media_purl)
       visit_iframe_response
       expect(page).to have_css '.sul-embed-body.sul-embed-media' # so shows download count
       within '.sul-i-download-3' do
@@ -55,7 +55,7 @@ RSpec.describe 'download panel', :js do
     end
 
     it 'only counts downloadable files' do
-      stub_purl_response_with_fixture(world_restricted_download_purl)
+      stub_purl_xml_response_with_fixture(world_restricted_download_purl)
       visit_iframe_response
       expect(page).to have_css '.sul-embed-body.sul-embed-media' # so shows download count
       within '.sul-i-download-3' do

--- a/spec/features/embed_this_panel_spec.rb
+++ b/spec/features/embed_this_panel_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'embed this panel', :js do
   let(:iframe_options) { {} }
 
   before do
-    stub_purl_response_with_fixture(spec_fixture)
+    stub_purl_xml_response_with_fixture(spec_fixture)
     visit_iframe_response('ab123cd4567', **iframe_options)
   end
 

--- a/spec/features/feature_testing_spec.rb
+++ b/spec/features/feature_testing_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'feature testing of viewers', :js do
   include PurlFixtures
   describe 'basic functionality' do
     it 'makes purl embed request and embed' do
-      stub_purl_response_with_fixture(file_purl)
+      stub_purl_xml_response_with_fixture(file_purl)
       visit_iframe_response
       expect(page).to have_css('.sul-embed-container')
       expect(page).to have_css('.sul-embed-header')
@@ -16,7 +16,7 @@ RSpec.describe 'feature testing of viewers', :js do
     end
 
     it 'hides the title when requested' do
-      stub_purl_response_with_fixture(file_purl)
+      stub_purl_xml_response_with_fixture(file_purl)
       visit_iframe_response('abc123', hide_title: true)
       expect(page).not_to have_css('.sul-embed-header-title')
     end
@@ -24,7 +24,7 @@ RSpec.describe 'feature testing of viewers', :js do
 
   describe 'file viewer' do
     it 'contains the file list' do
-      stub_purl_response_with_fixture(file_purl)
+      stub_purl_xml_response_with_fixture(file_purl)
       visit_iframe_response
       expect(page).to have_css('.sul-embed-file-list')
       expect(page).to have_css('.sul-embed-media-list')
@@ -39,7 +39,7 @@ RSpec.describe 'feature testing of viewers', :js do
     end
 
     it 'contains 4 files in file list' do
-      stub_purl_response_with_fixture(multi_resource_multi_type_purl)
+      stub_purl_xml_response_with_fixture(multi_resource_multi_type_purl)
       visit_iframe_response
       expect(page).to have_css('.sul-embed-count', count: 4)
     end

--- a/spec/features/file_hierarchy_spec.rb
+++ b/spec/features/file_hierarchy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'file viewer with hierarchy', :js do
   include PurlFixtures
   it 'renders hierarchy' do
-    stub_purl_response_with_fixture(hierarchical_file_purl)
+    stub_purl_xml_response_with_fixture(hierarchical_file_purl)
     visit_iframe_response
     expect(page).to have_content('2 items')
     # There are 2 files

--- a/spec/features/file_list_accessibility_spec.rb
+++ b/spec/features/file_list_accessibility_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'file list accessibility', :js do
   include PurlFixtures
   it 'page has relevant sr-only classes' do
-    stub_purl_response_with_fixture(hybrid_object_purl)
+    stub_purl_xml_response_with_fixture(hybrid_object_purl)
     visit_iframe_response
     expect(page).to have_css 'img.sul-embed-square-image[alt]', visible: :all
     expect(page).to have_content 'Download item 1'

--- a/spec/features/file_preview_spec.rb
+++ b/spec/features/file_preview_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'file preview', :js do
   include PurlFixtures
   it 'displays a toggle-able section image preview' do
-    stub_purl_response_with_fixture(hybrid_object_purl)
+    stub_purl_xml_response_with_fixture(hybrid_object_purl)
     visit_iframe_response
     expect(page).not_to have_css('.sul-embed-preview', visible: :visible)
     expect(page).to have_css('.sul-embed-preview-toggle', count: 1, text: 'Preview')
@@ -16,7 +16,7 @@ RSpec.describe 'file preview', :js do
   end
 
   it 'displays sul-embed-square-image for file list icon' do
-    stub_purl_response_with_fixture(hybrid_object_purl)
+    stub_purl_xml_response_with_fixture(hybrid_object_purl)
     visit_iframe_response('ab123cd4567')
     click_link('Preview')
     expect(page).to have_css('.sul-embed-square-image', visible: :all)
@@ -24,7 +24,7 @@ RSpec.describe 'file preview', :js do
   end
 
   it 'has (hidden) thumb image' do
-    stub_purl_response_with_fixture(hybrid_object_purl)
+    stub_purl_xml_response_with_fixture(hybrid_object_purl)
     visit_iframe_response('ab123cd4567')
     click_link('Preview')
     expect(page).to have_css('.sul-embed-preview')

--- a/spec/features/file_search_spec.rb
+++ b/spec/features/file_search_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'file viewer search bar', :js do
 
   context 'when text is entered with a file list' do
     it 'limits shown files' do
-      stub_purl_response_with_fixture(file_purl)
+      stub_purl_xml_response_with_fixture(file_purl)
       visit_iframe_response('abc123', min_files_to_search: 1)
       expect(page).to have_css('.sul-embed-count', count: 1)
       expect(page).to have_css '.sul-embed-item-count', text: '1 item'
@@ -21,7 +21,7 @@ RSpec.describe 'file viewer search bar', :js do
 
   context 'when text is entered with a hierarchical file list' do
     it 'hides empty directories' do
-      stub_purl_response_with_fixture(hierarchical_file_purl)
+      stub_purl_xml_response_with_fixture(hierarchical_file_purl)
       visit_iframe_response('abc123', min_files_to_search: 1)
       expect(page).to have_css '.sul-embed-item-count', text: '2 items'
       expect(page).to have_content('dir1')
@@ -41,13 +41,13 @@ RSpec.describe 'file viewer search bar', :js do
 
   context 'when the number of files are beneath the threshold' do
     it 'does not display the search box' do
-      stub_purl_response_with_fixture(file_purl)
+      stub_purl_xml_response_with_fixture(file_purl)
       visit_iframe_response
       expect(page).not_to have_css('.sul-embed-search-input')
     end
 
     it 'hides the search box when requested' do
-      stub_purl_response_with_fixture(file_purl)
+      stub_purl_xml_response_with_fixture(file_purl)
       visit_iframe_response('abc123', hide_search: true)
       expect(page).not_to have_css('.sul-embed-search')
     end

--- a/spec/features/geo_viewer_spec.rb
+++ b/spec/features/geo_viewer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'geo viewer public', :js do
   include PurlFixtures
 
   before do
-    stub_purl_response_with_fixture(geo_purl_public)
+    stub_purl_xml_response_with_fixture(geo_purl_public)
     visit_iframe_response('cz128vq0535')
   end
 
@@ -60,7 +60,7 @@ RSpec.describe 'geo viewer restricted', :js do
   include PurlFixtures
 
   before do
-    stub_purl_response_with_fixture(geo_purl_restricted)
+    stub_purl_xml_response_with_fixture(geo_purl_restricted)
     visit_iframe_response
   end
 
@@ -82,7 +82,7 @@ RSpec.describe 'geo index map viewer', :js do
   include PurlFixtures
 
   before do
-    stub_purl_response_with_fixture(geo_purl_index_map)
+    stub_purl_xml_response_with_fixture(geo_purl_index_map)
     visit_iframe_response 'ts545zc6250'
   end
 

--- a/spec/features/legacy_media_viewer_spec.rb
+++ b/spec/features/legacy_media_viewer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'The old media viewer', :js do
   before do
     allow(Settings.streaming).to receive(:auth_url).and_return('/test_auth_jsonp_endpoint')
     stub_auth
-    stub_purl_response_with_fixture(purl)
+    stub_purl_xml_response_with_fixture(purl)
     visit_iframe_response
   end
 

--- a/spec/features/media_viewer_spec.rb
+++ b/spec/features/media_viewer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Media viewer', :js do
   before do
     allow(Settings.enabled_features).to receive(:new_component).and_return(true)
     stub_auth
-    stub_purl_response_with_fixture(purl)
+    stub_purl_xml_response_with_fixture(purl)
     visit_iframe_response
   end
 

--- a/spec/features/metadata_panel_spec.rb
+++ b/spec/features/metadata_panel_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'metadata panel', :js do
   end
 
   it 'is present after a user clicks the button' do
-    stub_purl_response_with_fixture(file_purl)
+    stub_purl_xml_response_with_fixture(file_purl)
     visit_iframe_response
     expect(page).to have_css('.sul-embed-metadata-panel', visible: :hidden)
     page.find('[data-sul-embed-toggle="sul-embed-metadata-panel"]', match: :first).click
@@ -23,7 +23,7 @@ RSpec.describe 'metadata panel', :js do
   end
 
   it 'has purl link, use and reproduction, and license text' do
-    stub_purl_response_with_fixture(file_purl)
+    stub_purl_xml_response_with_fixture(file_purl)
     visit_iframe_response
     page.find('[data-sul-embed-toggle="sul-embed-metadata-panel"]', match: :first).click
     expect(page).to have_css('dt', text: 'Citation URL', visible: :all)

--- a/spec/features/pdf_viewer_spec.rb
+++ b/spec/features/pdf_viewer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'PDF Viewer', :js do
   let(:purl) { pdf_document_purl }
 
   before do
-    stub_purl_response_with_fixture(purl)
+    stub_purl_xml_response_with_fixture(purl)
     visit_iframe_response
   end
 

--- a/spec/features/sandbox_spec.rb
+++ b/spec/features/sandbox_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'embed sandbox page', :js do
   include PurlFixtures
 
   before do
-    stub_purl_response_with_fixture(file_purl)
+    stub_purl_xml_response_with_fixture(file_purl)
   end
 
   it 'returns the iframe output from the embed endpoint' do

--- a/spec/features/was_seed_viewer_spec.rb
+++ b/spec/features/was_seed_viewer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'was seed viewer public', :js do
   before do
     allow_any_instance_of(Embed::WasTimeMap).to receive(:redirectable_connection).and_return(fake_connection)
     expect(fake_connection).to receive(:get).once
-    stub_purl_response_with_fixture(was_seed_purl)
+    stub_purl_xml_response_with_fixture(was_seed_purl)
     visit_iframe_response
   end
 

--- a/spec/lib/embed/viewer/common_viewer_spec.rb
+++ b/spec/lib/embed/viewer/common_viewer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Embed::Viewer::CommonViewer do
       expect(request).to receive(:maxheight).at_least(:once).and_return(100)
       expect(request).to receive(:maxwidth).at_least(:once).and_return(200)
       stub_purl_request(request)
-      stub_purl_response_with_fixture(multi_file_purl)
+      stub_purl_xml_response_with_fixture(multi_file_purl)
       expect(file_viewer.height).to eq 100
       expect(file_viewer.width).to eq 200
     end

--- a/spec/lib/embed/viewer/file_spec.rb
+++ b/spec/lib/embed/viewer/file_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Embed::Viewer::File do
   end
 
   describe 'height' do
-    before { stub_purl_response_with_fixture(multi_file_purl) }
+    before { stub_purl_xml_response_with_fixture(multi_file_purl) }
 
     context 'when the requested maxheight is larger than the default height' do
       let(:request) { Embed::Request.new(url: 'http://purl.stanford.edu/abc123', maxheight: 600) }
@@ -55,17 +55,17 @@ RSpec.describe Embed::Viewer::File do
       end
 
       it 'defaults to 323' do
-        stub_purl_response_and_request(multi_resource_multi_type_purl, request)
+        stub_purl_xml_response_and_request(multi_resource_multi_type_purl, request)
         expect(file_viewer.send(:default_height)).to eq 323
       end
 
       it 'reduces the height based on the number of files in the object (1 file), but no lower than our min height' do
-        stub_purl_response_and_request(file_purl, request)
+        stub_purl_xml_response_and_request(file_purl, request)
         expect(file_viewer.send(:default_height)).to eq 189
       end
 
       it 'reduces the height based on the number of files in the object (2 files)' do
-        stub_purl_response_and_request(image_purl, request)
+        stub_purl_xml_response_and_request(image_purl, request)
         expect(file_viewer.send(:default_height)).to eq 189
       end
     end
@@ -77,7 +77,7 @@ RSpec.describe Embed::Viewer::File do
       end
 
       it 'adds 44 pixels to the height (to avoid unnecessary scroll)' do
-        stub_purl_response_and_request(embargoed_stanford_file_purl, request)
+        stub_purl_xml_response_and_request(embargoed_stanford_file_purl, request)
 
         expect(file_viewer.send(:default_height)).to eq 189 # minimum height
       end
@@ -89,7 +89,7 @@ RSpec.describe Embed::Viewer::File do
       end
 
       it 'adds the necessary height' do
-        stub_purl_response_and_request(file_purl, request)
+        stub_purl_xml_response_and_request(file_purl, request)
         expect(file_viewer.send(:default_height)).to eq 190
       end
     end
@@ -107,7 +107,7 @@ RSpec.describe Embed::Viewer::File do
 
     context 'when the title bar is hidden but a search is present' do
       before do
-        stub_purl_response_and_request(multi_resource_multi_type_purl, request)
+        stub_purl_xml_response_and_request(multi_resource_multi_type_purl, request)
         expect(file_viewer).to receive(:min_files_to_search).and_return(3)
         expect(request).to receive(:hide_title?).at_least(:once).and_return(true)
       end
@@ -140,19 +140,19 @@ RSpec.describe Embed::Viewer::File do
     subject { file_viewer.display_download_all? }
 
     context 'when there are not many files and the size is low' do
-      before { stub_purl_response_with_fixture(multi_file_purl) }
+      before { stub_purl_xml_response_with_fixture(multi_file_purl) }
 
       it { is_expected.to be true }
     end
 
     context 'when the files are too big' do
-      before { stub_purl_response_with_fixture(large_file_purl) }
+      before { stub_purl_xml_response_with_fixture(large_file_purl) }
 
       it { is_expected.to be false }
     end
 
     context 'when there are too many files' do
-      before { stub_purl_response_with_fixture(many_file_purl) }
+      before { stub_purl_xml_response_with_fixture(many_file_purl) }
 
       it { is_expected.to be false }
     end
@@ -162,13 +162,13 @@ RSpec.describe Embed::Viewer::File do
     subject { file_viewer.any_stanford_only_files? }
 
     context 'when one or more files are stanford only' do
-      before { stub_purl_response_with_fixture(stanford_restricted_download_purl) }
+      before { stub_purl_xml_response_with_fixture(stanford_restricted_download_purl) }
 
       it { is_expected.to be true }
     end
 
     context 'when no files are stanford only' do
-      before { stub_purl_response_with_fixture(multi_resource_multi_type_purl) }
+      before { stub_purl_xml_response_with_fixture(multi_resource_multi_type_purl) }
 
       it { is_expected.to be false }
     end
@@ -177,7 +177,7 @@ RSpec.describe Embed::Viewer::File do
   describe '#download_url' do
     subject { file_viewer.download_url }
 
-    before { stub_purl_response_with_fixture(file_purl) }
+    before { stub_purl_xml_response_with_fixture(file_purl) }
 
     it { is_expected.to eq 'https://stacks.stanford.edu/object/abc123' }
   end

--- a/spec/lib/embed/viewer/geo_spec.rb
+++ b/spec/lib/embed/viewer/geo_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Embed::Viewer::Geo do
 
   describe '#map_element_options' do
     it 'for public content' do
-      stub_purl_response_and_request(geo_purl_public, request)
+      stub_purl_xml_response_and_request(geo_purl_public, request)
       expect(geo_viewer.map_element_options).to be_an Hash
       expect(geo_viewer.map_element_options).to include style: 'flex: 1'
       expect(geo_viewer.map_element_options).to include id: 'sul-embed-geo-map'
@@ -32,7 +32,7 @@ RSpec.describe Embed::Viewer::Geo do
     end
 
     it 'for restricted content' do
-      stub_purl_response_and_request(geo_purl_restricted, request)
+      stub_purl_xml_response_and_request(geo_purl_restricted, request)
       expect(geo_viewer.map_element_options).to be_an Hash
       expect(geo_viewer.map_element_options).to include style: 'flex: 1'
       expect(geo_viewer.map_element_options).to include id: 'sul-embed-geo-map'

--- a/spec/lib/embed/viewer/was_seed_spec.rb
+++ b/spec/lib/embed/viewer/was_seed_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Embed::Viewer::WasSeed do
 
   describe '#archived_site_url' do
     it 'parses a mods archived site' do
-      stub_purl_response_and_request(was_seed_purl, request)
+      stub_purl_xml_response_and_request(was_seed_purl, request)
       expect(was_seed_viewer.archived_site_url).to eq 'https://swap.stanford.edu/*/http://naca.central.cranfield.ac.uk/'
     end
   end
@@ -34,7 +34,7 @@ RSpec.describe Embed::Viewer::WasSeed do
 
     context 'with a valid url' do
       before do
-        stub_purl_response_and_request(was_seed_purl, request)
+        stub_purl_xml_response_and_request(was_seed_purl, request)
       end
 
       it { is_expected.to eq 'https://swap.stanford.edu/timemap/http://naca.central.cranfield.ac.uk/' }
@@ -79,7 +79,7 @@ RSpec.describe Embed::Viewer::WasSeed do
       end
 
       before do
-        stub_purl_response_and_request(invalid, request)
+        stub_purl_xml_response_and_request(invalid, request)
       end
 
       it { is_expected.to be_nil }
@@ -88,7 +88,7 @@ RSpec.describe Embed::Viewer::WasSeed do
 
   describe '#shelved_thumb' do
     it 'parses a mods archived site' do
-      stub_purl_response_and_request(was_seed_purl, request)
+      stub_purl_xml_response_and_request(was_seed_purl, request)
       expect(was_seed_viewer.shelved_thumb).to eq 'https://stacks.stanford.edu/image/iiif/12345%2Fthumbnail/full/200,/0/default.jpg'
     end
   end
@@ -117,7 +117,7 @@ RSpec.describe Embed::Viewer::WasSeed do
 
   describe '.external_url' do
     it 'builds the external url based on wayback url as extracted from prul' do
-      stub_purl_response_and_request(was_seed_purl, request)
+      stub_purl_xml_response_and_request(was_seed_purl, request)
       expect(was_seed_viewer.external_url).to eq('https://swap.stanford.edu/*/http://naca.central.cranfield.ac.uk/')
     end
   end

--- a/spec/lib/embed/viewer_factory_spec.rb
+++ b/spec/lib/embed/viewer_factory_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Embed::ViewerFactory do
     subject { instance }
 
     context 'invalid Purl object' do
-      before { stub_purl_response_with_fixture(empty_content_metadata_purl) }
+      before { stub_purl_xml_response_with_fixture(empty_content_metadata_purl) }
 
       it 'raises an error' do
         expect { subject }.to raise_error(Embed::Purl::ResourceNotEmbeddable)
@@ -21,7 +21,7 @@ RSpec.describe Embed::ViewerFactory do
     end
 
     context 'valid Purl object' do
-      before { stub_purl_response_with_fixture(file_purl) }
+      before { stub_purl_xml_response_with_fixture(file_purl) }
 
       it 'initializes successfully' do
         expect { subject }.not_to raise_error
@@ -32,7 +32,7 @@ RSpec.describe Embed::ViewerFactory do
   describe '#viewer' do
     subject { instance.viewer }
 
-    before { stub_purl_response_with_fixture(image_purl) }
+    before { stub_purl_xml_response_with_fixture(image_purl) }
 
     context 'when the request has a type' do
       it { is_expected.to be_a Embed::Viewer::M3Viewer }

--- a/spec/models/embed/hierarchical_contents_spec.rb
+++ b/spec/models/embed/hierarchical_contents_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Embed::HierarchicalContents do
   include PurlFixtures
 
   describe '#contents' do
-    before { stub_purl_response_with_fixture(hierarchical_file_purl) }
+    before { stub_purl_xml_response_with_fixture(hierarchical_file_purl) }
 
     let(:root_dir) { described_class.contents(resources) }
     let(:resources) { Embed::Purl.new('12345').contents }

--- a/spec/models/embed/purl/resource_file_spec.rb
+++ b/spec/models/embed/purl/resource_file_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Embed::Purl::ResourceFile do
   include PurlFixtures
   describe 'attributes' do
-    before { stub_purl_response_with_fixture(file_purl) }
+    before { stub_purl_xml_response_with_fixture(file_purl) }
 
     let(:resource_file) { Embed::Purl.new('12345').contents.first.files.first }
 
@@ -66,7 +66,7 @@ RSpec.describe Embed::Purl::ResourceFile do
   end
 
   describe '#hierarchical_title' do
-    before { stub_purl_response_with_fixture(hierarchical_file_purl) }
+    before { stub_purl_xml_response_with_fixture(hierarchical_file_purl) }
 
     let(:resource_file) { Embed::Purl.new('12345').hierarchical_contents.dirs.first.dirs.first.files.first }
 
@@ -151,24 +151,24 @@ RSpec.describe Embed::Purl::ResourceFile do
 
   describe 'previewable?' do
     it 'returns true if the mimetype of the file is previewable' do
-      stub_purl_response_with_fixture(image_purl)
+      stub_purl_xml_response_with_fixture(image_purl)
       expect(Embed::Purl.new('12345').contents.first.files.first).to be_previewable
     end
 
     it 'returns false if the mimetype of the file is not previewable' do
-      stub_purl_response_with_fixture(file_purl)
+      stub_purl_xml_response_with_fixture(file_purl)
       expect(Embed::Purl.new('12345').contents.first.files.first).not_to be_previewable
     end
   end
 
   describe 'image?' do
     it 'returns true if the mimetype of the file is an image' do
-      stub_purl_response_with_fixture(image_purl)
+      stub_purl_xml_response_with_fixture(image_purl)
       expect(Embed::Purl.new('12345').contents.first.files.first).to be_image
     end
 
     it 'returns false if the mimetype of the file is not an image' do
-      stub_purl_response_with_fixture(file_purl)
+      stub_purl_xml_response_with_fixture(file_purl)
       expect(Embed::Purl.new('12345').contents.first.files.first).not_to be_image
     end
   end
@@ -176,22 +176,22 @@ RSpec.describe Embed::Purl::ResourceFile do
   describe 'rights' do
     describe 'stanford_only?' do
       it 'identifies stanford_only objects' do
-        stub_purl_response_with_fixture(stanford_restricted_file_purl)
+        stub_purl_xml_response_with_fixture(stanford_restricted_file_purl)
         expect(Embed::Purl.new('12345').contents.first.files.all?(&:stanford_only?)).to be true
       end
 
       it 'identifies stanford_only no-download objects' do
-        stub_purl_response_with_fixture(stanford_no_download_restricted_file_purl)
+        stub_purl_xml_response_with_fixture(stanford_no_download_restricted_file_purl)
         expect(Embed::Purl.new('12345').contents.first.files.all?(&:stanford_only?)).to be true
       end
 
       it 'identifies world accessible objects as not stanford only' do
-        stub_purl_response_with_fixture(file_purl)
+        stub_purl_xml_response_with_fixture(file_purl)
         expect(Embed::Purl.new('12345').contents.first.files.all?(&:stanford_only?)).to be false
       end
 
       it 'identifies file-level stanford_only rights' do
-        stub_purl_response_with_fixture(stanford_restricted_multi_file_purl)
+        stub_purl_xml_response_with_fixture(stanford_restricted_multi_file_purl)
         contents = Embed::Purl.new('12345').contents
         first_file = contents.first.files.first
         last_file = contents.last.files.first
@@ -202,17 +202,17 @@ RSpec.describe Embed::Purl::ResourceFile do
 
     describe 'location_restricted?' do
       it 'identifies location restricted objects' do
-        stub_purl_response_with_fixture(single_video_purl)
+        stub_purl_xml_response_with_fixture(single_video_purl)
         expect(Embed::Purl.new('12345').contents.first.files.all?(&:location_restricted?)).to be true
       end
 
       it 'identifies world accessible objects as not stanford only' do
-        stub_purl_response_with_fixture(file_purl)
+        stub_purl_xml_response_with_fixture(file_purl)
         expect(Embed::Purl.new('12345').contents.first.files.all?(&:location_restricted?)).to be false
       end
 
       it 'identifies file-level location_restricted rights' do
-        stub_purl_response_with_fixture(video_purl)
+        stub_purl_xml_response_with_fixture(video_purl)
         contents = Embed::Purl.new('12345').contents
         first_file = contents.first.files.first
         last_file = contents.last.files.first
@@ -223,24 +223,24 @@ RSpec.describe Embed::Purl::ResourceFile do
 
     describe 'world_downloadable?' do
       it 'is false for stanford-only objects' do
-        stub_purl_response_with_fixture(stanford_restricted_file_purl)
+        stub_purl_xml_response_with_fixture(stanford_restricted_file_purl)
         expect(Embed::Purl.new('12345').contents.first.files.all?(&:world_downloadable?)).to be false
       end
 
       it 'is false for no-download objects' do
-        stub_purl_response_with_fixture(stanford_no_download_restricted_file_purl)
+        stub_purl_xml_response_with_fixture(stanford_no_download_restricted_file_purl)
         expect(Embed::Purl.new('12345').contents.first.files.all?(&:world_downloadable?)).to be false
       end
 
       it 'is true for identify world accessible objects' do
-        stub_purl_response_with_fixture(file_purl)
+        stub_purl_xml_response_with_fixture(file_purl)
         expect(Embed::Purl.new('12345').contents.first.files.all?(&:world_downloadable?)).to be true
       end
     end
   end
 
   describe 'image data' do
-    before { stub_purl_response_with_fixture(image_purl) }
+    before { stub_purl_xml_response_with_fixture(image_purl) }
 
     let(:image) { Embed::Purl.new('12345').contents.first.files.first }
 
@@ -251,7 +251,7 @@ RSpec.describe Embed::Purl::ResourceFile do
   end
 
   describe 'file data' do
-    before { stub_purl_response_with_fixture(file_purl) }
+    before { stub_purl_xml_response_with_fixture(file_purl) }
 
     let(:file) { Embed::Purl.new('12345').contents.first.files.first }
 
@@ -303,7 +303,7 @@ RSpec.describe Embed::Purl::ResourceFile do
 
   describe 'video_data' do
     context 'with valid videoData' do
-      before { stub_purl_response_with_fixture(multi_media_purl) }
+      before { stub_purl_xml_response_with_fixture(multi_media_purl) }
 
       let(:video) { Embed::Purl.new('12345').contents.first.files.first }
 
@@ -320,7 +320,7 @@ RSpec.describe Embed::Purl::ResourceFile do
     context 'when it is a vtt transcript' do
       let(:file) { Embed::Purl.new('12345').contents.first.files.second }
 
-      before { stub_purl_response_with_fixture(video_purl_with_vtt) }
+      before { stub_purl_xml_response_with_fixture(video_purl_with_vtt) }
 
       it { is_expected.to be true }
     end
@@ -328,7 +328,7 @@ RSpec.describe Embed::Purl::ResourceFile do
     context 'when it is not a vtt transcript' do
       let(:file) { Embed::Purl.new('12345').contents.first.files.first }
 
-      before { stub_purl_response_with_fixture(single_video_purl) }
+      before { stub_purl_xml_response_with_fixture(single_video_purl) }
 
       it { is_expected.to be false }
     end

--- a/spec/models/embed/purl/resource_spec.rb
+++ b/spec/models/embed/purl/resource_spec.rb
@@ -5,17 +5,17 @@ require 'rails_helper'
 RSpec.describe Embed::Purl::Resource do
   include PurlFixtures
   it 'gets the type attribute' do
-    stub_purl_response_with_fixture(file_purl)
+    stub_purl_xml_response_with_fixture(file_purl)
     expect(Embed::Purl.new('12345').contents.first.type).to eq 'file'
   end
 
   it 'gets the description from the label element' do
-    stub_purl_response_with_fixture(file_purl)
+    stub_purl_xml_response_with_fixture(file_purl)
     expect(Embed::Purl.new('12345').contents.first.description).to eq 'File1 Label'
   end
 
   it 'gets the description from the attr[name="label"] element' do
-    stub_purl_response_with_fixture(multi_file_purl)
+    stub_purl_xml_response_with_fixture(multi_file_purl)
     expect(Embed::Purl.new('12345').contents.first.description).to eq 'File1 Label'
   end
 
@@ -45,7 +45,7 @@ RSpec.describe Embed::Purl::Resource do
 
   describe 'files' do
     it 'returns an array of Purl::Resource::ResourceFile objects' do
-      stub_purl_response_with_fixture(file_purl)
+      stub_purl_xml_response_with_fixture(file_purl)
       expect(Embed::Purl.new('12345').contents.first.files.all?(Embed::Purl::ResourceFile)).to be true
     end
   end
@@ -56,7 +56,7 @@ RSpec.describe Embed::Purl::Resource do
     context 'when it has a vtt transcript' do
       subject { resource.vtt.title }
 
-      before { stub_purl_response_with_fixture(video_purl_with_vtt) }
+      before { stub_purl_xml_response_with_fixture(video_purl_with_vtt) }
 
       it { is_expected.to eq 'abc_123_cap.webvtt' }
     end
@@ -64,7 +64,7 @@ RSpec.describe Embed::Purl::Resource do
     context 'when it does not have a vtt transcript' do
       subject { resource.vtt }
 
-      before { stub_purl_response_with_fixture(single_video_purl) }
+      before { stub_purl_xml_response_with_fixture(single_video_purl) }
 
       it { is_expected.to be_nil }
     end

--- a/spec/models/embed/purl_spec.rb
+++ b/spec/models/embed/purl_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Embed::Purl do
   include PurlFixtures
   describe 'title' do
-    before { stub_purl_response_with_fixture(file_purl) }
+    before { stub_purl_xml_response_with_fixture(file_purl) }
 
     it 'gets the objectLabel from the identityMetadata' do
       expect(described_class.new('12345').title).to eq 'File Title'
@@ -13,7 +13,7 @@ RSpec.describe Embed::Purl do
   end
 
   describe 'type' do
-    before { stub_purl_response_with_fixture(file_purl) }
+    before { stub_purl_xml_response_with_fixture(file_purl) }
 
     it 'gets the type attribute from the content metadata' do
       expect(described_class.new('12345').type).to eq 'file'
@@ -22,30 +22,30 @@ RSpec.describe Embed::Purl do
 
   describe 'embargoed?' do
     it 'returns true when an item is embargoed' do
-      stub_purl_response_with_fixture(embargoed_file_purl)
+      stub_purl_xml_response_with_fixture(embargoed_file_purl)
       expect(described_class.new('12345')).to be_embargoed
     end
 
     it 'returns false when an item is not embargoed' do
-      stub_purl_response_with_fixture(file_purl)
+      stub_purl_xml_response_with_fixture(file_purl)
       expect(described_class.new('12345')).not_to be_embargoed
     end
   end
 
   describe '#world_unrestricted?' do
     it 'without a world restriction' do
-      stub_purl_response_with_fixture(image_purl)
+      stub_purl_xml_response_with_fixture(image_purl)
       expect(described_class.new('12345')).to be_world_unrestricted
     end
 
     it 'when it has a world restriction' do
-      stub_purl_response_with_fixture(stanford_restricted_image_purl)
+      stub_purl_xml_response_with_fixture(stanford_restricted_image_purl)
       expect(described_class.new('12345')).not_to be_world_unrestricted
     end
   end
 
   describe 'embargo_release_date' do
-    before { stub_purl_response_with_fixture(embargoed_file_purl) }
+    before { stub_purl_xml_response_with_fixture(embargoed_file_purl) }
 
     it 'returns the date in the embargo field' do
       expect(described_class.new('12345').embargo_release_date).to match(/\d{4}-\d{2}-\d{2}/)
@@ -54,7 +54,7 @@ RSpec.describe Embed::Purl do
 
   describe 'valid?' do
     context 'with empty content metadata' do
-      before { stub_purl_response_with_fixture(empty_content_metadata_purl) }
+      before { stub_purl_xml_response_with_fixture(empty_content_metadata_purl) }
 
       it 'is false' do
         expect(described_class.new('12345')).not_to be_valid
@@ -62,7 +62,7 @@ RSpec.describe Embed::Purl do
     end
 
     context 'with content metadata' do
-      before { stub_purl_response_with_fixture(file_purl) }
+      before { stub_purl_xml_response_with_fixture(file_purl) }
 
       it 'is true' do
         expect(described_class.new('12345')).to be_valid
@@ -72,26 +72,26 @@ RSpec.describe Embed::Purl do
 
   describe '#collections' do
     it 'formats a list of collection druids' do
-      stub_purl_response_with_fixture(was_seed_purl)
+      stub_purl_xml_response_with_fixture(was_seed_purl)
       expect(described_class.new('12345').collections).to eq ['mk656nf8485']
     end
 
     it 'is empty when no collection is present in xml' do
-      stub_purl_response_with_fixture(file_purl)
+      stub_purl_xml_response_with_fixture(file_purl)
       expect(described_class.new('12345').collections).to eq []
     end
   end
 
   describe 'contents' do
     it 'returns an array of resources' do
-      stub_purl_response_with_fixture(file_purl)
+      stub_purl_xml_response_with_fixture(file_purl)
       expect(described_class.new('12345').contents.all?(Embed::Purl::Resource)).to be true
     end
   end
 
   describe 'all_resource_files' do
     it 'returns a flattened array of resource files' do
-      stub_purl_response_with_fixture(multi_resource_multi_type_purl)
+      stub_purl_xml_response_with_fixture(multi_resource_multi_type_purl)
       df = described_class.new('12345').all_resource_files
       expect(df).to be_an_instance_of Array
       expect(df.first).to be_an_instance_of Embed::Purl::ResourceFile
@@ -103,7 +103,7 @@ RSpec.describe Embed::Purl do
     subject { purl.size }
 
     before do
-      stub_purl_response_with_fixture(multi_file_purl)
+      stub_purl_xml_response_with_fixture(multi_file_purl)
     end
 
     let(:purl) { described_class.new('12345') }
@@ -113,7 +113,7 @@ RSpec.describe Embed::Purl do
 
   describe '#downloadable_files' do
     it 'returns a flattened array of downloadable resource files' do
-      stub_purl_response_with_fixture(multi_resource_multi_type_purl)
+      stub_purl_xml_response_with_fixture(multi_resource_multi_type_purl)
       df = described_class.new('12345').downloadable_files
       expect(df).to be_an_instance_of Array
       expect(df.first).to be_an_instance_of Embed::Purl::ResourceFile
@@ -121,14 +121,14 @@ RSpec.describe Embed::Purl do
     end
 
     it 'returns only downloadable files (world)' do
-      stub_purl_response_with_fixture(world_restricted_download_purl)
+      stub_purl_xml_response_with_fixture(world_restricted_download_purl)
       purl_obj = described_class.new('12345')
       expect(purl_obj.all_resource_files.count).to eq 3
       expect(purl_obj.downloadable_files.count).to eq 1
     end
 
     it 'returns only downloadable files (stanford)' do
-      stub_purl_response_with_fixture(stanford_restricted_download_purl)
+      stub_purl_xml_response_with_fixture(stanford_restricted_download_purl)
       purl_obj = described_class.new('5678')
       expect(purl_obj.all_resource_files.count).to eq 3
       expect(purl_obj.downloadable_files.count).to eq 2
@@ -136,7 +136,7 @@ RSpec.describe Embed::Purl do
   end
 
   describe '#bounding_box' do
-    before { stub_purl_response_with_fixture(geo_purl_public) }
+    before { stub_purl_xml_response_with_fixture(geo_purl_public) }
 
     it 'creates an Envelope and calls #to_bounding_box on it' do
       expect_any_instance_of(Embed::Envelope).to receive(:to_bounding_box)
@@ -146,49 +146,49 @@ RSpec.describe Embed::Purl do
 
   describe '#envelope' do
     it 'selects the envelope element' do
-      stub_purl_response_with_fixture(geo_purl_public)
+      stub_purl_xml_response_with_fixture(geo_purl_public)
       expect(described_class.new('12345').envelope).to be_an Nokogiri::XML::Element
     end
 
     it 'without an envelope present' do
-      stub_purl_response_with_fixture(image_purl)
+      stub_purl_xml_response_with_fixture(image_purl)
       expect(described_class.new('12345').envelope).to be_nil
     end
   end
 
   describe 'license' do
     it 'returns cc license if present' do
-      stub_purl_response_with_fixture(file_purl)
+      stub_purl_xml_response_with_fixture(file_purl)
       purl = described_class.new('12345')
       expect(purl.license).to eq 'Public Domain Mark 1.0'
     end
 
     it 'returns odc license if present' do
-      stub_purl_response_with_fixture(hybrid_object_purl)
+      stub_purl_xml_response_with_fixture(hybrid_object_purl)
       purl = described_class.new('12345')
       expect(purl.license).to eq 'ODC-By Attribution License'
     end
 
     it 'returns MODS license if present' do
-      stub_purl_response_with_fixture(mods_license_purl)
+      stub_purl_xml_response_with_fixture(mods_license_purl)
       purl = described_class.new('12345')
       expect(purl.license).to eq 'This work is licensed under an Apache License 2.0 license.'
     end
 
     it 'returns nil if no license is present' do
-      stub_purl_response_with_fixture(embargoed_file_purl)
+      stub_purl_xml_response_with_fixture(embargoed_file_purl)
       expect(described_class.new('12345').license).to be_nil
     end
   end
 
   describe 'public?' do
     it 'returns true if the object is publicly accessible' do
-      stub_purl_response_with_fixture(file_purl)
+      stub_purl_xml_response_with_fixture(file_purl)
       expect(described_class.new('12345')).to be_public
     end
 
     it 'returns false if the object is Stanford Only' do
-      stub_purl_response_with_fixture(stanford_restricted_file_purl)
+      stub_purl_xml_response_with_fixture(stanford_restricted_file_purl)
       expect(described_class.new('12345')).not_to be_public
     end
   end
@@ -198,7 +198,7 @@ RSpec.describe Embed::Purl do
     let(:purl) { described_class.new('12345') }
 
     before do
-      stub_purl_response_with_fixture(hierarchical_file_purl)
+      stub_purl_xml_response_with_fixture(hierarchical_file_purl)
       allow(Embed::HierarchicalContents).to receive(:contents).and_return(root_dir)
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,12 +37,12 @@ RSpec.configure do |config|
   config.include Capybara::RSpecMatchers, type: :component
 end
 
-def stub_purl_response_with_fixture(fixture)
+def stub_purl_xml_response_with_fixture(fixture)
   allow_any_instance_of(Embed::Purl).to receive(:response).and_return(fixture)
 end
 
-def stub_purl_response_and_request(fixture, request)
-  stub_purl_response_with_fixture(fixture)
+def stub_purl_xml_response_and_request(fixture, request)
+  stub_purl_xml_response_with_fixture(fixture)
   stub_purl_request(request)
 end
 


### PR DESCRIPTION
The purl could also be represented as json, but that's not what this method is doing