### PR TITLE
removing checked by default for autoscroll checkbox

### DIFF
--- a/app/components/embed/media_with_companion_windows_component.html.erb
+++ b/app/components/embed/media_with_companion_windows_component.html.erb
@@ -93,7 +93,7 @@
           <div class="transcript-controls header-background">
             <div class="transcript-autoscroll">
               <label for="autoscroll">Auto scroll</label>
-              <input data-transcript-target="autoscroll" type="checkbox" id="autoscroll" checked>
+              <input data-transcript-target="autoscroll" type="checkbox" id="autoscroll">
             </div>
             <div class="transcript-language">
               <label class="visually-hidden" for="caption-languages">Select Language</label>


### PR DESCRIPTION
Closes #1998 

What this pull request does:

- Removes the "checked" attribute on the autoscroll checkbox in the companion window, so the checkbox will not be checked by default when the transcript window loads. 