### PR TITLE
Extract tab controller

### DIFF
--- a/app/components/embed/companion_windows_component.html.erb
+++ b/app/components/embed/companion_windows_component.html.erb
@@ -56,27 +56,27 @@
   <div class="companion-window-component-body">
     <aside class="left-drawer collapse" data-companion-window-target="leftDrawer" id="left-drawer" aria-label="Sidebar" style="visibility: hidden">
       <nav class="vert-tabs" role="tablist">
-        <button data-action="click->companion-window#displayMetadata" data-companion-window-target="leftButton" class="active" aria-label="About this item" aria-controls="about" aria-selected="true" role="tab">
+        <button data-controller="tab" data-action="click->tab#switch" class="active" aria-label="About this item" aria-controls="about" aria-selected="true" role="tab">
           <svg class="MuiSvgIcon-root" focusable="false" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"></path></svg>
         </button>
-        <button data-action="click->companion-window#displayContents" data-companion-window-target="leftButton"  aria-label="Content" aria-controls="media-content" role="tab">
+        <button data-controller="tab" data-action="click->tab#switch" aria-label="Content" aria-controls="media-content" role="tab">
           <svg class="MuiSvgIcon-root" focusable="false" aria-hidden="true" viewBox="0 0 24 24"><path d="M4 10.5c-.83 0-1.5.67-1.5 1.5s.67 1.5 1.5 1.5 1.5-.67 1.5-1.5-.67-1.5-1.5-1.5zm0-6c-.83 0-1.5.67-1.5 1.5S3.17 7.5 4 7.5 5.5 6.83 5.5 6 4.83 4.5 4 4.5zm0 12c-.83 0-1.5.68-1.5 1.5s.68 1.5 1.5 1.5 1.5-.68 1.5-1.5-.67-1.5-1.5-1.5zM7 19h14v-2H7v2zm0-6h14v-2H7v2zm0-8v2h14V5H7z"></path></svg>
         </button>
         <%= drawer_button %>
-        <button data-action="click->companion-window#displayRights" data-companion-window-target="leftButton" aria-label="Use and reproduction" aria-controls="rights" role="tab">
+        <button data-controller="tab" data-action="click->tab#switch" aria-label="Use and reproduction" aria-controls="rights" role="tab">
           <svg class="MuiSvgIcon-root" focusable="false" viewBox="0 0 24 24" aria-hidden="true"><path d="M10.08 10.86c.05-.33.16-.62.3-.87s.34-.46.59-.62c.24-.15.54-.22.91-.23.23.01.44.05.63.13.2.09.38.21.52.36s.25.33.34.53.13.42.14.64h1.79c-.02-.47-.11-.9-.28-1.29s-.4-.73-.7-1.01-.66-.5-1.08-.66-.88-.23-1.39-.23c-.65 0-1.22.11-1.7.34s-.88.53-1.2.92-.56.84-.71 1.36S8 11.29 8 11.87v.27c0 .58.08 1.12.23 1.64s.39.97.71 1.35.72.69 1.2.91c.48.22 1.05.34 1.7.34.47 0 .91-.08 1.32-.23s.77-.36 1.08-.63.56-.58.74-.94.29-.74.3-1.15h-1.79c-.01.21-.06.4-.15.58s-.21.33-.36.46-.32.23-.52.3c-.19.07-.39.09-.6.1-.36-.01-.66-.08-.89-.23-.25-.16-.45-.37-.59-.62s-.25-.55-.3-.88-.08-.67-.08-1v-.27c0-.35.03-.68.08-1.01zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"></path></svg>
         </button>
       </nav>
 
       <div class="inner">
-        <section id="about" data-companion-window-target="metadata" role="tabpanel" hidden>
+        <section id="about" role="tabpanel">
           <div class="header-background">
             <h3>About this item</h3>
           </div>
           <dl data-controller="iiif-metadata" class="metadataList" data-action="iiif-manifest-received@window->iiif-metadata#drawMetadata"></dl>
         </section>
 
-        <section id="media-content" data-companion-window-target="contents" role="tabpanel" hidden>
+        <section id="media-content" role="tabpanel" hidden>
           <div class="header-background">
             <h3>Media content</h3>
           </div>
@@ -85,7 +85,7 @@
 
         <%= drawer_content %>
 
