### PR TITLE
Update design for item not accessible message

### DIFF
--- a/app/assets/stylesheets/pdf.scss
+++ b/app/assets/stylesheets/pdf.scss
@@ -70,3 +70,27 @@
     }
   }
 }
+
+.authLinkWrapper {
+  --active-color: rgb(140, 21, 21);
+  align-items: center;
+  display: flex;
+  background-color: var(--active-color);
+  color: white;
+  padding: .5rem;
+
+  .MuiSvgIcon-root {
+    fill: currentColor;
+    width: 1em;
+    height: 1em;
+    display: inline-block;
+    font-size: 1.5rem;
+    flex-shrink: 0;
+  }
+
+  .loginMessage {
+    margin-bottom: 0;
+    margin-left: 1rem;
+    margin-top: 0;
+  }
+}

--- a/app/components/embed/content_not_available_component.html.erb
+++ b/app/components/embed/content_not_available_component.html.erb
@@ -1,0 +1,4 @@
+<div class="authLinkWrapper">
+    <svg class="MuiSvgIcon-root" focusable="false" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8 0-1.85.63-3.55 1.69-4.9L16.9 18.31C15.55 19.37 13.85 20 12 20zm6.31-3.1L7.1 5.69C8.45 4.63 10.15 4 12 4c4.42 0 8 3.58 8 8 0 1.85-.63 3.55-1.69 4.9z"></path></svg>
+    <p class="loginMessage"><%= I18n.t('restrictions.not_accessible') %></p>
+</div>

--- a/app/components/embed/content_not_available_component.rb
+++ b/app/components/embed/content_not_available_component.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Embed
+  class ContentNotAvailableComponent < ViewComponent::Base
+  end
+end

--- a/app/components/embed/legacy_pdf_component.html.erb
+++ b/app/components/embed/legacy_pdf_component.html.erb
@@ -40,8 +40,9 @@
           <% # NOTE: Remove legacy_pdf_viewer.js file when this component is removed %>
           <%= javascript_pack_tag('legacy_pdf_viewer') %>
       <% else %>
-          <div style="padding: 10%;">
-            <strong><%= I18n.t('restrictions.not_accessible') %></strong>
+          <div class="authLinkWrapper">
+            <svg class="MuiSvgIcon-root" focusable="false" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8 0-1.85.63-3.55 1.69-4.9L16.9 18.31C15.55 19.37 13.85 20 12 20zm6.31-3.1L7.1 5.69C8.45 4.63 10.15 4 12 4c4.42 0 8 3.58 8 8 0 1.85-.63 3.55-1.69 4.9z"></path></svg>
+            <p class="loginMessage"><%= I18n.t('restrictions.not_accessible') %></p>
           </div>
       <% end %>
   </div>

--- a/app/components/embed/legacy_pdf_component.html.erb
+++ b/app/components/embed/legacy_pdf_component.html.erb
@@ -40,10 +40,7 @@
           <% # NOTE: Remove legacy_pdf_viewer.js file when this component is removed %>
           <%= javascript_pack_tag('legacy_pdf_viewer') %>
       <% else %>
-          <div class="authLinkWrapper">
-            <svg class="MuiSvgIcon-root" focusable="false" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8 0-1.85.63-3.55 1.69-4.9L16.9 18.31C15.55 19.37 13.85 20 12 20zm6.31-3.1L7.1 5.69C8.45 4.63 10.15 4 12 4c4.42 0 8 3.58 8 8 0 1.85-.63 3.55-1.69 4.9z"></path></svg>
-            <p class="loginMessage"><%= I18n.t('restrictions.not_accessible') %></p>
-          </div>
+         <%= render Embed::ContentNotAvailableComponent.new %>
       <% end %>
   </div>
   <%= render 'embed/metadata_panel', viewer: viewer %>

--- a/app/components/embed/media_component.html.erb
+++ b/app/components/embed/media_component.html.erb
@@ -69,10 +69,7 @@
         </div>
       </div>
       <div data-auth-restriction-target="noAccess" hidden>
-        <div class="authLinkWrapper">
-          <svg class="MuiSvgIcon-root" focusable="false" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8 0-1.85.63-3.55 1.69-4.9L16.9 18.31C15.55 19.37 13.85 20 12 20zm6.31-3.1L7.1 5.69C8.45 4.63 10.15 4 12 4c4.42 0 8 3.58 8 8 0 1.85-.63 3.55-1.69 4.9z"></path></svg>
-          <p class="loginMessage"><%= I18n.t('restrictions.not_accessible') %></p>
-        </div>
+         <%= render Embed::ContentNotAvailableComponent.new %>
       </div>
     </div>
   <% end %>

--- a/app/components/embed/media_component.html.erb
+++ b/app/components/embed/media_component.html.erb
@@ -71,7 +71,7 @@
       <div data-auth-restriction-target="noAccess" hidden>
         <div class="authLinkWrapper">
           <svg class="MuiSvgIcon-root" focusable="false" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8 0-1.85.63-3.55 1.69-4.9L16.9 18.31C15.55 19.37 13.85 20 12 20zm6.31-3.1L7.1 5.69C8.45 4.63 10.15 4 12 4c4.42 0 8 3.58 8 8 0 1.85-.63 3.55-1.69 4.9z"></path></svg>
-          <p class="loginMessage">This item cannot be accessed online. See access conditions for more information.</p>
+          <p class="loginMessage"><%= I18n.t('restrictions.not_accessible') %></p>
         </div>
       </div>
     </div>

