### PR TITLE
Improve local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,7 @@ coverage
 /public/assets
 /public/packs
 /public/packs-test
-/public/stream
-/public/gt507vy5436_cap.vtt
+/public/file
 /node_modules
 /yarn-error.log
 yarn-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ coverage
 /public/assets
 /public/packs
 /public/packs-test
+/public/stream
+/public/gt507vy5436_cap.vtt
 /node_modules
 /yarn-error.log
 yarn-debug.log*

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'nokogiri', '>= 1.7.1'
 group :development, :test do
   gem 'capybara'
   gem 'debug', platforms: %i[mri]
+  gem 'druid-tools'
   gem 'factory_bot_rails', '~> 6.4'
   gem 'high_voltage'
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,7 @@ GEM
       nokogiri
     drb (2.2.0)
       ruby2_keywords
+    druid-tools (3.0.0)
     dry-configurable (1.1.0)
       dry-core (~> 1.0, < 2)
       zeitwerk (~> 2.6)
@@ -406,6 +407,7 @@ DEPENDENCIES
   debug
   dlss-capistrano
   dor-rights-auth
+  druid-tools
   factory_bot_rails (~> 6.4)
   faraday (~> 2)
   faraday-follow_redirects

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 web: unset PORT && bin/rdbg -O -n -c -- bin/rails server
-css: yarn build:css --watch
+css: bin/yarn build:css --watch
 js: bin/shakapacker-dev-server
+stacks: docker compose up --abort-on-container-exit --build

--- a/README.md
+++ b/README.md
@@ -69,20 +69,21 @@ For links that are intended to navigate the users browser away from the current 
 
 ## Developing the media player locally
 
-In order to do local development we need to circumvent the need for stacks and a media player.  The first can be done by running a local version of stacks via docker.  You can then configure your local app to point at that container via:
+First, identify an object in production that looks like it will work for your development purposes (e.g., a public video with captions, a Stanford-only audio with a transcript, etc.), and set up a ViewComponent preview for it unless it's already got one. Then we'll pull its files locally, so we don't need to hit a media server or a deployed instance:
+
 ```
-SETTINGS__STACKS_URL="http://localhost:3001/" bin/dev
+bin/rake stackify[gt507vy5436]
 ```
 
-Then we'll pull some files local so we don't need a media server:
-```
-mkdir public/stream && curl https://file-examples.com/storage/fe19e15eac6560f8c936c41/2017/04/file_example_MP4_480_1_5MG.mp4 -o public/stream/file_example_MP4_480_1_5MG.mp4
+Then, make sure you have an updated `stacks` checkout in a sibling directory to your `sul-embed` checkout. To run a local instance of stacks (from the sibling directory) via docker:
+
+```shell
+DOCKER_STACKS=true SETTINGS__STACKS_URL="http://localhost:3001" bin/dev
 ```
 
-and a sample vtt
-```
-curl https://stacks.stanford.edu/file/druid:gt507vy5436/gt507vy5436_cap.vtt -o public/gt507vy5436_cap.vtt
-```​
+Finally, use the ViewComponent preview you identified earlier to do your development.
+
+NOTE: We can dispense with the sibling directory jazz if we decide to publish the Stacks docker image.
 
 ## Updating language tags
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,24 @@ The rich HTML payload that is supplied via the oEmbed API is an iframe. This mea
 
 For links that are intended to navigate the users browser away from the current page (e.g. the links to Memento/GeoBlacklight/etc.) then `target="_parent"` should be used to give the link the default browser behavior. [More about link targets](http://www.w3schools.com/tags/att_a_target.asp).
 
+
+## Developing the media player locally
+
+In order to do local development we need to circumvent the need for stacks and a media player.  The first can be done by running a local version of stacks via docker.  You can then configure your local app to point at that container via:
+```
+SETTINGS__STACKS_URL="http://localhost:3001/" bin/dev
+```
+
+Then we'll pull some files local so we don't need a media server:
+```
+mkdir public/stream && curl https://file-examples.com/storage/fe19e15eac6560f8c936c41/2017/04/file_example_MP4_480_1_5MG.mp4 -o public/stream/file_example_MP4_480_1_5MG.mp4
+```
+
+and a sample vtt
+```
+curl https://stacks.stanford.edu/file/druid:gt507vy5436/gt507vy5436_cap.vtt -o public/gt507vy5436_cap.vtt
+```​
+
 ## Updating language tags
 
 sul-embed uses the IANA language subtag registry to resolve user-provided file language codes (e.g., 'en-US') onto user-friendly labels (e.g., "English"), primarily for captions in the media player. This file lives on the web and changes every so often. We cache this file in `vendor/data/language-subtag-registry`, and it can be updated via `rake update_language_tags`.

--- a/Rakefile
+++ b/Rakefile
@@ -30,3 +30,15 @@ task :update_language_tags do
     file.write(Faraday.get(Settings.language_subtag_registry.url).body)
   end
 end
+
+task :stackify, [:bare_druid] => :environment do |_task, args|
+  exit(1) unless Rails.env.development?
+
+  bare_druid = args[:bare_druid]
+  druid_path = DruidTools::StacksDruid.new(bare_druid, Settings.stacks_storage_root).path
+  `mkdir -p #{druid_path}`
+  Embed::Purl.find(bare_druid).downloadable_files.each do |resource_file|
+    puts "Downloading #{resource_file.filename} to #{druid_path}/#{resource_file.filename}"
+    `curl https://stacks.stanford.edu/file/#{bare_druid}/#{resource_file.filename} -o #{druid_path}/#{resource_file.filename}`
+  end
+end

