### PR TITLE
Cleanup dismiss button style

### DIFF
--- a/app/assets/stylesheets/media.scss
+++ b/app/assets/stylesheets/media.scss
@@ -358,13 +358,17 @@
       border-radius: 5px;
       padding: 0.2rem 0.4rem;
       text-transform: uppercase;
+      &:hover {
+        cursor: pointer;
+        opacity: 0.9;
+      }
     }
 
-    button.dismissButton {
-      padding: 0rem;
-
+    .dismissButton {
+      padding: 0.2rem;
       svg {
-        font-size: 0.85rem;
+        font-size: 1rem;
+        vertical-align: bottom;
       }
     }
   }


### PR DESCRIPTION
Prior to this change the button on https://sul-purl-stage.stanford.edu/tw581qt4975 looked like this on Firefox and Edge:

<img width="181" alt="Screenshot 2023-12-05 at 4 22 05 PM" src="https://github.com/sul-dlss/sul-embed/assets/92044/8c4665fa-cdaf-4e54-b1f3-f70bc60475ef">

After: 

<img width="188" alt="Screenshot 2023-12-05 at 4 33 56 PM" src="https://github.com/sul-dlss/sul-embed/assets/92044/af09f8d2-26ec-419a-bf59-d9ee832c8e90">
