### PR TITLE
Disambiguate file labels in download modal

### DIFF
--- a/app/components/embed/media_tag_component.rb
+++ b/app/components/embed/media_tag_component.rb
@@ -5,16 +5,6 @@ module Embed
     include StacksImage
     with_collection_parameter :resource
     SUPPORTED_MEDIA_TYPES = %i[audio video].freeze
-    # Hardcoding some language code to label mappings, based on the mappings we currently need.
-    # This approach should be revisited once we have more robust BCP 47 code to label mapping integrated.
-    FILE_LANGUAGE_CAPTION_LABELS = {
-      'en' => 'English',
-      'ru' => 'Russian',
-      'de' => 'German',
-      'et' => 'Estonian',
-      'lv' => 'Latvian',
-      'es' => 'Spanish'
-    }.freeze
 
     # @param [Purl::Resource] resource This resource is expected to have a primary file.
     # @param [#index] resource_iteration Information about what part of the collection we are in
@@ -86,7 +76,7 @@ module Embed
                crossorigin: 'anonymous',
                class: 'sul-embed-media-file',
                height: '100%') do
-        enabled_streaming_sources + transcript
+        enabled_streaming_sources + captions
       end
     end
 
@@ -109,33 +99,22 @@ module Embed
     end
 
     # Generate the video caption elements
-    def transcript
+    def captions
       return unless render_captions?
 
       # A video clip may have multiple caption files in different languages.
       # We want to enable the user to select from any of these options.
       # We also want the different language options to be listed alphabetically.
       safe_join(
-        sort_caption_tracks(@resource.caption_files).map do |caption_file|
-          lang_code = caption_file.language || 'en'
-          lang_label = caption_language(lang_code)
-          tag.track(src: caption_file.file_url, kind: 'captions', srclang: lang_code, label: lang_label)
+        @resource.caption_files.map do |caption_file|
+          tag.track(src: caption_file.file_url, kind: 'captions',
+                    srclang: caption_file.language_code, label: caption_file.language_label)
         end
       )
     end
 
-    # Sort the caption files by language label so we can display them in alphabetical order in the
-    # captions options list.
-    def sort_caption_tracks(caption_files)
-      caption_files.sort_by { |cfile| caption_language(cfile.language) }
-    end
-
-    def caption_language(language_code)
-      FILE_LANGUAGE_CAPTION_LABELS.fetch(language_code, 'Caption')
-    end
-
     def render_captions?
-      @include_transcripts && @resource.caption_files
+      @include_transcripts && @resource.caption_files.any?
     end
 
     def streaming_settings_for(streaming_type)

--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -47,13 +47,11 @@ module Embed
     end
 
     def all_resource_files
-      contents.map(&:files).flatten
+      contents.flat_map(&:files)
     end
 
     def downloadable_files
-      all_resource_files.select do |rf|
-        rf.world_downloadable? || rf.stanford_only_downloadable?
-      end
+      all_resource_files.select(&:downloadable?)
     end
 
     def purl_url

--- a/app/models/embed/purl/file_xml_deserializer.rb
+++ b/app/models/embed/purl/file_xml_deserializer.rb
@@ -47,6 +47,7 @@ module Embed
           label: @description,
           mimetype: @file.attributes['mimetype']&.value,
           size: @file.attributes['size']&.value.to_i,
+          role: @file.attributes['role']&.value,
           language: @file.attributes['language']&.value,
           filename:,
           stanford_only:,

--- a/app/models/embed/purl/resource.rb
+++ b/app/models/embed/purl/resource.rb
@@ -44,9 +44,12 @@ module Embed
         files.find(&:image?)
       end
 
+      # Sort the caption files by language label so we can display them in alphabetical order in the
+      # captions options list.
+      #
       # @return [Array<ResourceFile>]
       def caption_files
-        files.select(&:vtt?)
+        files.select(&:caption?).sort_by(&:language_code)
       end
     end
   end

--- a/spec/components/embed/legacy_media/media_tag_component_spec.rb
+++ b/spec/components/embed/legacy_media/media_tag_component_spec.rb
@@ -220,15 +220,15 @@ RSpec.describe Embed::LegacyMedia::MediaTagComponent, type: :component do
     let(:include_transcripts) { true }
 
     it 'has a track element' do
