### PR TITLE
remove min-height for file list in CSS

### DIFF
--- a/app/assets/stylesheets/file.scss
+++ b/app/assets/stylesheets/file.scss
@@ -90,7 +90,7 @@ body {
     list-style: none;
     // font-size: 120%;
   }
-  
+
   ul[role="tree"] li {
     // margin: 0;
     padding: 0;
@@ -104,7 +104,7 @@ body {
   [role="treeitem"][aria-expanded="false"] + [role="group"] {
     display: none;
   }
-  
+
   [role="treeitem"][aria-expanded="true"] + [role="group"] {
     display: block;
   }
@@ -112,7 +112,7 @@ body {
   [role="treeitem"][aria-expanded="false"] > ul {
     display: none;
   }
-  
+
   [role="treeitem"][aria-expanded="true"] > ul {
     display: block;
   }
@@ -136,17 +136,17 @@ body {
 
   [role="treeitem"][aria-expanded="false"] > .#{$namespace}-treeitem::before {
     font-family: 'sul-icons';
-    content: '\f10b'; // sul-i-arrow-right-8 
+    content: '\f10b'; // sul-i-arrow-right-8
     display: inline-block;
     padding-right: 3px;
     vertical-align: middle;
     font-weight: 900;
     width: 15px;
   }
-  
+
   [role="treeitem"][aria-expanded="true"] > .#{$namespace}-treeitem::before {
     font-family: 'sul-icons';
-    content: '\f13e'; // sul-i-arrow-down-8 
+    content: '\f13e'; // sul-i-arrow-down-8
     display: inline-block;
     padding-right: 3px;
     vertical-align: middle;
@@ -171,8 +171,6 @@ body {
 
 .#{$namespace}-file-list {
   @include well-container;
-
-  min-height: 189px;
 }
 
 .#{$namespace}-media-list {


### PR DESCRIPTION
Fixes #1811 

Reverts this change from #1147 so that single file objects don't have a lot of extra space: https://github.com/sul-dlss/sul-embed/pull/1147/files#diff-38e0fb4859a070ef8a0dde01e3c4e80183d4d11925cc41390802b59f698140fdR81

Pending review to better understand why that change was introduced and unknown side-effects of removing it to fix this issue.  Could also consider leaving a min-height but cutting it in half.

![Screen Shot 2023-11-22 at 11 27 13 AM](https://github.com/sul-dlss/sul-embed/assets/47137/f235b4a1-9c95-4b4c-9fa9-8506ad0abb4e)

