### PR TITLE
Restore the visually-hidden class to the media player

### DIFF
--- a/app/assets/stylesheets/media.scss
+++ b/app/assets/stylesheets/media.scss
@@ -380,6 +380,10 @@
       }
     }
 
+    .visually-hidden {
+      @include visually-hidden;
+    }
+
     .inner {
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
This should have moved to the left companion window in https://github.com/sul-dlss/sul-embed/commit/dca8b4513ed720fec104a73b8745b3eb763a7620\#diff-ecb5a422e27a54dcca275598447d112392ff57a79f4192f5e4b1f90c0c22099cL274-L276

Fixes #1900