### PR TITLE
Simplify finding thumbnail

### DIFF
--- a/app/models/embed/purl/resource.rb
+++ b/app/models/embed/purl/resource.rb
@@ -48,7 +48,9 @@ module Embed
 
       # @return [ResourceFile]
       def thumbnail
-        files.find(&:thumbnail?)
+        return unless Settings.resource_types_that_contain_thumbnails.include?(type)
+
+        files.find(&:image?)
       end
 
       # @return [ResourceFile]

--- a/app/models/embed/purl/resource_file.rb
+++ b/app/models/embed/purl/resource_file.rb
@@ -44,10 +44,6 @@ module Embed
         title.split('/').last
       end
 
-      def thumbnail?
-        image? && Settings.resource_types_that_contain_thumbnails.include?(resource.type)
-      end
-
       def vtt?
         mimetype == 'text/vtt'
       end

--- a/spec/models/embed/purl/resource_file_spec.rb
+++ b/spec/models/embed/purl/resource_file_spec.rb
@@ -86,29 +86,6 @@ RSpec.describe Embed::Purl::ResourceFile do
     end
   end
 
-  describe '#thumbnail?' do
-    let(:resource) { instance_double(Embed::Purl::Resource) }
-    let(:file) { double('File') }
-    let(:resource_file) { described_class.new(resource, file, double('Rights')) }
-
-    it 'is false when the file is not an image' do
-      allow(file).to receive(:attributes).and_return('mimetype' => double(value: 'not-an-image'))
-      expect(resource_file).not_to be_thumbnail
-    end
-
-    it 'is true when the parent resource type is listed as having file-level thumbnail behaviors (and it is an image)' do
-      allow(resource).to receive_messages(type: 'video')
-      allow(file).to receive(:attributes).and_return('mimetype' => double(value: 'image/jp2'))
-      expect(resource_file).to be_thumbnail
-    end
-
-    it 'is false when the parent resource type is not listed as having file-level thumbnail behaviors (even if it is an image)' do
-      allow(resource).to receive_messages(type: 'book')
-      allow(file).to receive(:attributes).and_return('mimetype' => double(value: 'image/jp2'))
-      expect(resource_file).not_to be_thumbnail
-    end
-  end
-
   describe 'previewable?' do
     it 'returns true if the mimetype of the file is previewable' do
       stub_purl_xml_response_with_fixture(image_purl_xml)


### PR DESCRIPTION
Now the thumbnail is a property of a resource and the file doesn't need to understand the thubmbnail algorithm.