--- a/app/components/embed/media_tag_component.rb
+++ b/app/components/embed/media_tag_component.rb
@@ -81,8 +81,6 @@ module Embed
     end
 
     def enabled_streaming_sources
-      return tag.source(src: '/stream/file_example_MP4_480_1_5MG.mp4', type: 'video/mp4') if Rails.env.development?
-
       safe_join(
         enabled_streaming_types.map do |streaming_type|
           tag.source(src: streaming_url_for(streaming_type),
@@ -93,8 +91,6 @@ module Embed
 
     # Generate the video caption elements
     def captions
-      return tag.track(src: '/gt507vy5436_cap.vtt', kind: 'captions', srclang: 'en', label: 'English') if Rails.env.development?
-
       return unless render_captions?
 
       # A video clip may have multiple caption files in different languages.
@@ -113,6 +109,9 @@ module Embed
     end
 
     def streaming_settings_for(streaming_type)
+      # Return the media file's MIME type in dev, as we're circumventing the need for a streaming server
+      return { mimetype: file.mimetype } if Rails.env.development?
+
       Settings.streaming[streaming_type] || {}
     end
 

--- a/app/components/embed/media_tag_component.rb
+++ b/app/components/embed/media_tag_component.rb
@@ -81,6 +81,8 @@ module Embed
     end
 
     def enabled_streaming_sources
+      return tag.source(src: '/stream/file_example_MP4_480_1_5MG.mp4', type: 'video/mp4') if Rails.env.development?
+
       safe_join(
         enabled_streaming_types.map do |streaming_type|
           tag.source(src: streaming_url_for(streaming_type),
@@ -91,6 +93,8 @@ module Embed
 
     # Generate the video caption elements
     def captions
+      return tag.track(src: '/gt507vy5436_cap.vtt', kind: 'captions', srclang: 'en', label: 'English') if Rails.env.development?
+
       return unless render_captions?
 
       # A video clip may have multiple caption files in different languages.

--- a/bin/dev
+++ b/bin/dev
@@ -5,4 +5,11 @@ if ! gem list foreman -i --silent; then
   gem install foreman
 fi
 
-exec foreman start -f Procfile.dev "$@"
+# If the DOCKER_STACKS env variable is empty, do not spin up stacks via Procfile.dev
+if [ -z $DOCKER_STACKS ]; then
+    foreman_args=--formation="stacks=0,all=1"
+else
+    foreman_args=--formation="all=1"
+fi
+
+exec foreman start -f Procfile.dev $foreman_args "$@"

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,4 @@
+stacks_storage_root: "public/file"
+enabled_features:
+  new_component: true
+  transcripts: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.6'
+
+services:
+  stacks:
+    build: ../stacks/
+    ports:
+      - 3001:3000
+    volumes:
+      - ./public/file:/stacks
+    environment:
+      SECRET_KEY_BASE: 'e55fb68eb0f1f4f82fbb56eafeebf1c134518fd466d1c3d01b2bfd3d6b5cd9347b4c15eecb3bdc0e4c5bc226dba626a23bb7b9ddb14f709638571f910002f639'
+      RAILS_LOG_TO_STDOUT: 'true'
+      REMOTE_USER: blalbrit@stanford.edu
+      SETTINGS__CORS__ALLOW_ORIGIN_URL: 'http://localhost:3000'
+    tty: true

--- a/lib/embed/stacks_media_stream.rb
+++ b/lib/embed/stacks_media_stream.rb
@@ -33,6 +33,9 @@ module Embed
     def streaming_url_for(type)
       return unless file.title && streaming_file_prefix
 
+      # Use the Stacks URL to "stream" media in dev, as we're circumventing the need for a streaming server
+      return "#{Settings.stacks_url}/file/#{druid}/#{file.filename}" if Rails.env.development?
+
       protocol = streaming_protocol(type)
       suffix = TYPE_TO_MANIFEST_FILE[type]
       delimiter = streaming_url_delimiter(type)

--- a/test/components/previews/embed/media_with_companion_windows_component_preview.rb
+++ b/test/components/previews/embed/media_with_companion_windows_component_preview.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-# Access this preview at:
-# http://localhost:3000/rails/view_components/embed/media_with_companion_windows_component/with_default_title
-
+# Access these previews at:
+# http://localhost:3000/rails/view_components/embed/media_with_companion_windows_component
 module Embed
   class MediaWithCompanionWindowsComponentPreview < ViewComponent::Preview
     def with_audio


### PR DESCRIPTION
This commit aims to improve local development of the media player in particular, by running a Stacks container out of a sibling directory and by serving files without requiring a media server (such as Wowza).

Closes #1855

Includes the following changes:

* Add a rake task to pull downloadable files from prod stacks into the local fake stacks root
* Ignore the fake stacks root (in `public/file/`)
* Use the druid-tools gem to construct the directory structure Stacks expects to serve files from (only in development bundler group)
* Pull in stacks' docker-compose so we can run it as part of sul-embed's `bin/dev` and mount the fake stacks root as a volume in the container
* Update README
* Add development configuration as a file

NOTE: Depends on https://github.com/sul-dlss/stacks/pull/1053, and on having an up-to-date checkout of stacks in a sibling directory. We can get rid of this in the future if we publish the stacks image.
