### PR TITLE
Fix audio thumbnail icons in Chrome

### DIFF
--- a/app/assets/stylesheets/media.scss
+++ b/app/assets/stylesheets/media.scss
@@ -564,7 +564,7 @@ a:hover {
       }
 
       .default-thumbnail-icon {
-        display: inline-block;
+        display: contents;
         font-size: calc(var(--thumb-height) - 2px);
         width: 75px;
         margin-right: .5rem;


### PR DESCRIPTION
# Chrome

## Before

![inline-block-chrome](https://github.com/sul-dlss/sul-embed/assets/131982/4e92cef7-a9ff-4750-8e1d-0eabfbd1d42e)

## After

![contents-chrome](https://github.com/sul-dlss/sul-embed/assets/131982/a480b3e2-cc80-458c-aa95-dfcc18d69e7f)

# Firefox

## Before

![inline-block-firefox](https://github.com/sul-dlss/sul-embed/assets/131982/e1b929dd-758a-4818-a5ea-f9ef776dcfc8)

## After

![contents-firefox](https://github.com/sul-dlss/sul-embed/assets/131982/56517583-6dd7-46e7-82f3-9a60b182d31b)
