### PR TITLE
[OLD] IIIF Auth v2 interaction for PDFs

### DIFF
--- a/app/components/embed/login_component.html.erb
+++ b/app/components/embed/login_component.html.erb
@@ -1,0 +1,10 @@
+<div data-file-auth-target="loginPanel" hidden>
+    <div class="authLinkWrapper">
+        <svg class="MuiSvgIcon-root" focusable="false" aria-hidden="true" viewBox="0 0 24 24"><path d="m14.5 14.2 2.9 1.7-.8 1.3L13 15v-5h1.5v4.2zM22 14c0 4.41-3.59 8-8 8-2.02 0-3.86-.76-5.27-2H4c-1.15 0-2-.85-2-2V9c0-1.12.89-1.96 2-2v-.5C4 4.01 6.01 2 8.5 2c2.34 0 4.24 1.79 4.46 4.08.34-.05.69-.08 1.04-.08 4.41 0 8 3.59 8 8zM6 7h5v-.74C10.88 4.99 9.8 4 8.5 4 7.12 4 6 5.12 6 6.5V7zm14 7c0-3.31-2.69-6-6-6s-6 2.69-6 6 2.69 6 6 6 6-2.69 6-6z"></path></svg>
+        <p data-file-auth-target="loginMessage" class="loginMessage">Stanford users: log in to access all available features.</p>
+        <button data-file-auth-target="loginButton" data-action="file-auth#login"
+                 data-file-auth-messageId-param="" data-file-auth-url-param="">
+                Log in
+        </button>
+    </div>
+</div>

--- a/app/components/embed/login_component.rb
+++ b/app/components/embed/login_component.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Embed
+  class LoginComponent < ViewComponent::Base
+  end
+end

--- a/app/components/embed/pdf_component.html.erb
+++ b/app/components/embed/pdf_component.html.erb
@@ -1,11 +1,7 @@
-<div class="sul-embed-container" id='sul-embed-object' hidden>
+<div class="sul-embed-container" id='sul-embed-object' data-controller="file-auth" data-file-auth-iiif-manifest-value="<%= iiif_v3_manifest_url %>" hidden>
   <%= render Embed::HeaderComponent.new viewer: viewer %>
   <% # removing 5 pixels from the body height to account for being embedded %>
-  <div class='sul-embed-body sul-embed-pdf'>
-    <object data="<%= viewer.pdf_files.first %>" type="application/pdf" style="height: 100vh; width: 100%">
-      <p>Your browser does not support viewing PDFs.  Please <a href="<%= viewer.pdf_files.first %>">download the file</a> to view it.</p>
-    </object>
-  </div>
+  <div class='sul-embed-body sul-embed-pdf' data-file-auth-target="container"></div>
   <%= render 'embed/metadata_panel', viewer: viewer %>
   <%= render 'embed/embed_this/generic', viewer: viewer %>
   <%= render Embed::Download::PdfComponent.new viewer: viewer %>

--- a/app/components/embed/pdf_component.html.erb
+++ b/app/components/embed/pdf_component.html.erb
@@ -1,9 +1,7 @@
-<div class="sul-embed-container" id='sul-embed-object' data-controller="file-auth" data-file-auth-iiif-manifest-value="<%= iiif_v3_manifest_url %>" hidden>
-  <%= render Embed::HeaderComponent.new viewer: viewer %>
-  <% # removing 5 pixels from the body height to account for being embedded %>
-  <div class='sul-embed-body sul-embed-pdf' data-file-auth-target="container"></div>
-  <%= render 'embed/metadata_panel', viewer: viewer %>
-  <%= render 'embed/embed_this/generic', viewer: viewer %>
-  <%= render Embed::Download::PdfComponent.new viewer: viewer %>
-  <%= render Embed::FooterComponent.new viewer: viewer %>
- </div>
+<% # data-file-auth-iiif-manifest-value="<%= iiif_v3_manifest_url %>
+
+<%= render Embed::CompanionWindowsComponent.new(viewer:, stimulus_controller: 'file-auth') do |component| %>
+  <% component.with_body do %>
+    <div class='sul-embed-body sul-embed-pdf' data-action="iiif-manifest-received@window->file-auth#parseFiles"  data-file-auth-target="container"></div>
+  <% end %>
+<% end %>