-      expect(page).to have_css('track[src="https://stacks.stanford.edu/file/druid:bc123df4567/abc_123_cap.webvtt"]')
+      expect(page).to have_css('track[src="https://stacks.stanford.edu/file/druid:bc123df4567/abc_123_cap.vtt"]')
     end
   end
 
   context 'with captions for multiple languages' do
     let(:resource) do
       build(:resource, :video, files: [build(:resource_file, :video),
-                                       build(:resource_file, :vtt, language: 'en'),
-                                       build(:resource_file, :vtt, language: 'ru')])
+                                       build(:resource_file, :caption, language: 'en'),
+                                       build(:resource_file, :caption, language: 'ru')])
     end
 
     let(:include_transcripts) { true }
@@ -242,7 +242,7 @@ RSpec.describe Embed::LegacyMedia::MediaTagComponent, type: :component do
   context 'with caption with no specified language' do
     let(:resource) do
       build(:resource, :video, files: [build(:resource_file, :video),
-                                       build(:resource_file, :vtt)])
+                                       build(:resource_file, :caption)])
     end
     let(:include_transcripts) { true }
 

--- a/spec/components/embed/media_tag_component_spec.rb
+++ b/spec/components/embed/media_tag_component_spec.rb
@@ -210,15 +210,15 @@ RSpec.describe Embed::MediaTagComponent, type: :component do
     let(:include_transcripts) { true }
 
     it 'has a track element' do
-      expect(page).to have_css('track[src="https://stacks.stanford.edu/file/druid:bc123df4567/abc_123_cap.webvtt"]')
+      expect(page).to have_css('track[src="https://stacks.stanford.edu/file/druid:bc123df4567/abc_123_cap.vtt"]')
     end
   end
 
   context 'with captions for multiple languages' do
     let(:resource) do
       build(:resource, :video, files: [build(:resource_file, :video),
-                                       build(:resource_file, :vtt, language: 'en'),
-                                       build(:resource_file, :vtt, language: 'ru')])
+                                       build(:resource_file, :caption, language: 'en'),
+                                       build(:resource_file, :caption, language: 'ru')])
     end
 
     let(:include_transcripts) { true }
@@ -232,7 +232,7 @@ RSpec.describe Embed::MediaTagComponent, type: :component do
   context 'with caption with no specified language' do
     let(:resource) do
       build(:resource, :video, files: [build(:resource_file, :video),
-                                       build(:resource_file, :vtt)])
+                                       build(:resource_file, :caption)])
     end
     let(:include_transcripts) { true }
 

--- a/spec/factories/files.rb
+++ b/spec/factories/files.rb
@@ -36,10 +36,11 @@ FactoryBot.define do
       size { 152_000_000 }
     end
 
-    trait :vtt do
+    trait :caption do
       mimetype { 'text/vtt' }
-      filename { 'abc_123_cap.webvtt' }
+      filename { 'abc_123_cap.vtt' }
       size { 176_218 }
+      role { 'caption' }
     end
 
     trait :stanford_only do

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -12,13 +12,13 @@ FactoryBot.define do
     trait :video do
       type { 'video' }
       description { 'First Video' }
-      files { [build(:resource_file, :video), build(:resource_file, :vtt), build(:resource_file, :image, filename: 'video_1.jp2')] }
+      files { [build(:resource_file, :video), build(:resource_file, :caption), build(:resource_file, :image, filename: 'video_1.jp2')] }
     end
 
     trait :audio do
       type { 'audio' }
       description { 'First Audio' }
-      files { [build(:resource_file, :audio), build(:resource_file, :vtt), build(:resource_file, :image, filename: 'audio_1.jp2')] }
+      files { [build(:resource_file, :audio), build(:resource_file, :caption), build(:resource_file, :image, filename: 'audio_1.jp2')] }
     end
 
     trait :image do

--- a/spec/models/embed/purl/resource_file_spec.rb
+++ b/spec/models/embed/purl/resource_file_spec.rb
@@ -151,16 +151,16 @@ RSpec.describe Embed::Purl::ResourceFile do
     end
   end
 
-  describe '#vtt?' do
-    subject { resource_file.vtt? }
+  describe '#caption?' do
+    subject { resource_file.caption? }
 