-        <section id="rights" data-companion-window-target="rights" role="tabpanel" hidden>
+        <section id="rights" role="tabpanel" hidden>
           <div class="header-background">
             <h3>Rights</h3>
           </div>

--- a/app/components/embed/media_component.html.erb
+++ b/app/components/embed/media_component.html.erb
@@ -6,7 +6,7 @@
   <% end %>
 
   <% component.with_drawer_button do %>
-    <button data-action="click->companion-window#displayTranscript" data-transcript-target="button" data-companion-window-target="leftButton"  aria-label="Transcript" aria-controls="media-content" role="tab" hidden>
+    <button data-action="click->tab#switch" data-transcript-target="button" aria-label="Transcript" aria-controls="media-content" role="tab" hidden>
       <svg class="MuiSvgIcon-root" focusable="false" aria-hidden="true" viewBox="0 0 24 24"><path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"></path></svg>
     </button>
   <% end %>

--- a/app/javascript/controllers/companion_window_controller.js
+++ b/app/javascript/controllers/companion_window_controller.js
@@ -3,11 +3,10 @@ import EmbedThis from 'src/modules/embed_this';
 
 export default class extends Controller {
   // TODO: accessability and transcript should move to a controller just for media.
-  static targets = [ "leftDrawer", "leftButton", "metadata", "shareButton", "shareModal", "contents", "transcript",
-                     "downloadModal", "rights", "accessibility", "modalComponentsPopover"]
+  static targets = [ "leftDrawer", "shareButton", "shareModal",
+                     "downloadModal", "accessibility", "modalComponentsPopover"]
   connect() {
     this.element.hidden = false
-    this.metadataTarget.hidden = false
     EmbedThis.init();
   }
 
@@ -57,54 +56,6 @@ export default class extends Controller {
 
   openDownloadModal() {
     this.downloadModalTarget.showModal()
-  }
-
-  displayMetadata(evt) {
-    this.setLeftButtonActive(evt)
-
-    this.metadataTarget.hidden = false
-    this.contentsTarget.hidden = true
-    this.rightsTarget.hidden = true
-    this.transcriptTarget.hidden = true
-
-  }
-
-  displayContents(evt) {
-    this.setLeftButtonActive(evt)
-
-    this.metadataTarget.hidden = true
-    this.contentsTarget.hidden = false
-    this.rightsTarget.hidden = true
-    this.transcriptTarget.hidden = true
-  }
-
-  displayRights(evt) {
-    this.setLeftButtonActive(evt)
-
-    this.metadataTarget.hidden = true
-    this.contentsTarget.hidden = true
-    this.rightsTarget.hidden = false
-    this.transcriptTarget.hidden = true
-  }
-
-  displayTranscript(evt) {
-    this.setLeftButtonActive(evt)
-
-    this.metadataTarget.hidden = true
-    this.contentsTarget.hidden = true
-    this.rightsTarget.hidden = true
-    this.transcriptTarget.hidden = false
-  }
-
-  setLeftButtonActive(evt) {
-    this.leftButtonTargets.forEach((button) => {
-      button.classList.remove('active')
-      button.setAttribute("aria-selected", false);
-    })
-    // The evt.target may be the SVG, so need to look for a button
-    const button = evt.target.closest('button')
-    button.classList.add('active')
-    button.setAttribute("aria-selected", true);
   }
 
   displayAccessibility() {

--- a/app/javascript/controllers/tab_controller.js
+++ b/app/javascript/controllers/tab_controller.js
@@ -1,0 +1,33 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  switch() {
+    this.#deactivate(this.#currentlyActiveButton())
+    this.#makeActive(this.element)
+  }
+
+  #currentlyActiveButton() {
+    return this.#tabList.querySelector('[role=tab].active')
+  }
+
+  get #tabList() {
+    return this.element.closest('[role=tablist]')
+  }
+
+  #makeActive(button) {
+    button.classList.add("active")
+    button.setAttribute('aria-selected', true)
+    this.#tabPanelFor(button).hidden = false
+  }
+
+  #deactivate(button) {
+    button.classList.remove("active")
+    button.setAttribute('aria-selected', false)
+    this.#tabPanelFor(button).hidden = true
+  }
+
+  #tabPanelFor(button) {
+    const id = button.getAttribute('aria-controls')
+    return document.getElementById(id)
+  }
+}


### PR DESCRIPTION
This allows us to add more tabs without having to modify the javascript.  It also decouples it from the other responsibilities of the companion_window_controller.