--- a/app/components/embed/pdf_component.html.erb
+++ b/app/components/embed/pdf_component.html.erb
@@ -2,6 +2,8 @@
   <% component.with_body do %>
     <div class='sul-embed-body sul-embed-pdf' style="width: 100%"
          data-controller="pdf"
-         data-action="iiif-manifest-received@window->file-auth#parseFiles auth-success@window->pdf#show"></div>
+         data-action="iiif-manifest-received@window->file-auth#parseFiles auth-success@window->pdf#show">
+         <%= render Embed::LoginComponent.new %>
+    </div>
   <% end %>
 <% end %>

--- a/app/components/embed/pdf_component.html.erb
+++ b/app/components/embed/pdf_component.html.erb
@@ -1,5 +1,7 @@
 <%= render Embed::CompanionWindowsComponent.new(viewer:, stimulus_controller: 'file-auth') do |component| %>
   <% component.with_body do %>
-    <div class='sul-embed-body sul-embed-pdf' style="width: 100%" data-action="iiif-manifest-received@window->file-auth#parseFiles"  data-file-auth-target="container"></div>
+    <div class='sul-embed-body sul-embed-pdf' style="width: 100%"
+         data-controller="pdf"
+         data-action="iiif-manifest-received@window->file-auth#parseFiles auth-success@window->pdf#show"></div>
   <% end %>
 <% end %>

--- a/app/components/embed/pdf_component.html.erb
+++ b/app/components/embed/pdf_component.html.erb
@@ -1,7 +1,5 @@
-<% # data-file-auth-iiif-manifest-value="<%= iiif_v3_manifest_url %>
-
 <%= render Embed::CompanionWindowsComponent.new(viewer:, stimulus_controller: 'file-auth') do |component| %>
   <% component.with_body do %>
-    <div class='sul-embed-body sul-embed-pdf' data-action="iiif-manifest-received@window->file-auth#parseFiles"  data-file-auth-target="container"></div>
+    <div class='sul-embed-body sul-embed-pdf' style="width: 100%" data-action="iiif-manifest-received@window->file-auth#parseFiles"  data-file-auth-target="container"></div>
   <% end %>
 <% end %>

--- a/app/components/embed/pdf_component.rb
+++ b/app/components/embed/pdf_component.rb
@@ -7,5 +7,12 @@ module Embed
     end
 
     attr_reader :viewer
+
+    delegate :purl_object, to: :viewer
+    delegate :druid, to: :purl_object
+
+    def iiif_v3_manifest_url
+      "#{Settings.purl_url}/#{druid}/iiif3/manifest"
+    end
   end
 end

