### PR TITLE
Apply hover color to media content items

### DIFF
--- a/app/assets/stylesheets/media.scss
+++ b/app/assets/stylesheets/media.scss
@@ -85,7 +85,8 @@ body {
   --header-size: 62.65px; /* depends on the line-height of the header > nav > h2 */
   --modal-border-radius: 8px;
   --modal-max-width: 600px;
-  
+  --media-thumb-hover-color: #016895;
+
   border: 1px solid var(--border-color);
   display: flex;
   flex-direction: column;
@@ -339,7 +340,7 @@ body {
       display: flex;
       flex: 1 1 auto;
     }
-  
+
     .sul-embed-media-wrapper {
       display: inline-block;
       height: 100%;
@@ -541,6 +542,10 @@ body {
       margin-bottom: 0.5rem;
       height: var(--thumb-height);
       text-align: center;
+
+      &:hover {
+        box-shadow: 0px 0px 3px 2px var(--media-thumb-hover-color);
+      }
 
       .default-thumbnail-icon {
         display: inline-block;


### PR DESCRIPTION
Fixes #1969

This commit adds a visual style when the user hovers over media content items, letting them know which is currently being acted upon.

![Screenshot from 2023-12-13 14-12-13](https://github.com/sul-dlss/sul-embed/assets/131982/89f7fbe1-ed6f-48d5-9b2c-fcb2efb28e9f)

