### PR TITLE
set minimum height for PDF main panel so it does not shrink

### DIFF
--- a/app/assets/stylesheets/companion_window.scss
+++ b/app/assets/stylesheets/companion_window.scss
@@ -456,5 +456,5 @@
 }
 
 .sul-embed-pdf {
-  min-height: 700px;
+  min-height: 90vh;
 }

--- a/app/assets/stylesheets/companion_window.scss
+++ b/app/assets/stylesheets/companion_window.scss
@@ -454,3 +454,7 @@
     }
   }
 }
+
+.sul-embed-pdf {
+  min-height: 700px;
+}


### PR DESCRIPTION
Fixes #2086 - do not shrink the main PDF panel too much even if you open a sidebar that is smaller

In the screenshots below, ignore the fact that the content panel is blank and says "Media content"...this is fixed in #2082

**Without change**
When you view the contents panel
<img width="1243" alt="Screen Shot 2024-01-17 at 10 43 01 AM" src="https://github.com/sul-dlss/sul-embed/assets/47137/66554017-faeb-4c80-87a2-c459509172a6">

**With change**
When you view the contents panel
<img width="1517" alt="Screen Shot 2024-01-17 at 10 42 30 AM" src="https://github.com/sul-dlss/sul-embed/assets/47137/c84ea3b3-c7cc-4b89-ba48-dd0ed03ec79f">
