### PR TITLE
Remove download metrics tracking

### DIFF
--- a/app/javascript/3d.js
+++ b/app/javascript/3d.js
@@ -4,7 +4,7 @@ import EmbedThis from "src/modules/embed_this";
 import PopupPanels from "src/modules/popup_panels";
 import Fullscreen from "src/modules/fullscreen";
 import ModelViewer from "src/modules/model_viewer";
-import { trackView, trackFileDownloads } from "src/modules/metrics";
+import { trackView } from "src/modules/metrics";
 
 import "@google/model-viewer";
 
@@ -15,5 +15,4 @@ document.addEventListener("DOMContentLoaded", () => {
   EmbedThis.init();
   Fullscreen.init(".sul-embed-3d");
   trackView();
-  trackFileDownloads();
 });

--- a/app/javascript/document.js
+++ b/app/javascript/document.js
@@ -3,7 +3,7 @@
 import EmbedThis from "src/modules/embed_this";
 import PopupPanels from "src/modules/popup_panels";
 import Fullscreen from "src/modules/fullscreen";
-import { trackView, trackFileDownloads } from "src/modules/metrics";
+import { trackView } from "src/modules/metrics";
 
 document.addEventListener("DOMContentLoaded", () => {
   document.getElementById("sul-embed-object").hidden = false;
@@ -11,5 +11,4 @@ document.addEventListener("DOMContentLoaded", () => {
   EmbedThis.init();
   Fullscreen.init(".sul-embed-pdf");
   trackView();
-  trackFileDownloads();
 });

--- a/app/javascript/file.js
+++ b/app/javascript/file.js
@@ -1,6 +1,6 @@
 import EmbedThis from 'src/modules/embed_this';
 import PopupPanels from 'src/modules/popup_panels';
-import { trackView, trackFileDownloads, trackObjectDownload } from 'src/modules/metrics';
+import { trackView } from 'src/modules/metrics';
 import "file_controllers"
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -8,8 +8,4 @@ document.addEventListener('DOMContentLoaded', () => {
   PopupPanels.init();
   EmbedThis.init();
   trackView();
-  trackFileDownloads();
-
-  const button = document.querySelector('button[aria-label="download all files"]')
-  button?.addEventListener('click', () => trackObjectDownload())
 })

--- a/app/javascript/geo.js
+++ b/app/javascript/geo.js
@@ -1,7 +1,7 @@
 import EmbedThis from "../src/modules/embed_this";
 import PopupPanels from "../src/modules/popup_panels";
 import GeoViewer from "../src/modules/geo_viewer";
-import { trackView, trackFileDownloads } from "../src/modules/metrics";
+import { trackView } from "../src/modules/metrics";
 
 import "leaflet";
 import "../../../vendor/assets/javascripts/Leaflet.Control.Custom";
@@ -12,5 +12,4 @@ document.addEventListener("DOMContentLoaded", () => {
   PopupPanels.init();
   EmbedThis.init();
   trackView();
-  trackFileDownloads();
 });

--- a/app/javascript/media.js
+++ b/app/javascript/media.js
@@ -1,7 +1,6 @@
 import "controllers";
-import { trackView, trackFileDownloads } from "src/modules/metrics";
+import { trackView } from "src/modules/metrics";
 
 document.addEventListener("DOMContentLoaded", () => {
   trackView();
-  trackFileDownloads();
 });

--- a/app/javascript/src/modules/metrics.js
+++ b/app/javascript/src/modules/metrics.js
@@ -6,32 +6,6 @@ export const trackView = () => {
   ahoy.trackView(eventParameters());
 };
 
-// Set up download tracking for any links with a download attribute
-export const trackFileDownloads = () => {
-  document.querySelectorAll('a[download]').forEach(link => {
-    link.addEventListener('click', event => {
-      const linkElement = event.target.closest('a');
-      try {
-        const downloadUrl = new URL(linkElement.href);
-        const file = downloadUrl.pathname.split("/").pop();
-        trackFileDownload(file);
-      } catch (e) {
-        return;
-      }
-    });
-  });
-}
-
-// When an entire object is downloaded as a .zip file
-export const trackObjectDownload = () => {
-  ahoy.track("download", eventParameters());
-};
-
-// When a single file is downloaded from an object
-export const trackFileDownload = (file) => {
-  ahoy.track("download", { file, ...eventParameters() });
-};
-
 // Parameters common to all events we track
 // Modify url/page to be the embed location instead of embed.stanford.edu
 const eventParameters = () => {

--- a/spec/features/metrics_spec.rb
+++ b/spec/features/metrics_spec.rb
@@ -9,10 +9,6 @@ RSpec.describe 'metrics tracking', :js do
     StubMetricsApi.reset!
   end
 
-  after do
-    FileUtils.rm_rf(TEST_DOWNLOAD_DIR)
-  end
-
   describe 'iiif viewer' do
     let(:purl) { nil }
     let(:druid) { 'fr426cg9537' }
@@ -26,117 +22,44 @@ RSpec.describe 'metrics tracking', :js do
       wait_for_view
       expect(StubMetricsApi.last_event).to match(view_with_properties('druid' => druid))
     end
-
-    it 'tracks file downloads', skip: 'needs mirador plugin?' do
-      visit iiif_path(url: 'https://purl.stanford.edu/fr426cg9537/iiif/manifest')
-      click_button 'Share & download'
-      find('.MuiListItem-button', text: 'Download').click
-      click_link 'Whole image (400 x 272px)'
-      wait_for_download
-      expect(StubMetricsApi.last_event).to match(
-        download_with_properties(
-          'druid' => druid,
-          'file' => 'SC1094_s3_b14_f17_Cats_1976_0005/full/400,/0/default.jpg'
-        )
-      )
-    end
   end
 
   describe 'media viewer' do
     let(:druid) { 'bc123df4567' }
-    let(:purl) do
-      build(:purl, :video, contents: [
-              build(:resource, :video, files: [
-                      build(:resource_file, :video, :world_downloadable, druid:)
-                    ])
-            ], druid:)
-    end
+    let(:purl) { build(:purl, :video, druid:) }
 
     it 'tracks views' do
       visit_iframe_response(druid)
       wait_for_view
       expect(StubMetricsApi.last_event).to match(view_with_properties('druid' => druid))
-    end
-
-    it 'tracks file downloads' do
-      visit_iframe_response(druid)
-      click_button 'Share and Download'
-      click_button 'Download'
-      click_link 'Download First Video'
-      wait_for_download
-      expect(StubMetricsApi.last_event).to match(download_with_properties('druid' => druid, 'file' => 'abc_123.mp4'))
     end
   end
 
   describe 'leaflet viewer' do
     let(:druid) { 'cz128vq0535' }
-    let(:purl) do
-      build(:purl, :geo, contents: [
-              build(:resource, :file, files: [
-                      build(:resource_file, :world_downloadable, druid:)
-                    ])
-            ], druid:)
-    end
+    let(:purl) { build(:purl, :geo, druid:) }
 
     it 'tracks views' do
       visit_iframe_response(druid)
       wait_for_view
       expect(StubMetricsApi.last_event).to match(view_with_properties('druid' => druid))
-    end
-
-    it 'tracks file downloads' do
-      visit_iframe_response(druid)
-      click_button '1 file available for download'
-      click_link 'Download data.zip'
-      wait_for_download
-      expect(StubMetricsApi.last_event).to match(
-        download_with_properties(
-          'druid' => druid,
-          'file' => 'data.zip'
-        )
-      )
     end
   end
 
   describe 'pdf viewer' do
     let(:druid) { 'bc123df4567' }
-    let(:purl) do
-      build(:purl, :document, contents: [
-              build(:resource, :document, files: [
-                      build(:resource_file, :document, :world_downloadable, druid:)
-                    ])
-            ], druid:)
-    end
+    let(:purl) { build(:purl, :document, druid:) }
 
     it 'tracks views' do
       visit_iframe_response(druid)
       wait_for_view
       expect(StubMetricsApi.last_event).to match(view_with_properties('druid' => druid))
     end
-
-    it 'tracks file downloads' do
-      visit_iframe_response(druid)
-      click_button '1 file available for download'
-      click_link 'Download Title of the PDF.pdf'
-      wait_for_download
-      expect(StubMetricsApi.last_event).to match(
-        download_with_properties(
-          'druid' => druid,
-          'file' => 'Title%20of%20the%20PDF.pdf'
-        )
-      )
-    end
   end
 
   describe 'web archive viewer' do
     let(:druid) { 'bc123df4567' }
-    let(:purl) do
-      build(:purl, :was_seed, contents: [
-              build(:resource, :image, files: [
-                      build(:resource_file, :image, druid:)
-                    ])
-            ], druid:)
-    end
+    let(:purl) { build(:purl, :was_seed, druid:) }
 
     before do
       stub_request(:get, 'https://swap.stanford.edu/timemap/http://naca.central.cranfield.ac.uk/')
@@ -151,68 +74,23 @@ RSpec.describe 'metrics tracking', :js do
 
   describe '3d viewer' do
     let(:druid) { 'qf794pv6287' }
-    let(:purl) do
-      build(:purl, :model_3d, contents: [
-              build(:resource, :file, files: [
-                      build(:resource_file, :model_3d, :world_downloadable, druid:)
-                    ])
-            ], druid:)
-    end
+    let(:purl) { build(:purl, :model_3d, druid:) }
 
     it 'tracks views' do
       visit_iframe_response(druid)
       wait_for_view
       expect(StubMetricsApi.last_event).to match(view_with_properties('druid' => druid))
-    end
-
-    it 'tracks file downloads' do
-      visit_iframe_response(druid)
-      click_button '1 file available for download'
-      click_link 'Download abc_123.glb'
-      wait_for_download
-      expect(StubMetricsApi.last_event).to match(
-        download_with_properties(
-          'druid' => druid,
-          'file' => 'abc_123.glb'
-        )
-      )
     end
   end
 
   describe 'file viewer' do
     let(:druid) { 'bc123df4567' }
-    let(:purl) do
-      build(:purl, :file, contents: [
-              build(:resource, :audio, files: [
-                      build(:resource_file, :image, :world_downloadable, druid:),
-                      build(:resource_file, :audio, :world_downloadable, druid:)
-                    ])
-            ], druid:)
-    end
+    let(:purl) { build(:purl, :file, druid:) }
 
     it 'tracks views' do
       visit_iframe_response(druid)
       wait_for_view
       expect(StubMetricsApi.last_event).to match(view_with_properties('druid' => druid))
-    end
-
-    it 'tracks file downloads' do
-      visit_iframe_response(druid)
-      click_link 'Download audio.mp3'
-      wait_for_download
-      expect(StubMetricsApi.last_event).to match(
-        download_with_properties(
-          'druid' => druid,
-          'file' => 'audio.mp3'
-        )
-      )
-    end
-
-    it 'tracks object downloads' do
-      visit_iframe_response(druid)
-      click_button 'Download all 2 files (152.01 MB)'
-      wait_for_download
-      expect(StubMetricsApi.last_event).to match(download_with_properties('druid' => druid))
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,17 +13,6 @@ require 'selenium-webdriver'
 require 'view_component/test_helpers'
 require 'view_component/system_test_helpers'
 
-TEST_DOWNLOAD_DIR = 'tmp/test_downloads'
-
-Capybara.register_driver :selenium_chrome_headless do |app|
-  options = Selenium::WebDriver::Chrome::Options.new
-
-  options.add_argument('--headless')
-  options.add_preference(:download, default_directory: TEST_DOWNLOAD_DIR)
-
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options:)
-end
-
 Capybara.javascript_driver = :selenium_chrome_headless
 Capybara.enable_aria_label = true
 Capybara.default_max_wait_time = ENV['CI'] ? 30 : 5

--- a/spec/support/metrics_helper.rb
+++ b/spec/support/metrics_helper.rb
@@ -10,10 +10,6 @@ def view_with_properties(properties)
   event_with_properties('$view', properties)
 end
 
-def download_with_properties(properties)
-  event_with_properties('download', properties)
-end
-
 def wait_for_event(name)
   Timeout.timeout(Capybara.default_max_wait_time) do
     loop until StubMetricsApi.last_event&.dig('name') == name
@@ -22,8 +18,4 @@ end
 
 def wait_for_view
   wait_for_event('$view')
-end
-
-def wait_for_download
-  wait_for_event('download')
 end


### PR DESCRIPTION
This reverts much of ba28d9ed6922beebb46620aacd1385effb24cec8 in
favor of tracking downloads in stacks directly. See:
https://github.com/sul-dlss/stacks/pull/1086
