### PR TITLE
Remove object_thumbnail? method

### DIFF
--- a/app/models/embed/purl/resource.rb
+++ b/app/models/embed/purl/resource.rb
@@ -26,10 +26,6 @@ module Embed
                          end
       end
 
-      def object_thumbnail?
-        @resource.attributes['thumb'].try(:value) == 'yes' || type == 'thumb'
-      end
-
       def three_dimensional?
         @resource.attributes['type']&.value == '3d'
       end

--- a/app/models/embed/purl/resource_file.rb
+++ b/app/models/embed/purl/resource_file.rb
@@ -47,15 +47,11 @@ module Embed
       end
 
       def primary?
-        primary_types = Settings.primary_mimetypes[resource.type] || []
-        !thumbnail? && primary_types.include?(mimetype)
+        Array(Settings.primary_mimetypes[resource.type]).include?(mimetype)
       end
 
       def thumbnail?
-        return true if resource.object_thumbnail?
-        return false unless image?
-
-        Settings.resource_types_that_contain_thumbnails.include?(resource.type)
+        image? && Settings.resource_types_that_contain_thumbnails.include?(resource.type)
       end
 
       def vtt

--- a/spec/components/embed/media_tag_component_spec.rb
+++ b/spec/components/embed/media_tag_component_spec.rb
@@ -114,14 +114,9 @@ RSpec.describe Embed::MediaTagComponent, type: :component do
   end
 
   context 'with file and object level thumbnails' do
-    let(:purl) { file_and_object_level_thumb_purl }
+    let(:purl) { file_thumb_purl }
 
-    it 'does not include object level thumbnails' do
-      expect(page).to have_css('[data-file-label="audio.mp3"]', visible: :all)
-      expect(page).not_to have_css('[data-file-label="thumb.jp2"]', visible: :all)
-    end
-
-    it 'does not include file level thumbnails' do
+    it 'does not include thumbnails' do
       expect(page).not_to have_css('[data-file-label="audio_1.jp2"]', visible: :all)
     end
 
@@ -170,7 +165,7 @@ RSpec.describe Embed::MediaTagComponent, type: :component do
 
   describe 'with a poster' do
     context 'when a file level thumbnail is present' do
-      let(:purl) { file_and_object_level_thumb_purl }
+      let(:purl) { file_thumb_purl }
       let(:resource_iteration) { instance_double(ActionView::PartialIteration, index: 1) }
       let(:resource) { Embed::Purl.new(druid).contents.second }
 

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -1129,7 +1129,7 @@ module PurlFixtures
     XML
   end
 
-  def file_and_object_level_thumb_purl
+  def file_thumb_purl
     <<-XML
       <publicObject>
         <contentMetadata type="file">
@@ -1147,9 +1147,6 @@ module PurlFixtures
           </resource>
           <resource id="book_1" type="image">
             <file id="book1.jp2" mimetype="image/jp2" size="77041"></file>
-          </resource>
-          <resource id="thumb_1" type="thumb" thumb="yes">
-            <file id="thumb.jp2" mimetype="image/jp2" size="7722"></file>
           </resource>
         </contentMetadata>
       </publicObject>

--- a/spec/models/embed/purl/resource_file_spec.rb
+++ b/spec/models/embed/purl/resource_file_spec.rb
@@ -96,25 +96,19 @@ RSpec.describe Embed::Purl::ResourceFile do
     let(:file) { double('File') }
     let(:resource_file) { described_class.new(resource, file, double('Rights')) }
 
-    it 'is true when the parent resource is an object level thumbnail' do
-      allow(resource).to receive(:object_thumbnail?).and_return(true)
-      expect(resource_file).to be_thumbnail
-    end
-
     it 'is false when the file is not an image' do
-      allow(resource).to receive(:object_thumbnail?).and_return(false)
       allow(file).to receive(:attributes).and_return('mimetype' => double(value: 'not-an-image'))
       expect(resource_file).not_to be_thumbnail
     end
 
-    it 'is true when the parent resource type is whitelisted as having file-level thumbnail behaviors (and it is an image)' do
-      allow(resource).to receive_messages(object_thumbnail?: false, type: 'video')
+    it 'is true when the parent resource type is listed as having file-level thumbnail behaviors (and it is an image)' do
+      allow(resource).to receive_messages(type: 'video')
       allow(file).to receive(:attributes).and_return('mimetype' => double(value: 'image/jp2'))
       expect(resource_file).to be_thumbnail
     end
 
-    it 'is false when the parent resource type is not whitelisted as having file-level thumbnail behaviors (even if it is an image)' do
-      allow(resource).to receive_messages(object_thumbnail?: false, type: 'book')
+    it 'is false when the parent resource type is not listed as having file-level thumbnail behaviors (even if it is an image)' do
+      allow(resource).to receive_messages(type: 'book')
       allow(file).to receive(:attributes).and_return('mimetype' => double(value: 'image/jp2'))
       expect(resource_file).not_to be_thumbnail
     end

--- a/spec/models/embed/purl/resource_spec.rb
+++ b/spec/models/embed/purl/resource_spec.rb
@@ -57,30 +57,6 @@ RSpec.describe Embed::Purl::Resource do
     end
   end
 
-  describe '#object_thumbnail?' do
-    subject { described_class.new('bc123df4567', node, instance_double(Dor::RightsAuth)) }
-
-    let(:node) { instance_double(Nokogiri::XML::Node, attributes:) }
-
-    context 'when type="thumb"' do
-      let(:attributes) { { 'type' => double(value: 'thumb') } }
-
-      it { is_expected.to be_object_thumbnail }
-    end
-
-    context 'when thumb="yes"' do
-      let(:attributes) { { 'thumb' => double(value: 'yes') } }
-
-      it { is_expected.to be_object_thumbnail }
-    end
-
-    context 'when any other value' do
-      let(:attributes) { { 'type' => double(value: 'image') } }
-
-      it { is_expected.not_to be_object_thumbnail }
-    end
-  end
-
   describe 'files' do
     it 'returns an array of Purl::Resource::ResourceFile objects' do
       stub_purl_xml_response_with_fixture(file_purl_xml)


### PR DESCRIPTION
SDR never makes metadata with the thumb attribute anymore. This method would return false for every object


There were only 7 remaining objects that had this resource type.  Andrew remediatied these:
```
druid:pm026jg3348
druid:gb724cq8086
druid:cb810hh5010
druid:dm864vr8555
druid:gs516wd2597
druid:xs076vf8779
druid:ty839db5658
```