### PR TITLE
Do not present all media wrappers to the user

### DIFF
--- a/app/components/embed/media_wrapper_component.rb
+++ b/app/components/embed/media_wrapper_component.rb
@@ -24,7 +24,9 @@ module Embed
                 thumbnail_url: @thumbnail.presence,
                 default_icon: @type == 'audio' ? 'sul-i-file-music-1' : 'sul-i-file-video-3',
                 duration: @file.duration
-              }) do
+              },
+              # When rendering this component, show only the first media wrapper component
+              hidden: !@resource_index.zero?) do
         tag.div class: 'sul-embed-media-wrapper' do
           content
         end

--- a/spec/components/embed/legacy_media/media_tag_component_spec.rb
+++ b/spec/components/embed/legacy_media/media_tag_component_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Embed::LegacyMedia::MediaTagComponent, type: :component do
     let(:resource) { build(:resource, :video, files: [build(:resource_file, :video, :stanford_only)]) }
 
     it 'includes a data attribute for the thumb-slider bar' do
-      expect(page).to have_css('[data-slider-object="1"]')
+      expect(page).to have_css('[data-slider-object="1"]', visible: :hidden)
     end
 
     it 'includes a data-src attribute for the dash player' do

--- a/spec/components/embed/media_tag_component_spec.rb
+++ b/spec/components/embed/media_tag_component_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Embed::MediaTagComponent, type: :component do
     let(:resource) { build(:resource, :video, files: [build(:resource_file, :video, :stanford_only)]) }
 
     it 'includes a data attribute for the thumb-slider bar' do
-      expect(page).to have_css('[data-slider-object="1"]')
+      expect(page).to have_css('[data-slider-object="1"]', visible: :hidden)
     end
 
     it 'includes a data-src attribute for the dash player' do

--- a/spec/features/media_viewer_spec.rb
+++ b/spec/features/media_viewer_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Media viewer', :js do
     let(:purl) { video_purl_with_image }
 
     it 'includes a previewable image as a top level object' do
-      expect(page).to have_css('div .osd')
+      expect(page).to have_css('div .osd', visible: :hidden)
 
       click_button 'Display sidebar'
       within 'aside.open' do


### PR DESCRIPTION
Without this commit, a user can scroll horizontally between the various bits of media content in the player until any of the media thumbnails are clicked.