-    context 'when it is a vtt transcript' do
-      let(:resource_file) { build(:resource_file, :vtt) }
+    context 'when it is a caption file' do
+      let(:resource_file) { build(:resource_file, :caption) }
 
       it { is_expected.to be true }
     end
 
-    context 'when it is not a vtt transcript' do
+    context 'when it is not a caption file' do
       let(:resource_file) { build(:resource_file, :document) }
 
       it { is_expected.to be false }

--- a/spec/models/embed/purl/resource_spec.rb
+++ b/spec/models/embed/purl/resource_spec.rb
@@ -61,15 +61,15 @@ RSpec.describe Embed::Purl::Resource do
   end
 
   describe '#caption_files' do
-    context 'when it has a vtt transcript' do
+    context 'when it has a caption file' do
       subject { resource.caption_files[0].title }
 
       let(:resource) { build(:resource, :video) }
 
-      it { is_expected.to eq 'abc_123_cap.webvtt' }
+      it { is_expected.to eq 'abc_123_cap.vtt' }
     end
 
-    context 'when it does not have a vtt transcript' do
+    context 'when it does not have a caption file' do
       subject { resource.caption_files[0] }
 
       let(:resource) { build(:resource, :video, files: [build(:resource_file, :video)]) }

--- a/test/components/previews/embed/media_with_companion_windows_component_preview.rb
+++ b/test/components/previews/embed/media_with_companion_windows_component_preview.rb
@@ -6,31 +6,29 @@
 module Embed
   class MediaWithCompanionWindowsComponentPreview < ViewComponent::Preview
     def with_audio
-      embed_request = Embed::Request.new(url: 'https://purl.stanford.edu/gj753wr1198')
-      viewer = Embed::Viewer::Media.new(embed_request)
-      render(MediaWithCompanionWindowsComponent.new(viewer:))
+      render_media_viewer_for(url: 'https://purl.stanford.edu/gj753wr1198')
     end
 
     def with_public_video
-      embed_request = Embed::Request.new(url: 'https://purl.stanford.edu/gt507vy5436')
-      viewer = Embed::Viewer::Media.new(embed_request)
-      render(MediaWithCompanionWindowsComponent.new(viewer:))
+      render_media_viewer_for(url: 'https://purl.stanford.edu/gt507vy5436')
     end
 
     def with_stanford_only_video
-      embed_request = Embed::Request.new(url: 'https://purl.stanford.edu/bb142ws0723')
-      viewer = Embed::Viewer::Media.new(embed_request)
-      render(MediaWithCompanionWindowsComponent.new(viewer:))
+      render_media_viewer_for(url: 'https://purl.stanford.edu/bb142ws0723')
     end
 
     def with_embargo
-      embed_request = Embed::Request.new(url: 'https://purl.stanford.edu/hy056tp9463')
-      viewer = Embed::Viewer::Media.new(embed_request)
-      render(MediaWithCompanionWindowsComponent.new(viewer:))
+      render_media_viewer_for(url: 'https://purl.stanford.edu/hy056tp9463')
     end
 
     def with_lots_of_files
-      embed_request = Embed::Request.new(url: 'https://purl.stanford.edu/wz015vw6759')
+      render_media_viewer_for(url: 'https://purl.stanford.edu/wz015vw6759')
+    end
+
+    private
+
+    def render_media_viewer_for(url:)
+      embed_request = Embed::Request.new(url:)
       viewer = Embed::Viewer::Media.new(embed_request)
       render(MediaWithCompanionWindowsComponent.new(viewer:))
     end


### PR DESCRIPTION
Fixes #1527

This commit is primarily concerned with changing the generic "Video file" or "Audio file" file labels in the download modal. It includes:

* Concentrate caption language logic in the `ResourceFile` model
* In a few spots, be clearer about whether we're dealing with transcripts or captions (VTT)
* Move caption file sorting logic into `Resource#caption_files`
* Move logic about whether a `ResourceFile` is downloadable into that models
* Change references to `.webvtt` files to `.vtt` files
* Add `caption` role to `ResourceFile` factory
* Simplify ViewComponent previews by extracting the common bits, meaning less boilerplate copypasta for new previews
