### PR TITLE
Handle case where the auth-service doesn't give access

### DIFF
--- a/app/components/embed/media_with_companion_windows_component.html.erb
+++ b/app/components/embed/media_with_companion_windows_component.html.erb
@@ -47,13 +47,13 @@
         <button data-auth-restriction-target="embargoLoginButton" data-action="media-tag#logIn">Log in</button>
       </div>
     </div>
-  </div>
-  <% if citation_only? %>
-    <div class="authLinkWrapper">
-      <svg class="MuiSvgIcon-root" focusable="false" aria-hidden="true" viewBox="0 0 24 24"><path d="m14.5 14.2 2.9 1.7-.8 1.3L13 15v-5h1.5v4.2zM22 14c0 4.41-3.59 8-8 8-2.02 0-3.86-.76-5.27-2H4c-1.15 0-2-.85-2-2V9c0-1.12.89-1.96 2-2v-.5C4 4.01 6.01 2 8.5 2c2.34 0 4.24 1.79 4.46 4.08.34-.05.69-.08 1.04-.08 4.41 0 8 3.59 8 8zM6 7h5v-.74C10.88 4.99 9.8 4 8.5 4 7.12 4 6 5.12 6 6.5V7zm14 7c0-3.31-2.69-6-6-6s-6 2.69-6 6 2.69 6 6 6 6-2.69 6-6z"></path></svg>
-      <p class="loginMessage">This item cannot be accessed online. See access conditions for more information.</p>
+    <div data-auth-restriction-target="noAccess" hidden>
+      <div class="authLinkWrapper">
+        <svg class="MuiSvgIcon-root" focusable="false" aria-hidden="true" viewBox="0 0 24 24"><path d="m14.5 14.2 2.9 1.7-.8 1.3L13 15v-5h1.5v4.2zM22 14c0 4.41-3.59 8-8 8-2.02 0-3.86-.76-5.27-2H4c-1.15 0-2-.85-2-2V9c0-1.12.89-1.96 2-2v-.5C4 4.01 6.01 2 8.5 2c2.34 0 4.24 1.79 4.46 4.08.34-.05.69-.08 1.04-.08 4.41 0 8 3.59 8 8zM6 7h5v-.74C10.88 4.99 9.8 4 8.5 4 7.12 4 6 5.12 6 6.5V7zm14 7c0-3.31-2.69-6-6-6s-6 2.69-6 6 2.69 6 6 6 6-2.69 6-6z"></path></svg>
+        <p class="loginMessage">This item cannot be accessed online. See access conditions for more information.</p>
+      </div>
     </div>
-  <% end %>
+  </div>
 
   <div class="media-component-body">
     <aside class="left-drawer collapse" data-media-target="leftDrawer" id="left-drawer" aria-label="Sidebar" style="visibility: hidden">

--- a/app/components/embed/media_with_companion_windows_component.rb
+++ b/app/components/embed/media_with_companion_windows_component.rb
@@ -9,7 +9,7 @@ module Embed
     attr_reader :viewer
 
     delegate :purl_object, to: :viewer
-    delegate :citation_only?, :downloadable_files, :downloadable_transcript_files?,
+    delegate :downloadable_files, :downloadable_transcript_files?,
              :druid, to: :purl_object
 
     def include_transcripts

--- a/app/javascript/controllers/auth_restriction_controller.js
+++ b/app/javascript/controllers/auth_restriction_controller.js
@@ -4,13 +4,15 @@ export default class extends Controller {
   static targets = ["stanfordRestriction", "stanfordRestrictionMessage", "stanfordRestrictionNotLoggedInIcon",
                     "stanfordRestrictionLoggedInIcon", "stanfordRestrictionDismissButton", "stanfordLoginButton",
                     "locationRestriction", "embargoRestriction", "embargoAndStanfordRestriction",
-                    "embargoLoginButton"]
+                    "embargoLoginButton", "noAccess"]
 
