### PR TITLE
[refactor] Extract  content_list_controller from media_tag controller

### DIFF
--- a/app/components/embed/companion_windows_component.html.erb
+++ b/app/components/embed/companion_windows_component.html.erb
@@ -41,7 +41,7 @@
           <div class="header-background">
             <h3>Media content</h3>
           </div>
-          <ul class="contentsList" data-media-tag-target="list" role="tablist"></ul>
+          <ul class="contentsList" data-controller="content-list" data-action="thumbnails-found@window->content-list#draw" role="tablist"></ul>
         </section>
 
         <%= drawer_content %>

--- a/app/javascript/controllers/content_list_controller.js
+++ b/app/javascript/controllers/content_list_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from "@hotwired/stimulus"
+import Thumbnail from 'src/modules/thumbnail'
+
+export default class extends Controller {
+  // This listens for a thumbnails-found event. Then it draws each on the page.
+  draw(evt) {
+    const thumbnails = evt.detail.
+      map((thumbnailData, index) => new Thumbnail(thumbnailData).build(index))
+    this.element.innerHTML = thumbnails.join('')
+  }
+}


### PR DESCRIPTION
This will allow other implementations to use the companion windows component and draw thumbnails, but not need to pull the data from the DOM.  They could use the IIIF manifest instead.