### PR TITLE
Intercept links from IIIF manifest to set target and rels

### DIFF
--- a/app/components/embed/media_with_companion_windows_component.rb
+++ b/app/components/embed/media_with_companion_windows_component.rb
@@ -23,7 +23,7 @@ module Embed
     end
 
     def iiif_v3_manifest_url
-      "#{Settings.purl_url}/#{druid}//iiif3/manifest"
+      "#{Settings.purl_url}/#{druid}/iiif3/manifest"
     end
   end
 end

--- a/app/javascript/controllers/iiif_metadata_controller.js
+++ b/app/javascript/controllers/iiif_metadata_controller.js
@@ -9,6 +9,18 @@ export default class extends Controller {
   }
 
   valueToDefinition(defs) {
-    return defs.map((record) => `<dd>${record}</dd>`).join('')
+    return defs.map(record => {
+      // Make sure all links open in a new window
+      const node = new DOMParser().parseFromString(record, "text/html").body.firstChild
+      if ('target' in node) {
+        // Set all elements owning target to target=_blank
+        node.setAttribute('target', '_blank');
+        // Prevent https://www.owasp.org/index.php/Reverse_Tabnabbing
+        node.setAttribute('rel', 'noopener noreferrer');
+        return `<dd>${node.outerHTML}</dd>`
+      } else {
+        return `<dd>${record}</dd>`
+      }
+    }).join('')
   }
 }

--- a/app/javascript/controllers/media_tag_controller.js
+++ b/app/javascript/controllers/media_tag_controller.js
@@ -25,7 +25,7 @@ export default class extends Controller {
 
   dispatchManifestEvent(json) {
     const event = new CustomEvent('iiif-manifest-received', { detail: json })
-    window.dispatchEvent(event)  
+    window.dispatchEvent(event)
   }
 
   validateMedia(completeCallback) {


### PR DESCRIPTION
Fixes #1963

Links from the IIIF manifest, such as for "Available Online" in the metadata panel, are generated in PURL without targets or rels, and as such, these links wind up opening inside the embed iframe leading to a dizzying link-ception scenario as documented in the associated issue. This commit fixes that behavior in the same way Mirador already does: https://github.com/ProjectMirador/mirador/blob/cefe7b7b520ae1cb637d935c7b3cfceaff96b14a/src/components/SanitizedHtml.js#L17-L25 Namely, by sniffing each IIIF manifest value to see if it is a node with a target, such as an anchor element, and coercing the target to "_blank" and setting the expected rels. This forces links to open in a new window.
