### PR TITLE
Remove test that has nothing to do with the download panel

### DIFF
--- a/spec/components/embed/footer_component_spec.rb
+++ b/spec/components/embed/footer_component_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Embed::FooterComponent, type: :component do
       expect(page).to have_css 'div.sul-embed-footer'
       expect(page).to have_css '[aria-label="open embed this panel"]'
       expect(page).to have_css '[aria-label="2 files available for download"]'
+      expect(page).to have_css '.sul-embed-download-count', text: 2
     end
   end
 

--- a/spec/features/download_panel_spec.rb
+++ b/spec/features/download_panel_spec.rb
@@ -43,26 +43,4 @@ RSpec.describe 'download panel', :js do
       expect(page).to have_css('button[data-sul-embed-toggle="sul-embed-download-panel"]')
     end
   end
-
-  describe 'download file count shows within download button' do
-    it 'has the file count for multiple media files in the download panel' do
-      stub_purl_xml_response_with_fixture(multi_media_purl)
-      visit_iframe_response
-      expect(page).to have_css '.sul-embed-body.sul-embed-media' # so shows download count
-      expect(page).to have_css 'button.sul-i-download-3[aria-label="2 files available for download"]'
-      within '.sul-i-download-3' do
-        expect(page).to have_css '.sul-embed-download-count', text: 2
-      end
-    end
-
-    it 'only counts downloadable files' do
-      stub_purl_xml_response_with_fixture(world_restricted_download_purl)
-      visit_iframe_response
-      expect(page).to have_css '.sul-embed-body.sul-embed-media' # so shows download count
-      expect(page).to have_css 'button.sul-i-download-3[aria-label="1 file available for download"]'
-      within '.sul-i-download-3' do
-        expect(page).to have_css '.sul-embed-download-count', text: 1
-      end
-    end
-  end
 end


### PR DESCRIPTION
This is the footer. I think there was some confusion here when image_x viewer was removed