--- a/app/components/embed/pdf_component.html.erb
+++ b/app/components/embed/pdf_component.html.erb
@@ -8,10 +8,7 @@
       </div>
     <% else %>
        <div class='sul-embed-body sul-embed-pdf' style="width: 100%">
-          <div class="authLinkWrapper">
-            <svg class="MuiSvgIcon-root" focusable="false" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8 0-1.85.63-3.55 1.69-4.9L16.9 18.31C15.55 19.37 13.85 20 12 20zm6.31-3.1L7.1 5.69C8.45 4.63 10.15 4 12 4c4.42 0 8 3.58 8 8 0 1.85-.63 3.55-1.69 4.9z"></path></svg>
-            <p class="loginMessage"><%= I18n.t('restrictions.not_accessible') %></p>
-          </div>
+         <%= render Embed::ContentNotAvailableComponent.new %>
        </div>
     <% end %>
   <% end %>

--- a/app/components/embed/pdf_component.html.erb
+++ b/app/components/embed/pdf_component.html.erb
@@ -7,8 +7,11 @@
         <%= render Embed::LoginComponent.new %>
       </div>
     <% else %>
-       <div class='sul-embed-body sul-embed-pdf' style="width: 100%; padding: 10%;">
-          <strong><%= I18n.t('restrictions.not_accessible') %></strong>
+       <div class='sul-embed-body sul-embed-pdf' style="width: 100%">
+          <div class="authLinkWrapper">
+            <svg class="MuiSvgIcon-root" focusable="false" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8 0-1.85.63-3.55 1.69-4.9L16.9 18.31C15.55 19.37 13.85 20 12 20zm6.31-3.1L7.1 5.69C8.45 4.63 10.15 4 12 4c4.42 0 8 3.58 8 8 0 1.85-.63 3.55-1.69 4.9z"></path></svg>
+            <p class="loginMessage"><%= I18n.t('restrictions.not_accessible') %></p>
+          </div>
        </div>
     <% end %>
   <% end %>

--- a/app/javascript/controllers/pdf_controller.js
+++ b/app/javascript/controllers/pdf_controller.js
@@ -5,7 +5,13 @@ export default class extends Controller {
     const file_uri = evt.detail
     this.element.innerHTML = `
       <object data="${file_uri}" type="application/pdf" style="height: 100%; width: 100%">
-        <p>Your browser does not support viewing PDFs.  Please <a href="${file_uri}">download the file</a> to view it.</p>
+        <div class="authLinkWrapper">
+          <svg class="MuiSvgIcon-root" focusable="false" aria-hidden="true" viewBox="0 0 16 16">
+            <path d="M7.938 2.016A.13.13 0 0 1 8.002 2a.13.13 0 0 1 .063.016.15.15 0 0 1 .054.057l6.857 11.667c.036.06.035.124.002.183a.2.2 0 0 1-.054.06.1.1 0 0 1-.066.017H1.146a.1.1 0 0 1-.066-.017.2.2 0 0 1-.054-.06.18.18 0 0 1 .002-.183L7.884 2.073a.15.15 0 0 1 .054-.057m1.044-.45a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767z"/>
+            <path d="M7.002 12a1 1 0 1 1 2 0 1 1 0 0 1-2 0M7.1 5.995a.905.905 0 1 1 1.8 0l-.35 3.507a.552.552 0 0 1-1.1 0z"/>
+          </svg>
+          <p class="loginMessage">Your browser does not support viewing PDFs.  Please <a style="color: white;" href="${file_uri}">download the file</a> to view it.</p>
+        </div>
       </object>
     `
   }

--- a/test/components/previews/embed/media_component_preview.rb
+++ b/test/components/previews/embed/media_component_preview.rb
@@ -34,6 +34,10 @@ module Embed
       render_media_viewer_for(url: 'https://purl.stanford.edu/dp324gw4986')
     end
 
+    def citation_only
+      render_media_viewer_for(url: 'https://purl.stanford.edu/bc285ff3003')
+    end
+
     private
 
     def render_media_viewer_for(url:)


### PR DESCRIPTION
Two similar design changes in this PR.

1. When a PDF is not accessible due to it being no download/citation only, the UI currently looks like this:

![Screen Shot 2024-01-09 at 4 19 53 PM](https://github.com/sul-dlss/sul-embed/assets/47137/342a8987-adae-4dbb-a019-e1bf76fbbef2)

This updates it to more closely match the requested design in the [Google Doc](https://docs.google.com/document/d/1IIPYw4CVIaNCjPjtY427JxcPQngd5ZxgqhQLfhxVbi4/edit) (shown below).

![Screen Shot 2024-01-10 at 10 07 57 AM](https://github.com/sul-dlss/sul-embed/assets/47137/6925dd1e-3262-4548-b5db-c2db8bf007d4)


Here is what it looks like in this PR:

![Screen Shot 2024-01-09 at 4 27 18 PM](https://github.com/sul-dlss/sul-embed/assets/47137/4fc6bc9b-274f-45d1-84a1-834231b3edae)


2.  When a PDF is not viewable in the new PDF component (e.g. due to lack of browser support), the UI currently looks like this:

![Screen Shot 2024-01-09 at 4 35 29 PM](https://github.com/sul-dlss/sul-embed/assets/47137/f96cd31d-6866-4706-a40d-277c1efc55af)

This PR changes it to this (note that this change is only relevant for the new PDF viewer, not the legacy PDF viewer).

![Screen Shot 2024-01-09 at 4 34 42 PM](https://github.com/sul-dlss/sul-embed/assets/47137/0e3a54de-da9f-43dd-bcb9-87549e82deda)


