### PR TITLE
Remove unnecessary method

### DIFF
--- a/app/components/embed/media_tag_component.rb
+++ b/app/components/embed/media_tag_component.rb
@@ -105,11 +105,11 @@ module Embed
     def transcript
       return unless render_captions?
 
-      tag.track(src: file.vtt.file_url, kind: 'captions', srclang: 'en', label: 'English')
+      tag.track(src: @resource.vtt.file_url, kind: 'captions', srclang: 'en', label: 'English')
     end
 
     def render_captions?
-      @include_transcripts && file.vtt
+      @include_transcripts && @resource.vtt
     end
 
     # NOTE: This is only for the legacy media player. We can remove it when we switch to the new player.

--- a/app/models/embed/purl/resource_file.rb
+++ b/app/models/embed/purl/resource_file.rb
@@ -58,10 +58,6 @@ module Embed
         Settings.resource_types_that_contain_thumbnails.include?(resource.type)
       end
 
-      def vtt
-        resource.files.find(&:vtt?)
-      end
-
       def vtt?
         mimetype == 'text/vtt'
       end


### PR DESCRIPTION
vtt is a property of the resource, so just look for it there rather than on a file, which has to go back to the resource anyway