### PR TITLE
Refactor so that thumbnail is a property of a resource (FileSet), not of a file

### DIFF
--- a/app/components/embed/media_tag_component.rb
+++ b/app/components/embed/media_tag_component.rb
@@ -33,9 +33,27 @@ module Embed
       end
     end
 
+    def thumbnail_url
+      stacks_square_url(@druid, @resource.thumbnail.title, size: '75') if @resource.thumbnail
+    end
+
+    def poster_url_for
+      return default_audio_thumbnail if type == 'audio' && !@resource.thumbnail
+      return unless @resource.thumbnail
+
+      if @resource.thumbnail.world_downloadable?
+        stacks_thumb_url(@druid, @resource.thumbnail.title, size: '!800,600')
+      else
+        stacks_thumb_url(@druid, @resource.thumbnail.title)
+      end
+    end
+
+    def default_audio_thumbnail
+      asset_url('waveform-audio-poster.svg')
+    end
+
     def media_element
-      file_thumb = stacks_square_url(@druid, file.thumbnail.title, size: '75') if file.thumbnail
-      render MediaWrapperComponent.new(thumbnail: file_thumb, file:, type:, file_index: @resource_iteration.index) do
+      render MediaWrapperComponent.new(thumbnail: thumbnail_url, file:, type:, file_index: @resource_iteration.index) do
         access_restricted_overlay + media_tag
       end
     end
@@ -130,10 +148,6 @@ module Embed
 
     def enabled_streaming_types
       Settings.streaming[:source_types]
-    end
-
-    def poster_url_for
-      Embed::StacksMediaStream.new(druid: @druid, file:).to_thumbnail_url
     end
 
     def streaming_url_for(streaming_type)

--- a/app/models/embed/purl/resource_file.rb
+++ b/app/models/embed/purl/resource_file.rb
@@ -51,10 +51,6 @@ module Embed
         !thumbnail? && primary_types.include?(mimetype)
       end
 
-      def thumbnail
-        resource.files.find(&:thumbnail?)
-      end
-
       def thumbnail?
         return true if resource.object_thumbnail?
         return false unless image?

--- a/lib/embed/stacks_media_stream.rb
+++ b/lib/embed/stacks_media_stream.rb
@@ -26,25 +26,9 @@ module Embed
       streaming_url_for(:dash)
     end
 
-    def to_thumbnail_url
-      return default_audio_thumbnail unless file.thumbnail
-
-      if file.thumbnail.world_downloadable?
-        stacks_thumb_url(druid, file.thumbnail.title, size: '!800,600')
-      else
-        stacks_thumb_url(druid, file.thumbnail.title)
-      end
-    end
-
     private
 
     attr_reader :druid, :file
-
-    def default_audio_thumbnail
-      return unless audio?
-
-      ActionController::Base.helpers.asset_url('waveform-audio-poster.svg')
-    end
 
     def streaming_url_for(type)
       return unless file.title && streaming_file_prefix
@@ -63,14 +47,6 @@ module Embed
 
     def streaming_file_prefix
       Settings.streaming_prefix[file_extension]
-    end
-
-    def video?
-      Settings.stream.video.include? file_extension
-    end
-
-    def audio?
-      Settings.stream.audio.include? file_extension
     end
 
     def file_extension

--- a/spec/lib/embed/stacks_media_stream_spec.rb
+++ b/spec/lib/embed/stacks_media_stream_spec.rb
@@ -5,47 +5,9 @@ require 'rails_helper'
 RSpec.describe Embed::StacksMediaStream do
   subject(:stream) { described_class.new(druid: 'ab012cd3456', file:) }
 
-  let(:file) { instance_double(Embed::Purl::ResourceFile, title: media_filename, thumbnail:) }
+  let(:file) { instance_double(Embed::Purl::ResourceFile, title: media_filename) }
   let(:media_filename) { 'def.mp4' }
   let(:streaming_base_url) { Settings.stream.url }
