### PR TITLE
Encapsulate serialization within Purl

### DIFF
--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -72,10 +72,6 @@ module Embed
       @embargo_release_date ||= ng_xml.xpath('//rightsMetadata/access[@type="read"]/machine/embargoReleaseDate')&.text
     end
 
-    def ng_xml
-      @ng_xml ||= Nokogiri::XML(response)
-    end
-
     def all_resource_files
       contents.map(&:files).flatten
     end
@@ -136,7 +132,24 @@ module Embed
       )&.map { |_name, value| value.gsub('info:fedora/druid:', '') } || []
     end
 
+    def archived_site_url
+      @archived_site_url ||= ng_xml.xpath(
+        '//mods:url[@displayLabel="Archived website"]',
+        'mods' => 'http://www.loc.gov/mods/v3'
+      )&.text.tap do |url|
+        Honeybadger.notify("Purl#archived_site_url blank for #{druid}") if url.blank?
+      end
+    end
+
+    def external_url
+      ng_xml.xpath('//dc:identifier', 'dc' => 'http://purl.org/dc/elements/1.1/').try(:text)
+    end
+
     private
+
+    def ng_xml
+      @ng_xml ||= Nokogiri::XML(response)
+    end
 
     def mods_license
       ng_xml

--- a/app/viewers/embed/viewer/was_seed.rb
+++ b/app/viewers/embed/viewer/was_seed.rb
@@ -3,7 +3,7 @@
 module Embed
   module Viewer
     class WasSeed < CommonViewer
-      delegate :druid, to: :@purl_object
+      delegate :druid, :archived_site_url, :external_url, to: :@purl_object
 
       def component
         WasSeedComponent
@@ -23,15 +23,6 @@ module Embed
         @capture_list ||= Embed::WasTimeMap.new(archived_timemap_url).capture_list
       end
 
-      def archived_site_url
-        @archived_site_url ||= @purl_object.ng_xml.xpath(
-          '//mods:url[@displayLabel="Archived website"]',
-          'mods' => 'http://www.loc.gov/mods/v3'
-        )&.text.tap do |url|
-          Honeybadger.notify("WasSeed#archived_site_url blank for #{druid}") if url.blank?
-        end
-      end
-
       def archived_timemap_url
         if archived_site_url.include?('/*/') # Not a valid timemap url
           archived_site_url.sub('/*/', '/timemap/')
@@ -48,10 +39,6 @@ module Embed
 
       def format_memento_datetime(memento_datetime)
         I18n.l(Date.parse(memento_datetime), format: :sul_was_long) if memento_datetime.present?
-      end
-
-      def external_url
-        @purl_object.ng_xml.xpath('//dc:identifier', 'dc' => 'http://purl.org/dc/elements/1.1/').try(:text)
       end
 
       def external_url_text


### PR DESCRIPTION
WasSeed was breaking the encapsulation by asking for the xml document from the Purl, rather than asking for the properties it needs