### PR TITLE
Improve alignment of content listing icons and text

### DIFF
--- a/app/assets/stylesheets/media.scss
+++ b/app/assets/stylesheets/media.scss
@@ -485,9 +485,15 @@
       border: 1px solid gray;
       margin-bottom: 0.5rem;
       height: var(--slider-thumb-height);
+      text-align: center;
 
       .default-thumbnail-icon {
+        display: inline-block;
         font-size: calc(var(--slider-thumb-height) - 2px);
+        width: 75px;
+        margin-right: .5rem;
+        padding-left: .3rem;
+
         &::before {
           vertical-align: text-top;
         }
@@ -515,6 +521,7 @@
         margin-top: 0.25rem;
         vertical-align: top;
         width: 130px;
+        text-align: left;
       }
     }
   }

--- a/app/components/embed/legacy_media/media_tag_component.rb
+++ b/app/components/embed/legacy_media/media_tag_component.rb
@@ -35,7 +35,7 @@ module Embed
       end
 
       def thumbnail_url
-        stacks_square_url(@druid, @resource.thumbnail.title, size: '75') if @resource.thumbnail
+        stacks_square_url(@druid, @resource.thumbnail.title, size: '75,75') if @resource.thumbnail
       end
 
       def poster_url_for
@@ -85,7 +85,7 @@ module Embed
       end
 
       def previewable_element
-        thumb_url = stacks_square_url(@druid, file.title, size: '75')
+        thumb_url = stacks_square_url(@druid, file.title, size: '75,75')
         render MediaWrapperComponent.new(thumbnail: thumb_url, file:, type:, resource_index: @resource_iteration.index,
                                          scroll: true) do
           tag.img(src: stacks_thumb_url(@druid, file.title),

--- a/app/components/embed/media_preview_image_component.rb
+++ b/app/components/embed/media_preview_image_component.rb
@@ -19,7 +19,8 @@ module Embed
     attr_reader :resource_index, :druid, :file, :type
 
     def call
-      thumb_url = stacks_square_url(druid, file.title, size: '75')
+      # the 74,73 size accounts for the additional pixel size returned by the image server 
+      thumb_url = stacks_square_url(druid, file.title, size: '74,73')
       render MediaWrapperComponent.new(thumbnail: thumb_url, file:, type:, resource_index:, scroll: true) do
         tag.div(class: 'osd', id: "openseadragon-#{resource_index}",
                 data: { controller: 'osd', osd_url_value:, osd_nav_images_value: })

--- a/app/components/embed/media_preview_image_component.rb
+++ b/app/components/embed/media_preview_image_component.rb
@@ -19,7 +19,7 @@ module Embed
     attr_reader :resource_index, :druid, :file, :type
 
     def call
-      # the 74,73 size accounts for the additional pixel size returned by the image server 
+      # the 74,73 size accounts for the additional pixel size returned by the image server
       thumb_url = stacks_square_url(druid, file.title, size: '74,73')
       render MediaWrapperComponent.new(thumbnail: thumb_url, file:, type:, resource_index:, scroll: true) do
         tag.div(class: 'osd', id: "openseadragon-#{resource_index}",

--- a/app/components/embed/media_tag_component.rb
+++ b/app/components/embed/media_tag_component.rb
@@ -31,7 +31,7 @@ module Embed
     end
 
     def thumbnail_url
-      # the 74,73 size accounts for the additional pixel size returned by the image server 
+      # the 74,73 size accounts for the additional pixel size returned by the image server
       stacks_square_url(druid, @resource.thumbnail.title, size: '74,73') if @resource.thumbnail
     end
 

--- a/app/components/embed/media_tag_component.rb
+++ b/app/components/embed/media_tag_component.rb
@@ -31,7 +31,8 @@ module Embed
     end
 
     def thumbnail_url
-      stacks_square_url(druid, @resource.thumbnail.title, size: '75') if @resource.thumbnail
+      # the 74,73 size accounts for the additional pixel size returned by the image server 
+      stacks_square_url(druid, @resource.thumbnail.title, size: '74,73') if @resource.thumbnail
     end
 
     def poster_url_for

--- a/lib/embed/stacks_image.rb
+++ b/lib/embed/stacks_image.rb
@@ -9,8 +9,8 @@ module Embed
       "#{stacks_image_url(druid, file_name)}/full/#{size}/0/default.jpg"
     end
 
-    def stacks_square_url(druid, file_name, size: 100)
-      "#{stacks_image_url(druid, file_name)}/square/#{size},#{size}/0/default.jpg"
+    def stacks_square_url(druid, file_name, size: '100,100')
+      "#{stacks_image_url(druid, file_name)}/square/#{size}/0/default.jpg"
     end
 
     def stacks_image_url(druid, file_name)

--- a/spec/components/embed/media_tag_component_spec.rb
+++ b/spec/components/embed/media_tag_component_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Embed::MediaTagComponent, type: :component do
 
       it 'includes the file level thumbnail data-attribute' do
         object = page.find('[data-slider-object="0"]')
-        expect(object['data-thumbnail-url']).to match(%r{%2Faudio_1/square/75,75/})
+        expect(object['data-thumbnail-url']).to match(%r{%2Faudio_1/square/74,75/})
       end
     end
 
@@ -92,7 +92,7 @@ RSpec.describe Embed::MediaTagComponent, type: :component do
 
       it 'includes the file level thumbnail data-attribute when present' do
         object = page.find('[data-slider-object="0"]')
-        expect(object['data-thumbnail-url']).to match(%r{%2Fvideo_1/square/75,75/})
+        expect(object['data-thumbnail-url']).to match(%r{%2Fvideo_1/square/74,75/})
       end
     end
 

--- a/spec/components/embed/media_tag_component_spec.rb
+++ b/spec/components/embed/media_tag_component_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Embed::MediaTagComponent, type: :component do
 
       it 'includes the file level thumbnail data-attribute' do
         object = page.find('[data-slider-object="0"]')
-        expect(object['data-thumbnail-url']).to match(%r{%2Faudio_1/square/74,75/})
+        expect(object['data-thumbnail-url']).to match(%r{%2Faudio_1/square/74,73/})
       end
     end
 
@@ -92,7 +92,7 @@ RSpec.describe Embed::MediaTagComponent, type: :component do
 
       it 'includes the file level thumbnail data-attribute when present' do
         object = page.find('[data-slider-object="0"]')
-        expect(object['data-thumbnail-url']).to match(%r{%2Fvideo_1/square/74,75/})
+        expect(object['data-thumbnail-url']).to match(%r{%2Fvideo_1/square/74,73/})
       end
     end
 

--- a/spec/lib/embed/stacks_image_spec.rb
+++ b/spec/lib/embed/stacks_image_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Embed::StacksImage do
     end
 
     it 'accpets an optional size parameter' do
-      expect(subject.stacks_square_url('abc123', 'filename.jpg', size: 50)).to match(%r{square/50,50/})
+      expect(subject.stacks_square_url('abc123', 'filename.jpg', size: '50,50')).to match(%r{square/50,50/})
     end
 
     it 'escapes special characters in the image file name' do


### PR DESCRIPTION
Fixes #1933 

- centers the default icon with the thumbnails
- aligns text to the right of the icon/thumbnails

![Screenshot 2023-12-08 at 9 06 43 AM](https://github.com/sul-dlss/sul-embed/assets/2294288/9f9b9621-1413-4afb-818c-6c6e4542b84f)
