### PR TITLE
PDF Authorization using IIIF Probe Service

### DIFF
--- a/app/components/embed/pdf_component.html.erb
+++ b/app/components/embed/pdf_component.html.erb
@@ -1,11 +1,7 @@
-<div class="sul-embed-container" id='sul-embed-object' hidden>
+<div class="sul-embed-container" id='sul-embed-object' data-controller="file-auth" data-file-auth-iiif-manifest-value="<%= iiif_v3_manifest_url %>" hidden>
   <%= render Embed::HeaderComponent.new viewer: viewer %>
   <% # removing 5 pixels from the body height to account for being embedded %>
-  <div class='sul-embed-body sul-embed-pdf'>
-    <object data="<%= viewer.pdf_files.first %>" type="application/pdf" style="height: 100vh; width: 100%">
-      <p>Your browser does not support viewing PDFs.  Please <a href="<%= viewer.pdf_files.first %>">download the file</a> to view it.</p>
-    </object>
-  </div>
+  <div class='sul-embed-body sul-embed-pdf' data-file-auth-target="container"></div>
   <%= render 'embed/metadata_panel', viewer: viewer %>
   <%= render 'embed/embed_this/generic', viewer: viewer %>
   <%= render Embed::Download::PdfComponent.new viewer: viewer %>

--- a/app/components/embed/pdf_component.rb
+++ b/app/components/embed/pdf_component.rb
@@ -7,5 +7,12 @@ module Embed
     end
 
     attr_reader :viewer
+
+    delegate :purl_object, to: :viewer
+    delegate :druid, to: :purl_object
+
+    def iiif_v3_manifest_url
+      "#{Settings.purl_url}/#{druid}/iiif3/manifest"
+    end
   end
 end

--- a/app/javascript/controllers/file_auth_controller.js
+++ b/app/javascript/controllers/file_auth_controller.js
@@ -1,0 +1,124 @@
+import { Controller } from "@hotwired/stimulus"
+// import validator from 'src/modules/validator'
+// import mediaTagTokenWriter from 'src/modules/media_tag_token_writer'
+// import buildThumbnail from 'src/modules/media_thumbnail_builder'
+
+export default class extends Controller {
+  static targets = ["container"]
+  static values = {
+    iiifManifest: String
+  }
+
+  resources = {} // Hash of messageIds to resources
+
+  connect() {
+    this.fetchIiifManifest()
+    window.addEventListener("message", (event) => {
+      if (event.origin !== "https://stacks.stanford.edu" && event.origin !== "https://sul-stacks-stage.stanford.edu") return;
+
+      this.accessTokenReceived(event.data.accessToken, event.data.messageId)
+    }, false)
+
+  }
+
+  fetchIiifManifest() {
+    fetch(this.iiifManifestValue)
+      .then((response) => response.json())
+      .then((json) => this.dispatchManifestEvent(json))
+      .catch((err) => console.error(err))
+  }
+
+  dispatchManifestEvent(json) {
+    const event = new CustomEvent('iiif-manifest-received', { detail: json })
+    window.dispatchEvent(event)
+
+    this.parseFiles(json)
+  }
+
+  parseFiles(document) {
+    const canvases = document.items
+    canvases.forEach((canvas) => {
+      const annotationPages = canvas.items
+      annotationPages.forEach((annotationPage) => {
+        const annotations = annotationPage.items
+        annotations.forEach((annotation) => {
+          if (annotation.motivation === "painting") {
+            const contentResource = annotation.body
+            this.maybeDrawContentResource(contentResource)
+          }
+        })
+      })
+    })
+  }
+
+  // TODO: This causes 1 login window to open for each resource that needs a login.
+  //       Instead we should open one window if any resource needs a login.
+  maybeDrawContentResource(contentResource) {
+    console.log("Now figure out if we can render", contentResource)
+    if (!contentResource.service) {
+      // no auth is present, render it
+      this.renderViewer(contentResource.id)
+    } else {
+      const probeService = contentResource.service.find((service) => service.type === "AuthProbeService2")
+      if (probeService)
+        this.probe(probeService)
+      else
+        throw(`No probe service found for ${contentResource.id}`)
+    }
+  }
+
+  renderViewer(file_uri) {
+    this.containerTarget.innerHTML = `
+      <object data="${file_uri}" type="application/pdf" style="height: 100vh; width: 100%">
+        <p>Your browser does not support viewing PDFs.  Please <a href="${file_uri}">download the file</a> to view it.</p>
+      </object>
+    `
+  }
+
+  // https://iiif.io/api/auth/2.0/#71-authorization-flow-algorithm
+  probe(probeService) {
+    // We're going to make the assumption that calling the probe without a token is going to fail.
+    // So we'll just get the token first.
+    console.log(probeService)
+    const activeAccessService = probeService.service.find((service) => service.type === "AuthAccessService2" && service.profile === "active")
+
+    if (activeAccessService) {
+      const tokenService = activeAccessService.service.find((service) => service.type === "AuthAccessTokenService2")
+      if (!tokenService)
+        throw(`No token service found`)
+      this.login(activeAccessService)
+      const messageId = 'ae3415' // TODO: Make this random
+      this.resources[messageId] = probeService
+      const token = this.initiateTokenRequest(tokenService, messageId)
+    } else {
+      throw(`No active access service found`)
+    }
+  }
+
+  accessTokenReceived(token, messageId) {
+    const probeService = this.resources[messageId]
+    console.log("Trying probe service")
+    fetch(probeService.id, { headers: { 'Authorization': `Bearer ${token}`}})
+      .then((response) => response.json())
+      .then((json) => console.log("Response from the probe is", json))
+      .catch((err) => console.error(err))
+  }
+
+  initiateTokenRequest(tokenService, messageId) {
+    const iframe = document.createElement('iframe')
+    iframe.src = `${tokenService.id}?messageId=${messageId}&origin=${window.origin}`
+    document.body.appendChild(iframe)
+  }
+
+  // Open the login window in a new window and then poll to see if the auth credentials are now active.
+  login(activeAccessService) {
+    const windowReference = window.open(activeAccessService.id);
+    let loginStart = Date.now();
+    let checkWindow = setInterval(() => {
+      if ((Date.now() - loginStart) < 30000 &&
+        (!windowReference || !windowReference.closed)) return;
+
+      clearInterval(checkWindow);
+    }, 500)
+  }
+}

