### PR TITLE
Use a delegator for the hierarchical file

### DIFF
--- a/app/models/embed/hierarchical_contents.rb
+++ b/app/models/embed/hierarchical_contents.rb
@@ -22,7 +22,7 @@ module Embed
     attr_reader :resources
 
     def file_contents
-      resources.map(&:files).flatten
+      resources.map(&:files).flatten.map { |file| HierarchicalFile.new(file) }
     end
 
     def add_to_hierarchy(file, root_directory)

--- a/app/models/embed/hierarchical_file.rb
+++ b/app/models/embed/hierarchical_file.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Embed
+  class HierarchicalFile < SimpleDelegator
+    attr_accessor :index
+  end
+end

--- a/app/models/embed/purl/resource_file.rb
+++ b/app/models/embed/purl/resource_file.rb
@@ -12,10 +12,7 @@ module Embed
         @description = description
         @file = file
         @rights = rights
-        @index = nil
       end
-
-      attr_accessor :index
 
       def label
         @description

--- a/spec/models/embed/hierarchical_contents_spec.rb
+++ b/spec/models/embed/hierarchical_contents_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Embed::HierarchicalContents do
       expect(root_dir.title).to eq ''
       expect(root_dir.files.count).to eq 1
       file1 = root_dir.files.first
-      expect(file1).to be_an Embed::Purl::ResourceFile
+      expect(file1).to be_an Embed::HierarchicalFile
       expect(file1.title).to eq 'Title_of_the_PDF.pdf'
       expect(file1.index).to eq 1
       expect(root_dir.dirs.count).to eq 1


### PR DESCRIPTION
The hierarchy feature requires an index property, that is not relevant to ResourceFile itself, so a delegator can keep this concern separate