### PR TITLE
removing crossorigin config

### DIFF
--- a/app/components/embed/media_tag_component.rb
+++ b/app/components/embed/media_tag_component.rb
@@ -75,7 +75,6 @@ module Embed
                },
                poster: poster_url_for,
                controls: 'controls',
-               crossorigin: 'anonymous',
                class: 'sul-embed-media-file',
                height: '100%') do
         streaming_source + captions


### PR DESCRIPTION
Context:
With the change merged in https://github.com/sul-dlss/stacks/pull/1100 , we no longer need to state "crossorigin=anonymous" in the video player.  Without the stacks level change, we would have to set the player to this crossorigin setting but then have the poster image crossorigin attributes set to "use-credentials".  Now, since stacks knows which embed URLs are allowed to ask for content, we no longer need to worry about setting this attribute at all.  