--- a/app/javascript/document.js
+++ b/app/javascript/document.js
@@ -4,6 +4,7 @@ import EmbedThis from "src/modules/embed_this";
 import PopupPanels from "src/modules/popup_panels";
 import Fullscreen from "src/modules/fullscreen";
 import { trackView, trackFileDownloads } from "src/modules/metrics";
+import "controllers";
 
 document.addEventListener("DOMContentLoaded", () => {
   document.getElementById("sul-embed-object").hidden = false;

--- a/test/components/previews/embed/pdf_component_preview.rb
+++ b/test/components/previews/embed/pdf_component_preview.rb
@@ -10,11 +10,15 @@ module Embed
       render_viewer_for(url: 'https://purl.stanford.edu/sq929fn8035')
     end
 
+    def stanford_only
+      render_viewer_for(url: 'https://purl.stanford.edu/jr789rw2402')
+    end
+
     private
 
     def render_viewer_for(url:)
       embed_request = Embed::Request.new(url:)
-      viewer = Embed::Viewer::PdfViewer.new(embed_request)
+      viewer = Embed::ViewerFactory.new(embed_request).viewer
       render(PdfComponent.new(viewer:))
     end
   end


### PR DESCRIPTION
Based on #2032 

Removed some code I didn't think was needed and made it work for content that is world viewable or for stanford only content where you are already authed, but it doesn't work when you need to auth to continue.

The issue:
- this code always fetches a token before calling the probe service, but you can't get a token if you are not authorized... so it seems like we should just call the probe service first without a token, which lets us know if we even need one and how to login if possible to get one
- BUT calling the probe service without a token throws a CORs error...and not sure why this would make a difference or if has to do with the pre-flight options in some way

Still need to work out:

- [x] ~~changes to stacks needed to authorize access to files using the tokens granted by the probe token service (in addition to the current method)~~ Already exists
- [x] ~~refactoring of media authorization login flow into it's own component for re-use with other content types~~ HOLD for now
- [x] update this PR to make use of the above two items -- not needed