-
+  // Listener for auth-denied events
   displayMessage(event) {
     const authResponse = event.detail
     const status = authResponse.status
-    if (status.includes('embargoed')) { // Embargo check must come before stanford_restricted, because both can occur together
+    if (!status) {
+      this.displayNoAccess()
+    } else if (status.includes('embargoed')) { // Embargo check must come before stanford_restricted, because both can occur together
       if (status.includes('stanford_restricted'))
         this.displayEmbargoAndStanfordRestriction(authResponse.embargo, authResponse.service)
       else
@@ -33,6 +35,11 @@ export default class extends Controller {
 
   hideAuthRestrictionMessages() {
     this.element.hidden = true
+  }
+
+  displayNoAccess() {
+    this.element.hidden = false
+    this.noAccessTarget.hidden = false
   }
 
   displayStanfordRestriction(loginService) {

--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -16,11 +16,10 @@ module Embed
 
     attr_accessor :druid, :type, :title, :use_and_reproduction, :copyright, :contents, :collections,
                   :license, :bounding_box, :embargo_release_date, :archived_site_url, :external_url,
-                  :embargoed, :citation_only, :stanford_only_unrestricted, :public, :controlled_digital_lending,
+                  :embargoed, :stanford_only_unrestricted, :public, :controlled_digital_lending,
                   :etag, :last_modified
 
     alias embargoed? embargoed
-    alias citation_only? citation_only
     alias stanford_only_unrestricted? stanford_only_unrestricted
     alias public? public
     alias controlled_digital_lending? controlled_digital_lending

--- a/app/models/embed/purl_json_loader.rb
+++ b/app/models/embed/purl_json_loader.rb
@@ -24,7 +24,6 @@ module Embed
         bounding_box:,
         archived_site_url:,
         embargoed:,
-        citation_only:,
         stanford_only_unrestricted:,
         controlled_digital_lending:,
         public:
@@ -46,10 +45,6 @@ module Embed
 
     def embargoed
       json.dig('access', 'embargo').present?
-    end
-
-    def citation_only
-      json.dig('access', 'view') == 'citation-only'
     end
 
     def stanford_only_unrestricted

--- a/app/models/embed/purl_xml_loader.rb
+++ b/app/models/embed/purl_xml_loader.rb
@@ -20,7 +20,6 @@ module Embed
         bounding_box:,
         archived_site_url:,
         embargoed:,
-        citation_only:,
         stanford_only_unrestricted:,
         controlled_digital_lending:,
         public:
@@ -42,10 +41,6 @@ module Embed
 
     def embargoed
       rights.embargoed?
-    end
-
-    def citation_only
-      rights.citation_only?
     end
 
     def stanford_only_unrestricted
@@ -114,9 +109,7 @@ module Embed
     end
 
     def rights
-      # TODO: we have to pass `forindex=true` here so that we can subsequently call citation_only?
-      #       This is pretty slow.
-      @rights ||= ::Dor::RightsAuth.parse(rights_xml, true)
+      @rights ||= ::Dor::RightsAuth.parse(rights_xml)
     end
 
     def rights_xml

--- a/spec/components/embed/media_with_companion_windows_component_spec.rb
+++ b/spec/components/embed/media_with_companion_windows_component_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe Embed::MediaWithCompanionWindowsComponent, type: :component do
                     title: 'foo',
                     purl_url: 'https://purl.stanford.edu/123',
                     manifest_json_url: 'https://purl.stanford.edu/123/iiif/manifest',
-                    citation_only?: citation_only,
                     use_and_reproduction: '',
                     copyright: '',
                     license: '',
@@ -26,7 +25,6 @@ RSpec.describe Embed::MediaWithCompanionWindowsComponent, type: :component do
                     downloadable_files: [],
                     downloadable_transcript_files?: false)
   end
-  let(:citation_only) { false }
 
   it 'displays the page' do
     # Accessabile dialog
@@ -38,13 +36,5 @@ RSpec.describe Embed::MediaWithCompanionWindowsComponent, type: :component do
     expect(page).to have_content 'Access is restricted to the reading room. See Access conditions for more information.'
     expect(page).to have_content 'Stanford users: log in to access all available features'
     expect(page).to have_content 'Access is restricted until the embargo has elapsed'
-  end
-
-  context 'when citation_only access' do
-    let(:citation_only) { true }
-
-    it 'displays citation only message' do
-      expect(page).to have_content 'This item cannot be accessed online.'
-    end
   end
 end

--- a/spec/models/embed/purl_json_loader_spec.rb
+++ b/spec/models/embed/purl_json_loader_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Embed::PurlJsonLoader do
       context 'with a stanford only purl with file type' do
         let(:json) { stanford_restricted_file_purl_json }
 
-        it { is_expected.to include({ type: 'file', embargoed: false, public: false, stanford_only_unrestricted: true, citation_only: false }) }
+        it { is_expected.to include({ type: 'file', embargoed: false, public: false, stanford_only_unrestricted: true }) }
       end
 
       context 'with an embargoed purl with file type' do

--- a/spec/models/embed/purl_xml_loader_spec.rb
+++ b/spec/models/embed/purl_xml_loader_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Embed::PurlXmlLoader do
       context 'with a stanford only purl with file type' do
         let(:xml) { stanford_restricted_file_purl_xml }
 
-        it { is_expected.to include({ type: 'file', embargoed: false, public: false, stanford_only_unrestricted: true, citation_only: false }) }
+        it { is_expected.to include({ type: 'file', embargoed: false, public: false, stanford_only_unrestricted: true }) }
       end
 
       context 'with an embargoed purl with file type' do


### PR DESCRIPTION
And the object isn't embargoed, stanford or location access.

This should also prevent double-headers.