### PR TITLE
Short-circuit loading transcript experience if there are no current cues

### DIFF
--- a/app/javascript/controllers/transcript_controller.js
+++ b/app/javascript/controllers/transcript_controller.js
@@ -14,7 +14,7 @@ export default class extends Controller {
 
   // We can't load right away, because the VTT tracks may not have been parsed yet. So we wait until this panel is revealed.
   load() {
-    if (this.loaded)
+    if (this.loaded || !this.currentCues())
       return
     this.revealButton()
     this.setupTranscriptLanguageSwitching()
@@ -34,6 +34,9 @@ export default class extends Controller {
     if (this.captionTracks.length == 0) return cues
 
     this.captionTracks.forEach(track => {
+      if (!track.cues)
+        return
+
       const list = track.cues.cues_
       const cueStartTimes = list.length === 0 ? undefined : list.map((cue) => cue.startTime)
 

--- a/test/components/previews/embed/media_with_companion_windows_component_preview.rb
+++ b/test/components/previews/embed/media_with_companion_windows_component_preview.rb
@@ -28,6 +28,10 @@ module Embed
       render_media_viewer_for(url: 'https://purl.stanford.edu/dq301jn4140')
     end
 
+    def without_captions
+      render_media_viewer_for(url: 'https://purl.stanford.edu/dp324gw4986')
+    end
+
     private
 
     def render_media_viewer_for(url:)


### PR DESCRIPTION
Fixes #1950

Also, guard against caption tracks lacking cues. (In response to errors like https://app.honeybadger.io/projects/49295/faults/102912251 and https://app.honeybadger.io/projects/49295/faults/102908994)
