### PR TITLE
changing event handling order and linking transcript load to data being ready for a track

### DIFF
--- a/app/components/embed/media_with_companion_windows_component.html.erb
+++ b/app/components/embed/media_with_companion_windows_component.html.erb
@@ -1,7 +1,7 @@
 <div class="sul-embed-container media-component" id='sul-embed-object' hidden data-controller="media media-tag transcript" data-media-tag-iiif-manifest-value="<%= iiif_v3_manifest_url %>" data-action="media-seek@window->media-tag#seek">
   <header>
     <nav aria-label="Window navigation">
-      <button data-action="click->media#toggleLeft transcript#load" aria-label="Display sidebar" aria-controls="left-drawer">
+      <button data-action="click->media#toggleLeft" aria-label="Display sidebar" aria-controls="left-drawer">
         <span class="button-label"><svg class="MuiSvgIcon-root" focusable="false" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"></path></svg></span>
       </button>
       <h2 class=""><%= viewer.purl_object.title %></h2>
@@ -102,7 +102,7 @@
               </select>
             </div>
           </div>
-          <div class="transcript" data-action="media-loaded@window->transcript#persistPlayer time-update@window->transcript#highlightCue">
+          <div class="transcript" data-action="media-loaded@window->transcript#persistPlayer media-data-loaded@window->transcript#load time-update@window->transcript#highlightCue">
             <div data-transcript-target="outlet"></div>
           </div>
         </section>

--- a/app/javascript/controllers/media_tag_controller.js
+++ b/app/javascript/controllers/media_tag_controller.js
@@ -73,6 +73,22 @@ export default class extends Controller {
           const event = new CustomEvent('time-update', { detail: timestamp })
           window.dispatchEvent(event)
         })
+       
+        // When at least one of the tracks has been loaded, trigger transcript loading
+        // Before the tracks are loaded, the cues will not be recognized and the transcript will
+        // not load properly
+        player.textTracks().on('addtrack', () => {
+          // Retrieve the track objects.  Unfortunately, the "textTracks()" method did not cooperate
+          const tracks = player.textTracks_?.tracks_
+          // If there is at least one track we can attach the "loadeddata" event to
+          if(tracks && tracks.length > 0) {
+            player.textTracks_.tracks_[0].on('loadeddata', () => {
+              // Trigger this event, which will then lead to the transcript player load method
+              const event = new CustomEvent('media-data-loaded', { detail: player })
+              window.dispatchEvent(event)
+            })
+          }
+        })
       })
       return player
     })

--- a/app/javascript/controllers/transcript_controller.js
+++ b/app/javascript/controllers/transcript_controller.js
@@ -12,10 +12,14 @@ export default class extends Controller {
     this.player = evt.detail
   }
 
-  // We can't load right away, because the VTT tracks may not have been parsed yet. So we wait until this panel is revealed.
+  // We can't load right away, because the VTT tracks may not have been parsed yet. 
+  // We are going to load this panel when at least one track has been loaded.
+  // This function is triggered by the 'media-data-loaded' event which is triggered
+  // by the 'loadeddata' event on the first track.  
   load() {
-    if (this.loaded || !this.currentCues())
+    if (this.loaded || !this.currentCues()) 
       return
+
     this.revealButton()
     this.setupTranscriptLanguageSwitching()
     this.renderCues()
@@ -31,7 +35,6 @@ export default class extends Controller {
 
   get cuesByLanguage() {
     const cues = {}
-
     this.captionTracks.forEach(track => {
       const list = track.cues.cues_
       const cueStartTimes = list.length === 0 ? undefined : list.map((cue) => cue.startTime)


### PR DESCRIPTION
Background: 

- In the media_tag_controller file, when the videojs object is initialized, we listen for the "loadedmetadata" event. At that point, we fire the vent for "media-loaded".
- In the media component html.erb file, the "media-loaded" event triggers the "persistPlayer" method in the transcript_controller javascript file, which saves the player object in "this.player"
- When the user clicks on the companion window, the transcript "load" method is triggered (you can see this connection again in the html erb file)
- This error appears to be happening because the transcript controller "load" method can throw an error not recognizing "this.player" if the "loadedmetadata" event has not yet happened (and the resulting persistPlayer method has not been executed).
- Separately, based on analysis (noted below), the 'loadedmetadata' event happens before the tracks and cues are all necessarily available.


What this pull request does:

- Decouple the transcript loading from the companion window click.
- Load the transcript when the tracks are available. This event will be after "loadedmetadata" which would mean "this.player" should already be defined.
- The track cue information is not available until at least the first track has been loaded.  (See notes for various event timings below).   This is captured in a new event "media-data-loaded" and captured in "media_component.html.erb" in the data-action attribute on the transcript element.  When this event is fired, the transcript load method is called which will parse the cues for the various tracks and load them.  

Closes #1968 
