### PR TITLE
Revert to pdf.js v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "mirador-dl-plugin": "^0.13.0",
     "mirador-image-tools": "^0.8.0",
     "mirador-share-plugin": "^0.11.0",
-    "pdfjs-dist": "^4",
+    "pdfjs-dist": "^3.11.174",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5085,10 +5085,10 @@ path2d-polyfill@^2.0.1:
   resolved "https://registry.yarnpkg.com/path2d-polyfill/-/path2d-polyfill-2.0.1.tgz#24c554a738f42700d6961992bf5f1049672f2391"
   integrity sha512-ad/3bsalbbWhmBo0D6FZ4RNMwsLsPpL6gnvhuSaU5Vm7b06Kr5ubSltQQ0T7YKsiJQO+g22zJ4dJKNTXIyOXtA==
 
-pdfjs-dist@^4:
-  version "4.0.269"
-  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-4.0.269.tgz#3a319367f441e84f9c8aae01d88b0fb5a7defc4e"
-  integrity sha512-jjWO56tcOjnmPqDf8PmXDeZ781AGvpHMYI3HhNtaFKTRXXPaD1ArSrhVe38/XsrIQJ0onISCND/vuXaWJkiDWw==
+pdfjs-dist@^3.11.174:
+  version "3.11.174"
+  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-3.11.174.tgz#5ff47b80f2d58c8dd0d74f615e7c6a7e7e704c4b"
+  integrity sha512-TdTZPf1trZ8/UFu5Cx/GXB7GZM30LT+wWUNfsi6Bq8ePLnb+woNKtDymI2mxZYBpMbonNFqKmiz684DIfnd8dA==
   optionalDependencies:
     canvas "^2.11.2"
     path2d-polyfill "^2.0.1"


### PR DESCRIPTION
Pdf.js v4 is causing issues with our custom JS implementation: https://app.honeybadger.io/projects/49295/faults/101989226

This reverts it back to v3.  We are likely to stop using pdf.js completely anyway, so not worth making our code work with v4 right now (see #1832)