### PR TITLE
update pdfjs to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "mirador-dl-plugin": "^0.13.0",
     "mirador-image-tools": "^0.8.0",
     "mirador-share-plugin": "^0.11.0",
-    "pdfjs-dist": "^3.11.174",
+    "pdfjs-dist": "^4",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5062,10 +5062,10 @@ path2d-polyfill@^2.0.1:
   resolved "https://registry.yarnpkg.com/path2d-polyfill/-/path2d-polyfill-2.0.1.tgz#24c554a738f42700d6961992bf5f1049672f2391"
   integrity sha512-ad/3bsalbbWhmBo0D6FZ4RNMwsLsPpL6gnvhuSaU5Vm7b06Kr5ubSltQQ0T7YKsiJQO+g22zJ4dJKNTXIyOXtA==
 
-pdfjs-dist@^3.11.174:
-  version "3.11.174"
-  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-3.11.174.tgz#5ff47b80f2d58c8dd0d74f615e7c6a7e7e704c4b"
-  integrity sha512-TdTZPf1trZ8/UFu5Cx/GXB7GZM30LT+wWUNfsi6Bq8ePLnb+woNKtDymI2mxZYBpMbonNFqKmiz684DIfnd8dA==
+pdfjs-dist@^4:
+  version "4.0.189"
+  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-4.0.189.tgz#c69e403cbea9a49b657bedc47f223eece7bb8c0f"
+  integrity sha512-5IWbLRJjQJhk3cu3nNFAvIYoSzT8xRYlRkFCIV1tn7hK1eq9H+6vOP0ytJhZz9YI35IXlu33uQspvmYO6Oir4g==
   optionalDependencies:
     canvas "^2.11.2"
     path2d-polyfill "^2.0.1"


### PR DESCRIPTION
Update pdfjs-dist to v4.  Fixes #1756 (at least the main part of the ticket, there are other bits in the ticket referencing features on/off that I would consider separately).

Tests pass locally for me, as does viewing this sample PDF in my localhost browser: https://purl.stanford.edu/bh502xm3351  I don't see any obvious differences with v3