### PR TITLE
Fix nested closed branches in file viewer.

### DIFF
--- a/app/javascript/file_controllers/tree_controller.js
+++ b/app/javascript/file_controllers/tree_controller.js
@@ -23,9 +23,19 @@ export default class extends Controller {
     } else {
       // Expand
       dirTrElement.setAttribute('aria-expanded', 'true')
+      let closedBranchLevel = null
       this.childTrElements(dirTrElement).forEach((childTrElement) => {
+        // Keeps nested closed branches closed and children hidden.
+        if(closedBranchLevel && childTrElement.getAttribute('aria-level') > closedBranchLevel) return
+
         delete childTrElement.dataset.expandHidden
-        this.toggleHide(childTrElement)
+        this.toggleHide(childTrElement)  
+        
+        if(this.isClosedBranch(childTrElement)) {
+          closedBranchLevel = childTrElement.getAttribute('aria-level')
+        } else {
+          closedBranchLevel = null
+        }        
       })
     }
   }


### PR DESCRIPTION
Per @jcoyne steps to reproduce:
1. Go to https://sul-purl-stage.stanford.edu/bh114dk3076
2. Collapse “settings”
3. Collapse “config”
4. Expand “config”
5. Now the icon for “settings” is collapsed, but the files under it are expanded.