### PR TITLE
Prevent race condition with loading the transcript.

### DIFF
--- a/app/components/embed/media_with_companion_windows_component.html.erb
+++ b/app/components/embed/media_with_companion_windows_component.html.erb
@@ -52,7 +52,7 @@
 
 
   <div class="media-component-body">
-    <aside class="left-drawer collapse" data-media-target="leftDrawer" id="left-drawer" aria-label="Sidebar" style="visibility: hidden">
+    <aside class="left-drawer collapse" data-controller="transcript" data-media-target="leftDrawer" id="left-drawer" aria-label="Sidebar" style="visibility: hidden">
       <nav class="vert-tabs" role="tablist">
         <button data-action="click->media#displayMetadata" data-media-target="leftButton" class="active" aria-label="About this item" aria-controls="about" aria-selected="true" role="tab">
           <svg class="MuiSvgIcon-root" focusable="false" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"></path></svg>
@@ -60,7 +60,7 @@
         <button data-action="click->media#displayContents" data-media-target="leftButton"  aria-label="Content" aria-controls="media-content" role="tab">
           <svg class="MuiSvgIcon-root" focusable="false" aria-hidden="true" viewBox="0 0 24 24"><path d="M4 10.5c-.83 0-1.5.67-1.5 1.5s.67 1.5 1.5 1.5 1.5-.67 1.5-1.5-.67-1.5-1.5-1.5zm0-6c-.83 0-1.5.67-1.5 1.5S3.17 7.5 4 7.5 5.5 6.83 5.5 6 4.83 4.5 4 4.5zm0 12c-.83 0-1.5.68-1.5 1.5s.68 1.5 1.5 1.5 1.5-.68 1.5-1.5-.67-1.5-1.5-1.5zM7 19h14v-2H7v2zm0-6h14v-2H7v2zm0-8v2h14V5H7z"></path></svg>
         </button>
-        <button data-action="click->media#displayTranscript" data-media-target="leftButton"  aria-label="Transcript" aria-controls="media-content" role="tab">
+        <button data-action="click->media#displayTranscript transcript#load" data-media-target="leftButton"  aria-label="Transcript" aria-controls="media-content" role="tab">
           <svg class="MuiSvgIcon-root" focusable="false" aria-hidden="true" viewBox="0 0 24 24"><path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"></path></svg>
         </button>
         <button data-action="click->media#displayRights" data-media-target="leftButton" aria-label="Use and reproduction" aria-controls="rights" role="tab">
@@ -86,7 +86,9 @@
           <div class="header-background">
             <h3>Transcript</h3>
           </div>
-          <div class="transcript" data-controller="transcript" data-action="media-loaded@window->transcript#load"></div>
+          <div class="transcript" data-action="media-loaded@window->transcript#persistPlayer">
+            <div data-transcript-target="outlet"></div>
+          </div>
         </section>
 
         <section id="rights" data-media-target="rights" role="tabpanel" hidden>

--- a/app/javascript/src/controllers/transcript_controller.js
+++ b/app/javascript/src/controllers/transcript_controller.js
@@ -3,16 +3,25 @@ import videojs from 'video.js';
 
 // This is tightly coupled to VideoJS's tracks implementation, because VideoJS removes the tracks from the
 // native player when it initializes.  This depends on the media_tag_controller.js emitting a custom media-loaded
-// event.  The load method on this class is called when that happens, and draws the transcript.
+// event.
 export default class extends Controller {
-  static targets = [ ]
+  static targets = [ "outlet" ]
 
-  load(evt) {
-    const tracks = evt.detail.textTracks_.tracks_
+  // When the media-loaded event occurs, store the handle to the player
+  persistPlayer(evt) {
+    this.player = evt.detail
+  }
+
+  // We can't load right away, because the VTT tracks may not have been parsed yet. So we wait until this panel is revealed.
+  load() {
+    if (this.loaded)
+      return
+    const tracks = this.player.textTracks_.tracks_
     if (!tracks)
       return
     const track = tracks.find((track) => track.kind === 'captions' )
     const cues = track.cues.cues_.map((cue) => `<p class="cue" data-controller="cue" data-action="click->cue#jump" data-cue-id="${cue.id}" data-cue-start-value="${cue.startTime}" data-cue-end-value="${cue.endTime}">${cue.text}</p>`)
-    this.element.innerHTML = cues.join('')
+    this.outletTarget.innerHTML = cues.join('')
+    this.loaded = true
   }
 }


### PR DESCRIPTION
We don't want to initialize our transcript viewer before videojs has parsed the webvtt files.  If we don't initialize until the transcript panel is open, this is unlikely to happen