--- a/app/javascript/controllers/file_auth_controller.js
+++ b/app/javascript/controllers/file_auth_controller.js
@@ -1,0 +1,124 @@
+import { Controller } from "@hotwired/stimulus"
+// import validator from 'src/modules/validator'
+// import mediaTagTokenWriter from 'src/modules/media_tag_token_writer'
+// import buildThumbnail from 'src/modules/media_thumbnail_builder'
+
+export default class extends Controller {
+  static targets = ["container"]
+  static values = {
+    iiifManifest: String
+  }
+
+  resources = {} // Hash of messageIds to resources
+
+  connect() {
+    this.fetchIiifManifest()
+    window.addEventListener("message", (event) => {
+      if (event.origin !== "https://stacks.stanford.edu" && event.origin !== "https://sul-stacks-stage.stanford.edu") return;
+
+      this.accessTokenReceived(event.data.accessToken, event.data.messageId)
+    }, false)
+
+  }
+
+  fetchIiifManifest() {
+    fetch(this.iiifManifestValue)
+      .then((response) => response.json())
+      .then((json) => this.dispatchManifestEvent(json))
+      .catch((err) => console.error(err))
+  }
+
+  dispatchManifestEvent(json) {
+    const event = new CustomEvent('iiif-manifest-received', { detail: json })
+    window.dispatchEvent(event)
+
+    this.parseFiles(json)
+  }
+
+  parseFiles(document) {
+    const canvases = document.items
+    canvases.forEach((canvas) => {
+      const annotationPages = canvas.items
+      annotationPages.forEach((annotationPage) => {
+        const annotations = annotationPage.items
+        annotations.forEach((annotation) => {
+          if (annotation.motivation === "painting") {
+            const contentResource = annotation.body
+            this.maybeDrawContentResource(contentResource)
+          }
+        })
+      })
+    })
+  }
+
+  // TODO: This causes 1 login window to open for each resource that needs a login.
+  //       Instead we should open one window if any resource needs a login.
+  maybeDrawContentResource(contentResource) {
+    console.log("Now figure out if we can render", contentResource)
+    if (!contentResource.service) {
+      // no auth is present, render it
+      this.renderViewer(contentResource.id)
+    } else {
+      const probeService = contentResource.service.find((service) => service.type === "AuthProbeService2")
+      if (probeService)
+        this.probe(probeService)
+      else
+        throw(`No probe service found for ${contentResource.id}`)
+    }
+  }
+
+  renderViewer(file_uri) {
+    this.containerTarget.innerHTML = `
+      <object data="${file_uri}" type="application/pdf" style="height: 100vh; width: 100%">
+        <p>Your browser does not support viewing PDFs.  Please <a href="${file_uri}">download the file</a> to view it.</p>
+      </object>
+    `
+  }
+
+  // https://iiif.io/api/auth/2.0/#71-authorization-flow-algorithm
+  probe(probeService) {
+    // We're going to make the assumption that calling the probe without a token is going to fail.
+    // So we'll just get the token first.
+    console.log(probeService)
+    const activeAccessService = probeService.service.find((service) => service.type === "AuthAccessService2" && service.profile === "active")
+
+    if (activeAccessService) {
+      const tokenService = activeAccessService.service.find((service) => service.type === "AuthAccessTokenService2")
+      if (!tokenService)
+        throw(`No token service found`)
+      this.login(activeAccessService)
+      const messageId = 'ae3415' // TODO: Make this random
+      this.resources[messageId] = probeService
+      const token = this.initiateTokenRequest(tokenService, messageId)
+    } else {
+      throw(`No active access service found`)
+    }
+  }
+
+  accessTokenReceived(token, messageId) {
+    const probeService = this.resources[messageId]
+    console.log("Trying probe service")
+    fetch(probeService.id, { headers: { 'Authorization': `Bearer ${token}`}})
+      .then((response) => response.json())
+      .then((json) => console.log("Response from the probe is", json))
+      .catch((err) => console.error(err))
+  }
+
+  initiateTokenRequest(tokenService, messageId) {
+    const iframe = document.createElement('iframe')
+    iframe.src = `${tokenService.id}?messageId=${messageId}&origin=${window.origin}`
+    document.body.appendChild(iframe)
+  }
+
+  // Open the login window in a new window and then poll to see if the auth credentials are now active.
+  login(activeAccessService) {
+    const windowReference = window.open(activeAccessService.id);
+    let loginStart = Date.now();
+    let checkWindow = setInterval(() => {
+      if ((Date.now() - loginStart) < 30000 &&
+        (!windowReference || !windowReference.closed)) return;
+
+      clearInterval(checkWindow);
+    }, 500)
+  }
+}

--- a/app/javascript/controllers/file_auth_controller.js
+++ b/app/javascript/controllers/file_auth_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["container"]
+  static targets = ["container", "loginPanel", "loginButton", "loginMessage"]
 
   resources = {} // Hash of messageIds to resources
 
