### PR TITLE
If not authorized on an audio file, show the default waveform poster

### DIFF
--- a/app/components/embed/media_with_companion_windows_component.html.erb
+++ b/app/components/embed/media_with_companion_windows_component.html.erb
@@ -115,7 +115,7 @@
       <div data-controller="locked-audio-poster" data-action="auth-success@window->locked-audio-poster#hide auth-denied@window->locked-audio-poster#show" tabindex="-1" role="presentation" style="display: none; flex: 1 0 100%;">
         <picture class="locked-media">
           <%# The explicitly empty alt is preferred here, since this image merely adds visual decoration. %>
-          <%= image_tag 'waveform-audio-poster.svg', loading: 'lazy', alt: '' %>
+          <%= image_tag 'waveform-audio-poster.svg', id: 'audio-poster', loading: 'lazy', alt: '' %>
         </picture>
       </div>
 

--- a/app/components/embed/media_with_companion_windows_component.html.erb
+++ b/app/components/embed/media_with_companion_windows_component.html.erb
@@ -112,7 +112,7 @@
         </picture>
       </div>
 
-      <div data-controller="locked-audio-poster" data-action="auth-success@window->locked-audio-poster#hide auth-denied@window->locked-audio-poster#show" tabindex="-1" role="presentation" style="display: none; flex: 1 0 100%;">
+      <div data-controller="locked-audio-poster" data-action="auth-success@window->locked-audio-poster#hide auth-denied@window->locked-audio-poster#show" tabindex="-1" role="presentation" style="flex: 1 0 100%;" hidden>
         <picture class="locked-media">
           <%# The explicitly empty alt is preferred here, since this image merely adds visual decoration. %>
           <%= image_tag 'waveform-audio-poster.svg', id: 'audio-poster', loading: 'lazy', alt: '' %>

--- a/app/components/embed/media_with_companion_windows_component.html.erb
+++ b/app/components/embed/media_with_companion_windows_component.html.erb
@@ -115,7 +115,7 @@
       <div data-controller="locked-audio-poster" data-action="auth-success@window->locked-audio-poster#hide auth-denied@window->locked-audio-poster#show" tabindex="-1" role="presentation" style="flex: 1 0 100%;" hidden>
         <picture class="locked-media">
           <%# The explicitly empty alt is preferred here, since this image merely adds visual decoration. %>
-          <%= image_tag 'waveform-audio-poster.svg', id: 'audio-poster', loading: 'lazy', alt: '' %>
+          <%= image_tag 'waveform-audio-poster.svg', loading: 'lazy', alt: '', data: { locked_audio_poster_target: 'poster' } %>
         </picture>
       </div>
 

--- a/app/components/embed/media_with_companion_windows_component.html.erb
+++ b/app/components/embed/media_with_companion_windows_component.html.erb
@@ -112,6 +112,13 @@
         </picture>
       </div>
 
+      <div data-controller="locked-audio-poster" data-action="auth-success@window->locked-audio-poster#hide auth-denied@window->locked-audio-poster#show" tabindex="-1" role="presentation" style="display: none; flex: 1 0 100%;">
+        <picture class="locked-media">
+          <%# The explicitly empty alt is preferred here, since this image merely adds visual decoration. %>
+          <%= image_tag 'waveform-audio-poster.svg', loading: 'lazy', alt: '' %>
+        </picture>
+      </div>
+
       <%= render Embed::MediaTagComponent.with_collection(resources_with_primary_file,
                                                           include_transcripts:,
                                                           druid:) %>

--- a/app/javascript/controllers/locked_audio_poster_controller.js
+++ b/app/javascript/controllers/locked_audio_poster_controller.js
@@ -4,8 +4,13 @@ export default class extends Controller {
   // Display the waveform when logged out as the audio tag
   // does not support the poster attribute
   show() {
-    if (this.isAudio())
+    if (this.isAudio()) {
+      const poster_path = this.poster()
+      if (poster_path)
+        document.getElementById('audio-poster').setAttribute('src', poster_path)
+
       this.element.style.display = 'flex'
+    }
   }
 
   hide() {
@@ -14,5 +19,11 @@ export default class extends Controller {
 
   isAudio() {
     return document.querySelectorAll('audio').length > 0
+  }
+
+  poster() {
+    const tags = document.querySelectorAll('audio')
+    const audio_posters = [...tags].map((tag) => tag.getAttribute('poster'))
+    return audio_posters.filter(poster => poster.includes('default.jpg'))[0]
   }
 }

--- a/app/javascript/controllers/locked_audio_poster_controller.js
+++ b/app/javascript/controllers/locked_audio_poster_controller.js
@@ -1,13 +1,14 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
+  static targets = [ "poster"]
   // Display the waveform when logged out as the audio tag
   // does not support the poster attribute
   show() {
     if (this.isAudio()) {
       const poster_path = this.poster()
       if (poster_path)
-        document.getElementById('audio-poster').setAttribute('src', poster_path)
+        this.posterTarget.setAttribute('src', poster_path)
 
       this.element.hidden = false
     }
@@ -22,8 +23,6 @@ export default class extends Controller {
   }
 
   poster() {
-    const tags = document.querySelectorAll('audio')
-    const audio_posters = [...tags].map((tag) => tag.getAttribute('poster'))
-    return audio_posters.filter(poster => poster.includes('default.jpg'))[0]
+    return document.querySelector('audio').getAttribute('poster')
   }
 }

--- a/app/javascript/controllers/locked_audio_poster_controller.js
+++ b/app/javascript/controllers/locked_audio_poster_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  // Display the waveform when logged out as the audio tag
+  // does not support the poster attribute
+  show() {
+    if (this.isAudio())
+      this.element.style.display = 'flex'
+  }
+
+  hide() {
+    this.element.style.display = 'none'
+  }
+
+  isAudio() {
+    return document.querySelectorAll('audio').length > 0
+  }
+}

--- a/app/javascript/controllers/locked_audio_poster_controller.js
+++ b/app/javascript/controllers/locked_audio_poster_controller.js
@@ -9,12 +9,12 @@ export default class extends Controller {
       if (poster_path)
         document.getElementById('audio-poster').setAttribute('src', poster_path)
 
-      this.element.style.display = 'flex'
+      this.element.hidden = false
     }
   }
 
   hide() {
-    this.element.style.display = 'none'
+    this.element.hidden = true
   }
 
   isAudio() {


### PR DESCRIPTION
Closes #1761 

When not authorized and the file is audio:

![Screenshot 2023-12-04 at 1 57 31 PM](https://github.com/sul-dlss/sul-embed/assets/2294288/7eec084c-1da5-48d7-ba7b-2af6e95c1feb)

Audio when a poster is provided:

![Screenshot 2023-12-05 at 4 20 33 PM](https://github.com/sul-dlss/sul-embed/assets/2294288/e3ad78c6-457a-470c-a8ea-2f07192bb087)

Video shows the poster:

![Screenshot 2023-12-04 at 1 59 13 PM](https://github.com/sul-dlss/sul-embed/assets/2294288/028cbd15-6fb6-4508-a6a0-fb39d321add4)
