### PR TITLE
[refactor] move envelope parsing to the PurlXmlLoader

### DIFF
--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -13,7 +13,7 @@ module Embed
     end
 
     attr_accessor :druid, :type, :title, :use_and_reproduction, :copyright, :contents, :collections,
-                  :license, :envelope, :embargo_release_date, :archived_site_url, :external_url,
+                  :license, :bounding_box, :embargo_release_date, :archived_site_url, :external_url,
                   :embargoed, :citation_only, :stanford_only_unrestricted, :public, :controlled_digital_lending
 
     alias embargoed? embargoed
@@ -54,10 +54,6 @@ module Embed
 
     def purl_url
       "#{Settings.purl_url}/#{@druid}"
-    end
-
-    def bounding_box
-      Embed::Envelope.new(envelope).to_bounding_box
     end
 
     def manifest_json_url

--- a/app/models/embed/purl_xml_loader.rb
+++ b/app/models/embed/purl_xml_loader.rb
@@ -21,7 +21,7 @@ module Embed
         license:,
         use_and_reproduction:,
         embargo_release_date:,
-        envelope:,
+        bounding_box:,
         archived_site_url:,
         external_url:,
         embargoed:,
@@ -72,8 +72,11 @@ module Embed
       )&.map { |_name, value| value.gsub('info:fedora/druid:', '') } || []
     end
 
-    def envelope
-      ng_xml.at_xpath('//gml:Envelope', 'gml' => 'http://www.opengis.net/gml/3.2/')
+    def bounding_box
+      node = ng_xml.at_xpath('//gml:Envelope', 'gml' => 'http://www.opengis.net/gml/3.2/')
+      return unless node
+
+      Embed::Envelope.new(node).to_bounding_box
     end
 
     def embargo_release_date

--- a/spec/models/embed/purl_spec.rb
+++ b/spec/models/embed/purl_spec.rb
@@ -139,27 +139,6 @@ RSpec.describe Embed::Purl do
     end
   end
 
-  describe '#bounding_box' do
-    before { stub_purl_xml_response_with_fixture(geo_purl_public) }
-
-    it 'creates an Envelope and calls #to_bounding_box on it' do
-      expect_any_instance_of(Embed::Envelope).to receive(:to_bounding_box)
-      described_class.find('12345').bounding_box
-    end
-  end
-
-  describe '#envelope' do
-    it 'selects the envelope element' do
-      stub_purl_xml_response_with_fixture(geo_purl_public)
-      expect(described_class.find('12345').envelope).to be_an Nokogiri::XML::Element
-    end
-
-    it 'without an envelope present' do
-      stub_purl_xml_response_with_fixture(image_purl_xml)
-      expect(described_class.find('12345').envelope).to be_nil
-    end
-  end
-
   describe 'license' do
     it 'returns cc license if present' do
       stub_purl_xml_response_with_fixture(file_purl_xml)

--- a/spec/models/embed/purl_xml_loader_spec.rb
+++ b/spec/models/embed/purl_xml_loader_spec.rb
@@ -31,5 +31,13 @@ RSpec.describe Embed::PurlXmlLoader do
                                   type: 'webarchive-seed', collections: ['mk656nf8485'] })
       end
     end
+
+    context 'with an envelope' do
+      let(:xml) { geo_purl_public }
+
+      it 'creates a bounding_box' do
+        expect(data).to include({ bounding_box: [['-1.478794', '29.572742'], ['4.234077', '35.000308']] })
+      end
+    end
   end
 end


### PR DESCRIPTION
This is a parsing routine, not a data model routine, so it belongs in the loader