-  let(:thumbnail) { instance_double(Embed::Purl::ResourceFile, title: 'thumb.jp2', world_downloadable?: world_downloadable) }
-  let(:world_downloadable) { true }
-
-  describe '#to_thumbnail_url' do
-    context 'when file has a world-downloadable thumbnail' do
-      it 'uses a high-resolution thumbnail' do
-        expect(stream.to_thumbnail_url).to match(%r{ab012cd3456%2Fthumb/full/!800,600})
-      end
-    end
-
-    context 'when file has a non-world-downloadable thumbnail' do
-      let(:world_downloadable) { false }
-
-      it 'uses a standard thumbnail' do
-        expect(stream.to_thumbnail_url).to match(%r{ab012cd3456%2Fthumb/full/!400,400})
-      end
-    end
-
-    context 'when file has no thumbnail' do
-      let(:thumbnail) { nil }
-
-      context 'when file is audio' do
-        let(:media_filename) { 'def.m4a' }
-
-        it 'uses the default audio thumbnail' do
-          expect(stream.to_thumbnail_url).to match(/waveform-audio-poster/)
-        end
-      end
-
-      context 'when file is not audio' do
-        let(:media_file) { 'def.mp4' }
-
-        it 'returns nil' do
-          expect(stream.to_thumbnail_url).to be_nil
-        end
-      end
-    end
-  end
 
   describe '#to_playlist_url' do
     context 'with mp4 video' do

--- a/spec/models/embed/purl/resource_file_spec.rb
+++ b/spec/models/embed/purl/resource_file_spec.rb
@@ -91,35 +91,6 @@ RSpec.describe Embed::Purl::ResourceFile do
     end
   end
 
-  describe '#thumbnail' do
-    let(:resource_with_thumb) do
-      instance_double(
-        Embed::Purl::Resource, files: [
-          instance_double(described_class, thumbnail?: false, title: 'Non thumb'),
-          instance_double(described_class, thumbnail?: true, title: 'The Thumb')
-        ]
-      )
-    end
-    let(:resource_without_thumb) do
-      instance_double(
-        Embed::Purl::Resource, files: [
-          instance_double(described_class, thumbnail?: false, title: 'Non thumb'),
-          instance_double(described_class, thumbnail?: false, title: 'Another Non Thumb')
-        ]
-      )
-    end
-
-    it 'is the thumbnail within the same resource' do
-      file = described_class.new(resource_with_thumb, double('File'), double('Rights'))
-      expect(file.thumbnail.title).to eq 'The Thumb'
-    end
-
-    it 'is nil when the resource does not have a file specific thumb' do
-      file = described_class.new(resource_without_thumb, double('File'), double('Rights'))
-      expect(file.thumbnail).to be_nil
-    end
-  end
-
   describe '#thumbnail?' do
     let(:resource) { instance_double(Embed::Purl::Resource) }
     let(:file) { double('File') }

--- a/spec/models/embed/purl/resource_spec.rb
+++ b/spec/models/embed/purl/resource_spec.rb
@@ -19,6 +19,44 @@ RSpec.describe Embed::Purl::Resource do
     expect(Embed::Purl.new('12345').contents.first.description).to eq 'File1 Label'
   end
 
+  describe '#thumbnail' do
+    let(:resource) { described_class.new('12345', resource_element, instance_double(Dor::RightsAuth)) }
+
+    context 'when the resource has a thumbnail' do
+      let(:resource_element) do
+        Nokogiri::XML(
+          <<~XML
+            <resource sequence="1" type="file">
+              <file id="Non thumb" mimetype="image/tiff" size="2799535" />
+              <file id="The Thumb" mimetype="image/jp2" size="2799535" />
+            </resource>
+          XML
+        ).xpath('//resource').first
+      end
+
+      it 'is the thumbnail' do
+        expect(resource.thumbnail.title).to eq 'The Thumb'
+      end
+    end
+
+    context 'when the resource does not have a file specific thumbnail' do
+      let(:resource_element) do
+        Nokogiri::XML(
+          <<~XML
+            <resource sequence="1" type="file">
+              <file id="Non thumb" mimetype="image/tiff" size="2799535" />
+              <file id="Another non Thumb" mimetype="audio/aiff" size="2799535" />
+            </resource>
+          XML
+        ).xpath('//resource').first
+      end
+
+      it 'is nil' do
+        expect(resource.thumbnail).to be_nil
+      end
+    end
+  end
+
   describe '#object_thumbnail?' do
     subject { described_class.new('bc123df4567', node, instance_double(Dor::RightsAuth)) }
 


### PR DESCRIPTION
And, StacksMediaStream should know nothing about thumbnail/poster.   Previously to get the thumbnail of a file we would go up to the resource (fileset) and then find which file was a thumbnail.  This refactor avoids unnecessarily traversing back up to the resource (fileset).