@@ -26,7 +26,7 @@ export default class extends Controller {
     const document = evt.detail
     const canvases = document.items
     this.addPostCallbackListener()
-    const paintingResources = canvases.flatMap((canvas) => {
+    canvases.flatMap((canvas) => {
       const annotationPages = canvas.items
       return annotationPages.flatMap((annotationPage) => {
         const paintingAnnotations = annotationPage.items.filter((annotation) => annotation.motivation === "painting")
@@ -105,7 +105,7 @@ export default class extends Controller {
     console.log(probeService)
     const accessService = this.findAccessService(probeService)
 
-    const messageId = 'ae3415' // TODO: Make this random
+    const messageId = Math.random().toString(36).slice(2) // random key to reference later
     this.resources[messageId] = { probeService, contentResourceId }
 
     this.queryProbeService(messageId)
@@ -196,15 +196,16 @@ export default class extends Controller {
 
   // Open the login window in a new window and then poll to see if the auth credentials are now active.
   loginNeeded(activeAccessService, messageId) {
-    // TODO: perhaps use hidden div for login UI instead
-    this.dialog = document.createElement('dialog')
-    this.dialog.innerHTML = `${activeAccessService.label.en[0]}: <button data-action="file-auth#login" data-file-auth-messageId-param="${messageId}" data-file-auth-url-param="${activeAccessService.id}">${activeAccessService.confirmLabel.en[0]}</button>`
-    this.element.appendChild(this.dialog)
-    this.dialog.showModal()
+    console.log(activeAccessService)
+    this.loginPanelTarget.hidden = false
+    this.loginButtonTarget.innerHTML = activeAccessService.confirmLabel.en[0]
+    this.loginButtonTarget.setAttribute('data-file-auth-messageId-param', messageId)
+    this.loginButtonTarget.setAttribute('data-file-auth-url-param', activeAccessService.id)
+    this.loginMessageTarget.innerHTML = activeAccessService.label.en[0]
   }
 
   login(evt) {
-    this.dialog.remove()
+    this.loginPanelTarget.hidden = true
     console.log(evt)
     const windowReference = window.open(evt.params.url);
     let loginStart = Date.now();

--- a/app/javascript/controllers/file_auth_controller.js
+++ b/app/javascript/controllers/file_auth_controller.js
@@ -72,8 +72,7 @@ export default class extends Controller {
       return
     }
 
-    // TODO Change kiosk to external
-    const externalAccessService = probeService.service.find((service) => service.type === "AuthAccessService2" && service.profile === "kiosk")
+    const externalAccessService = probeService.service.find((service) => service.type === "AuthAccessService2" && service.profile === "external")
 
     if (externalAccessService) {
       const tokenService = externalAccessService.service.find((service) => service.type === "AuthAccessTokenService2")

--- a/app/javascript/controllers/file_auth_controller.js
+++ b/app/javascript/controllers/file_auth_controller.js
@@ -7,6 +7,8 @@ export default class extends Controller {
 
   addPostCallbackListener() {
     window.addEventListener("message", (event) => {
+      this.iframe.remove()
+      console.log("Post message", event.data)
       if (event.origin !== "https://stacks.stanford.edu" && event.origin !== "https://sul-stacks-stage.stanford.edu") return;
       if (event.data.type === "AuthAccessTokenError2") {
         this.displayAccessTokenError(event.data)
@@ -59,26 +61,41 @@ export default class extends Controller {
     // We're going to make the assumption that calling the probe without a token is going to fail.
     // So we'll just get the token first.
     console.log(probeService)
+    const accessService = this.findAccessService(probeService)
+
+    const messageId = 'ae3415' // TODO: Make this random
+    this.resources[messageId] = { probeService, contentResourceId }
+  
+    if (accessService.profile === "active") {
+      this.loginNeeded(accessService, messageId)
+    } else {
+      this.initiateTokenRequest(accessService, messageId)
+    }
+  }
+
+  findAccessService(probeService) {
     const accessService = probeService.service.find((service) => service.type === "AuthAccessService2")
 
     if (!accessService)
       throw(`No access service found`)
 
+    return accessService
+  }
+
+  findTokenService(accessService) {
     const tokenService = accessService.service.find((service) => service.type === "AuthAccessTokenService2")
     if (!tokenService)
       throw(`No token service found`)
 
-    if (accessService.profile === "active")
-      this.login(accessService)
-
-    const messageId = 'ae3415' // TODO: Make this random
-    this.resources[messageId] = { probeService, contentResourceId }
-    this.initiateTokenRequest(tokenService, messageId)
+    return tokenService
   }
 
   displayAccessTokenError(accessTokenError) {
     console.error("There was an error getting the token", accessTokenError)
     alert("Authentication error. Unable to get a token from Stacks.")
+    const resource = this.resources[accessTokenError.messageId]
+    const activeAccessService = this.findAccessService(resource.probeService)
+    this.loginNeeded(activeAccessService, accessTokenError.messageId)
   }
 
   accessTokenReceived(token, messageId) {
@@ -98,21 +115,45 @@ export default class extends Controller {
     }
   }
 
-  initiateTokenRequest(tokenService, messageId) {
-    const iframe = document.createElement('iframe')
-    iframe.src = `${tokenService.id}?messageId=${messageId}&origin=${window.origin}`
-    document.body.appendChild(iframe)
+  initiateTokenRequest(accessService, messageId) {
+    const tokenService = this.findTokenService(accessService)
+
+    this.iframe = document.createElement('iframe')
+    this.iframe.src = `${tokenService.id}?messageId=${messageId}&origin=${window.origin}`
+    console.log(`Creating iframe for ${tokenService.id}`)
+    document.body.appendChild(this.iframe)
   }
 
   // Open the login window in a new window and then poll to see if the auth credentials are now active.
-  login(activeAccessService) {
-    const windowReference = window.open(activeAccessService.id);
+  loginNeeded(activeAccessService, messageId) {
+    this.dialog = document.createElement('dialog')
+    this.dialog.innerHTML = `${activeAccessService.label.en[0]}: <button data-action="file-auth#login" data-file-auth-messageId-param="${messageId}" data-file-auth-url-param="${activeAccessService.id}">${activeAccessService.confirmLabel.en[0]}</button>`
+    this.element.appendChild(this.dialog)
+    this.dialog.showModal()
+  }
+
+  login(evt) {
+    this.dialog.remove()
+    console.log(evt)
+    const windowReference = window.open(evt.params.url);
     let loginStart = Date.now();
+    console.log("window reference", windowReference)
     let checkWindow = setInterval(() => {
+      console.log("in interval", (Date.now() - loginStart))
       if ((Date.now() - loginStart) < 30000 &&
         (!windowReference || !windowReference.closed)) return;
 
       clearInterval(checkWindow);
+      // once the window is closed we can initiate the token request
+      this.afterLoginWindowClosed(evt.params.messageid)
     }, 500)
+  }
+
+  afterLoginWindowClosed(messageId) {
+    console.log("Done waiting on that window")
+    const probeService = this.resources[messageId].probeService
+    const accessService = this.findAccessService(probeService)
+
+    this.initiateTokenRequest(accessService, messageId)
   }
 }

--- a/app/javascript/controllers/file_auth_controller.js
+++ b/app/javascript/controllers/file_auth_controller.js
@@ -59,32 +59,21 @@ export default class extends Controller {
     // We're going to make the assumption that calling the probe without a token is going to fail.
     // So we'll just get the token first.
     console.log(probeService)
-    const activeAccessService = probeService.service.find((service) => service.type === "AuthAccessService2" && service.profile === "active")
+    const accessService = probeService.service.find((service) => service.type === "AuthAccessService2")
 
-    if (activeAccessService) {
-      const tokenService = activeAccessService.service.find((service) => service.type === "AuthAccessTokenService2")
-      if (!tokenService)
-        throw(`No token service found`)
-      this.login(activeAccessService)
-      const messageId = 'ae3415' // TODO: Make this random
-      this.resources[messageId] = { probeService, contentResourceId }
-      this.initiateTokenRequest(tokenService, messageId)
-      return
-    }
+    if (!accessService)
+      throw(`No access service found`)
 
-    const externalAccessService = probeService.service.find((service) => service.type === "AuthAccessService2" && service.profile === "external")
+    const tokenService = accessService.service.find((service) => service.type === "AuthAccessTokenService2")
+    if (!tokenService)
+      throw(`No token service found`)
 
-    if (externalAccessService) {
-      const tokenService = externalAccessService.service.find((service) => service.type === "AuthAccessTokenService2")
-      if (!tokenService)
-        throw(`No token service found`)
-      const messageId = 'ae3415' // TODO: Make this random
-      this.resources[messageId] = { probeService, contentResourceId }
-      this.initiateTokenRequest(tokenService, messageId)
-      return
-    }
+    if (accessService.profile === "active")
+      this.login(accessService)
 
-    throw(`No access service found`)
+    const messageId = 'ae3415' // TODO: Make this random
+    this.resources[messageId] = { probeService, contentResourceId }
+    this.initiateTokenRequest(tokenService, messageId)
   }
 
   displayAccessTokenError(accessTokenError) {

--- a/app/javascript/controllers/file_auth_controller.js
+++ b/app/javascript/controllers/file_auth_controller.js
@@ -22,18 +22,25 @@ export default class extends Controller {
     const document = evt.detail
     const canvases = document.items
     this.addPostCallbackListener()
-    canvases.forEach((canvas) => {
+    const paintingResources = canvases.flatMap((canvas) => {
       const annotationPages = canvas.items
-      annotationPages.forEach((annotationPage) => {
-        const annotations = annotationPage.items
-        annotations.forEach((annotation) => {
-          if (annotation.motivation === "painting") {
-            const contentResource = annotation.body
-            this.maybeDrawContentResource(contentResource)
-          }
+      return annotationPages.flatMap((annotationPage) => {
+        const paintingAnnotations = annotationPage.items.filter((annotation) => annotation.motivation === "painting")
+        return paintingAnnotations.map((annotation) => {
+          const contentResource = annotation.body
+          this.maybeDrawContentResource(contentResource)
+          return contentResource
         })
       })
     })
+    const thumbnails = paintingResources.map((resource) => {
+      return { isStanfordOnly: false,
+               thumbnailUrl: '',
+               defaultIcon: '',
+               isLocationRestricted: false,
+               fileLabel: resource.label }
+    })
+    window.dispatchEvent(new CustomEvent('thumbnails-found', { detail: thumbnails }))
   }
 
   // TODO: This causes 1 login window to open for each resource that needs a login.

--- a/app/javascript/controllers/file_auth_controller.js
+++ b/app/javascript/controllers/file_auth_controller.js
@@ -5,38 +5,21 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["container"]
-  static values = {
-    iiifManifest: String
-  }
 
   resources = {} // Hash of messageIds to resources
 
-  connect() {
-    this.fetchIiifManifest()
+  addPostCallbackListener() {
     window.addEventListener("message", (event) => {
       if (event.origin !== "https://stacks.stanford.edu" && event.origin !== "https://sul-stacks-stage.stanford.edu") return;
 
       this.accessTokenReceived(event.data.accessToken, event.data.messageId)
     }, false)
-
   }
 
-  fetchIiifManifest() {
-    fetch(this.iiifManifestValue)
-      .then((response) => response.json())
-      .then((json) => this.dispatchManifestEvent(json))
-      .catch((err) => console.error(err))
-  }
-
-  dispatchManifestEvent(json) {
-    const event = new CustomEvent('iiif-manifest-received', { detail: json })
-    window.dispatchEvent(event)
-
-    this.parseFiles(json)
-  }
-
-  parseFiles(document) {
+  parseFiles(evt) {
+    const document = evt.detail
     const canvases = document.items
+    this.addPostCallbackListener()
     canvases.forEach((canvas) => {
       const annotationPages = canvas.items
       annotationPages.forEach((annotationPage) => {

--- a/app/javascript/controllers/file_auth_controller.js
+++ b/app/javascript/controllers/file_auth_controller.js
@@ -13,6 +13,7 @@ export default class extends Controller {
       if (event.data.type === "AuthAccessTokenError2") {
         this.displayAccessTokenError(event.data)
       } else {
+        // TODO: store token in local browser storage
         this.queryProbeService(event.data.messageId, event.data.accessToken)
           .then((contentResourceId) => this.renderViewer(contentResourceId))
           .catch((json) => console.error("no access", json))
@@ -35,14 +36,15 @@ export default class extends Controller {
         })
       })
     })
-    const thumbnails = paintingResources.map((resource) => {
-      return { isStanfordOnly: false,
-               thumbnailUrl: '',
-               defaultIcon: '',
-               isLocationRestricted: false,
-               fileLabel: resource.label }
-    })
-    window.dispatchEvent(new CustomEvent('thumbnails-found', { detail: thumbnails }))
+    // TODO: Deal with thumbnail views
+    // const thumbnails = paintingResources.map((resource) => {
+    //   return { isStanfordOnly: false,
+    //            thumbnailUrl: '',
+    //            defaultIcon: '',
+    //            isLocationRestricted: false,
+    //            fileLabel: resource.label }
+    // })
+    // window.dispatchEvent(new CustomEvent('thumbnails-found', { detail: thumbnails }))
   }
 
   // TODO: This causes 1 login window to open for each resource that needs a login.
@@ -74,12 +76,17 @@ export default class extends Controller {
 
     const messageId = 'ae3415' // TODO: Make this random
     this.resources[messageId] = { probeService, contentResourceId }
-  
+
     this.queryProbeService(messageId)
       .then((contentResourceId) => this.renderViewer(contentResourceId))
       .catch((json) => {
         console.log("initial probe failed", json)
         if (accessService.profile === "active") {
+          // TODO: Check if non-expired token already exists in local storage,
+          // and if one exists, query probe service with token, e.g.
+          // this.queryProbeService(messageId, token)
+          // .then((contentResourceId) => this.renderViewer(contentResourceId))
+          // .catch((json) => console.error("no access", json))
           this.loginNeeded(accessService, messageId)
         } else {
           this.initiateTokenRequest(accessService, messageId)
@@ -145,6 +152,7 @@ export default class extends Controller {
 
   // Open the login window in a new window and then poll to see if the auth credentials are now active.
   loginNeeded(activeAccessService, messageId) {
+    // TODO: perhaps use hidden div for login UI instead
     this.dialog = document.createElement('dialog')
     this.dialog.innerHTML = `${activeAccessService.label.en[0]}: <button data-action="file-auth#login" data-file-auth-messageId-param="${messageId}" data-file-auth-url-param="${activeAccessService.id}">${activeAccessService.confirmLabel.en[0]}</button>`
     this.element.appendChild(this.dialog)

--- a/app/javascript/controllers/pdf_controller.js
+++ b/app/javascript/controllers/pdf_controller.js
@@ -4,7 +4,7 @@ export default class extends Controller {
   show(evt) {
     const file_uri = evt.detail
     this.element.innerHTML = `
-      <object data="${file_uri}" type="application/pdf" style="height: 100vh; width: 100%">
+      <object data="${file_uri}" type="application/pdf" style="height: 100%; width: 100%">
         <p>Your browser does not support viewing PDFs.  Please <a href="${file_uri}">download the file</a> to view it.</p>
       </object>
     `

--- a/app/javascript/controllers/pdf_controller.js
+++ b/app/javascript/controllers/pdf_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  show(evt) {
+    const file_uri = evt.detail
+    this.element.innerHTML = `
+      <object data="${file_uri}" type="application/pdf" style="height: 100vh; width: 100%">
+        <p>Your browser does not support viewing PDFs.  Please <a href="${file_uri}">download the file</a> to view it.</p>
+      </object>
+    `
+  }
+}

--- a/app/viewers/embed/viewer/pdf_viewer.rb
+++ b/app/viewers/embed/viewer/pdf_viewer.rb
@@ -15,7 +15,7 @@ module Embed
       end
 
       def stylesheet
-        'pdf.css'
+        'media.css' # TODO: change this
       end
 
       def pdf_files

--- a/app/views/layouts/preview/pdf.html.erb
+++ b/app/views/layouts/preview/pdf.html.erb
@@ -4,7 +4,7 @@
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"
         integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
         crossorigin="anonymous"></script>
-    <%= stylesheet_link_tag 'pdf.css' %>
+    <%= stylesheet_link_tag 'media.css' %> <%# TODO: Change this %>
     <%= stylesheet_link_tag 'sul_icons.css' %>
     <%= javascript_importmap_tags 'document' %>
   </head>

--- a/test/components/previews/embed/pdf_component_preview.rb
+++ b/test/components/previews/embed/pdf_component_preview.rb
@@ -10,11 +10,15 @@ module Embed
       render_viewer_for(url: 'https://purl.stanford.edu/sq929fn8035')
     end
 
+    def stanford_only
+      render_viewer_for(url: 'https://purl.stanford.edu/jr789rw2402')
+    end
+
     private
 
     def render_viewer_for(url:)
       embed_request = Embed::Request.new(url:)
-      viewer = Embed::Viewer::PdfViewer.new(embed_request)
+      viewer = Embed::ViewerFactory.new(embed_request).viewer
       render(PdfComponent.new(viewer:))
     end
   end

--- a/test/components/previews/embed/pdf_component_preview.rb
+++ b/test/components/previews/embed/pdf_component_preview.rb
@@ -14,6 +14,10 @@ module Embed
       render_viewer_for(url: 'https://purl.stanford.edu/jr789rw2402')
     end
 
+    def citation_only
+      render_viewer_for(url: 'https://purl.stanford.edu/bz673hm0344')
+    end
+
     private
 
     def render_viewer_for(url:)


### PR DESCRIPTION
Fixes #1919 - Implement authorization flow for PDFs.

Using the new IIIF auth/token/probe services and setting it up so it can be re-used later for other content types

Todos, see code comments.

NOTE: use rebased branch over here: #2075

~~Also, figure out where the messages are coming from the access service in the IIIF response, as they are pretty generic right now ("Login" and "Stanford login")~~ In PURL at sul-dlss/purl#925