### PR TITLE
Check that the button exists before adding a listener

### DIFF
--- a/app/javascript/file.js
+++ b/app/javascript/file.js
@@ -10,7 +10,6 @@ document.addEventListener('DOMContentLoaded', () => {
   trackView();
   trackFileDownloads();
 
-  document.querySelector('button[aria-label="download all files"]').addEventListener('click', () => {
-    trackObjectDownload();
-  });
+  const button = document.querySelector('button[aria-label="download all files"]')
+  button?.addEventListener('click', () => trackObjectDownload())
 })


### PR DESCRIPTION
If there is only one file, then the button doesn't exist. Fixes #2060