### PR TITLE
Enhance rights panel in left companion window of media player

### DIFF
--- a/app/assets/stylesheets/media.scss
+++ b/app/assets/stylesheets/media.scss
@@ -377,7 +377,18 @@
       font-family: "Roboto", "Helvetica", "Arial", sans-serif;
     }
 
+    .logoContainer {
+      padding: 1rem;
+      border-bottom: .5px solid rgba(0, 0, 0, 0.25);
+    }
+
+    .attributionLogo {
+      max-width: 100%;
+    }
+
     .metadataList, .rightsList {
+      border-bottom: .5px solid rgba(0, 0, 0, 0.25);
+
       dt {
         font-size: 0.878rem;
         font-weight: 500;

--- a/app/components/rights_component.html.erb
+++ b/app/components/rights_component.html.erb
@@ -9,8 +9,13 @@
   <% end %>
   <% if license.present? %>
     <dt>License</dt>
-    <dd>
-      <%= license %>
-    </dd>
+    <dd><%= license %></dd>
+  <% end %>
+  <% if no_rights_information_present? %>
+    <dt>Attribution</dt>
+    <dd><%= default_attribution %></dd>
   <% end %>
 </dl>
+<div class="logoContainer">
+  <%= image_tag stanford_libraries_logo_url, alt: "Stanford Libraries logo", role: "presentation", class: "attributionLogo" %>
+</div>

--- a/app/components/rights_component.rb
+++ b/app/components/rights_component.rb
@@ -9,4 +9,20 @@ class RightsComponent < ViewComponent::Base
 
   delegate :purl_object, to: :viewer
   delegate :use_and_reproduction, :copyright, :license, to: :purl_object
+
+  def no_rights_information_present?
+    use_and_reproduction.blank? &&
+      copyright.blank? &&
+      license.blank?
+  end
+
+  def default_attribution
+    'Provided by the Stanford University Libraries'
+  end
+
+  def stanford_libraries_logo_url
+    # NOTE: This is the URL Mirador already uses, so this increases parity between the
+    #       image and media viewers even if it may appear brittle
+    'https://stacks.stanford.edu/image/iiif/wy534zh7137/SULAIR_rosette/full/400,/0/default.jpg'
+  end
 end

--- a/spec/components/rights_component_spec.rb
+++ b/spec/components/rights_component_spec.rb
@@ -15,9 +15,24 @@ RSpec.describe RightsComponent, type: :component do
                     license: 'cc-0')
   end
 
-  it 'renders something useful' do
+  it 'renders the rights information and an attribution logo' do
     expect(page).to have_content 'The materials are open for research use'
     expect(page).to have_content 'cc-0'
     expect(page).to have_content 'The Board of Trustees of the Leland Stanford Junior University'
+    expect(page).not_to have_content 'Provided by the Stanford University Libraries'
+    expect(page).to have_css('img.attributionLogo')
+  end
+
+  context 'when object has no rights information' do
+    let(:purl_object) do
+      instance_double(Embed::Purl,
+                      use_and_reproduction: nil,
+                      copyright: nil,
+                      license: nil)
+    end
+
+    it 'renders the default attribution information' do
+      expect(page).to have_content 'Provided by the Stanford University Libraries'
+    end
   end
 end


### PR DESCRIPTION
Fixes #1797

This commit makes two changes to the rights panel in the LCW of the media
player, both of which bring look & feel parity with the Mirador viewer:

* Add the Stanford Libraries logo to the bottom of the panel
* When an object lacks rights information (use statement, copyright statement,
license), render a default attribution


![Screenshot from 2023-11-22 12-44-10](https://github.com/sul-dlss/sul-embed/assets/131982/a7b4b1f3-688f-47fc-9fd4-b66c2e19fc18)
