### PR TITLE
Make the geo viewer download panel use the FileListItemComponent

### DIFF
--- a/app/components/embed/download/file_list_item_component.html.erb
+++ b/app/components/embed/download/file_list_item_component.html.erb
@@ -1,6 +1,6 @@
 <li>
-  <a href='<%= url %>' title='<%= file.title %>' target='_blank' rel='noopener noreferrer'>
-    Download <%= file.label_or_filename %>
+  <a href='<%= url %>' target='_blank' rel='noopener noreferrer'>
+    Download <%= download_label %>
   </a>
   <%= render 'embed/restrictions_text_for_file', file: file %>
   <%= file_size %>

--- a/app/components/embed/download/file_list_item_component.rb
+++ b/app/components/embed/download/file_list_item_component.rb
@@ -4,8 +4,9 @@ module Embed
   module Download
     class FileListItemComponent < ViewComponent::Base
       include Embed::PrettyFilesize
-      def initialize(file_list_item:)
+      def initialize(file_list_item:, prefer_filename: false)
         @file = file_list_item
+        @prefer_filename = prefer_filename
       end
       attr_reader :file
 
@@ -15,6 +16,12 @@ module Embed
 
       def url
         file.file_url(download: true)
+      end
+
+      def download_label
+        return file.filename if @prefer_filename
+
+        file.label_or_filename
       end
     end
   end

--- a/app/components/embed/download/geo_component.html.erb
+++ b/app/components/embed/download/geo_component.html.erb
@@ -2,14 +2,7 @@
   <%= render DownloadPanelComponent.new do %>
     <% viewer.purl_object.contents.each do |resource| %>
       <ul class='sul-embed-download-list'>
-        <% resource.files.each do |file| %>
-          <li>
-            <a href="<%= file.file_url(download: true) %>" title="<%= file.title %>" target='_blank' rel='noopener noreferrer'>
-              Download <%= file.title %>
-            </a>
-            <%= render 'embed/restrictions_text_for_file', file: file %>
-          </li>
-        <% end %>
+        <%= render Embed::Download::FileListItemComponent.with_collection(resource.files, prefer_filename: true) %>
       </ul>
     <% end %>
   <% end %>


### PR DESCRIPTION
This adds a flag to the FileListItemComponent so that you can
choose to render download items with their filename instead of
the label, in the event that the label is unusably generic,
which it nearly always is for geo content.
