### PR TITLE
add fullscreen button to new PDF viewer

### DIFF
--- a/app/assets/stylesheets/companion_window.scss
+++ b/app/assets/stylesheets/companion_window.scss
@@ -1,3 +1,5 @@
+@import 'common';
+@import 'modules/fullscreen';
 
 .authLinkWrapper {
   align-items: center;

--- a/app/components/embed/pdf_component.html.erb
+++ b/app/components/embed/pdf_component.html.erb
@@ -1,4 +1,11 @@
 <%= render Embed::CompanionWindowsComponent.new(viewer:, stimulus_controller: 'file-auth') do |component| %>
+  <% component.with_header_button do %>
+      <button
+        aria-label="Full screen"
+        class="btn sul-i-expand-1 sul-fullscreen-button"
+        id="full-screen-button">
+      </button>
+  <% end %>
   <% component.with_body do %>
     <% if viewer.available? %>
       <div class='sul-embed-body sul-embed-pdf' style="width: 100%"

--- a/app/javascript/document.js
+++ b/app/javascript/document.js
@@ -1,6 +1,8 @@
 import "controllers";
 import { trackView } from "src/modules/metrics";
+import Fullscreen from "src/modules/fullscreen";
 
 document.addEventListener("DOMContentLoaded", () => {
+  Fullscreen.init(".sul-embed-pdf");
   trackView();
 });


### PR DESCRIPTION
Fixes #2081 - add fullscreen button to top toolbar for new PDF viewer

~~HOLD for PO review~~ Reviewed and signed off

Example: https://sul-purl-stage.stanford.edu/bg077wm0255  (if correct branch is deployed to stage)

<img width="708" alt="Screen Shot 2024-01-11 at 10 56 49 AM" src="https://github.com/sul-dlss/sul-embed/assets/47137/1aa6d723-1cae-4735-9840-9d150330dcd4">
