### PR TITLE
Update the padding on the file toolbar buttons

### DIFF
--- a/app/assets/stylesheets/modules/buttons.scss
+++ b/app/assets/stylesheets/modules/buttons.scss
@@ -1,4 +1,8 @@
 .#{$namespace}-container {
+  .sul-embed-footer-tool.btn {
+    --bs-btn-padding-y: 0.075rem;
+  }
+
   // .btn classes from https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.css
   .btn {
     --bs-btn-padding-x: 0.75rem;


### PR DESCRIPTION
The current setting has too much padding on the top:
<img width="434" alt="Screenshot 2024-01-04 at 11 39 15 AM" src="https://github.com/sul-dlss/sul-embed/assets/92044/246b741c-4125-4112-8f83-e0819c2fbd84">
