### PR TITLE
Only track events if Ahoy is available

### DIFF
--- a/app/javascript/src/modules/metrics.js
+++ b/app/javascript/src/modules/metrics.js
@@ -3,7 +3,7 @@
 
 // When the viewer is loaded for an object
 export const trackView = () => {
-  ahoy.trackView(eventParameters());
+  if (typeof ahoy !== "undefined") ahoy.trackView(eventParameters());
 };
 
 // Parameters common to all events we track

--- a/app/views/embed/iframe.html.erb
+++ b/app/views/embed/iframe.html.erb
@@ -16,6 +16,7 @@
         onerror: true
       });
     </script>
+    <%= render 'analytics' %>
     <%= javascript_importmap_tags @embed_response.viewer.importmap if @embed_response.viewer.importmap %>
     <%= stylesheet_link_tag @embed_response.viewer.stylesheet %>
     <%= stylesheet_link_tag 'sul_icons.css' %>
@@ -23,6 +24,5 @@
   </head>
   <body>
     <%= render @embed_response.viewer.component.new(viewer: @embed_response.viewer) %>
-    <%= render 'analytics' %>
   </body>
 </html>


### PR DESCRIPTION
In this PR:

- Ensure ahoy is loaded before viewer javascript executes
- Don't track analytics events if ahoy failed to load

It's hard to know if this will work because I can't replicate the production failures...this should at least silence the errors, but it's unclear what's causing them (at least in production). A lot of the user agents for which Ahoy doesn't load look like bots, but not _all_ of them do.

See:
- https://app.honeybadger.io/projects/49295/faults/103098294/
-  https://app.honeybadger.io/projects/49295/faults/102311434/
