### PR TITLE
Have video player init when event is missed

### DIFF
--- a/app/javascript/controllers/media_player_controller.js
+++ b/app/javascript/controllers/media_player_controller.js
@@ -2,6 +2,20 @@ import { Controller } from "@hotwired/stimulus"
 import videojs from 'video.js';
 
 export default class extends Controller {
+  connect() {
+    // See afterValidate in media_tag_controller. The auth check might have
+    // dispatched auth-success prior to Stimulus adding the binding for
+    // initializeVideoJSPlayer.
+    const authSuccessAlreadyDispatched = this.element.dataset.authSuccessAlreadyDispatched === "true"
+    if (!this.videoJSPlayerAlreadyInitialized() && authSuccessAlreadyDispatched) {
+      this.initializeVideoJSPlayer()
+    }
+  }
+
+  videoJSPlayerAlreadyInitialized() {
+    return this.element.classList.contains('video-js')
+  }
+
   initializeVideoJSPlayer() {
     this.element.classList.add('video-js', 'vjs-default-skin')
     this.player = videojs(this.element.id)

--- a/app/javascript/controllers/media_tag_controller.js
+++ b/app/javascript/controllers/media_tag_controller.js
@@ -26,6 +26,13 @@ export default class extends Controller {
       if (result.authResponse.access_restrictions.stanford_restricted === true)
         window.dispatchEvent(new CustomEvent('auth-stanford-restricted'))
       window.dispatchEvent(new CustomEvent('auth-success'))
+
+      // In some cases, such as slow connections, auth-success is dispatched
+      // prior to the auth-success@window->media-player#initializeVideoJSPlayer
+      // action being bound and Video.js will never initialize.
+      // Track if we have already dispatched auth-success in each media tag.
+      this.authorizeableResourceTargets
+        .map((mediaTag) => mediaTag.dataset.authSuccessAlreadyDispatched = true)
     } else {
       const event = new CustomEvent('auth-denied', { detail: result.authResponse })
       window.dispatchEvent(event)


### PR DESCRIPTION
As we discovered in https://github.com/sul-dlss/exhibits/issues/2385, there are some cases (e.g., very slow connection) where the auth validator is dispatching the auth-success event prior to Stimulus adding the binding for initializeVideoJSPlayer which means the video player never initializes. This is true for one embed or multiple and can be reproduced on many browsers.

This is my attempt at a low risk, "don't restructure all the events during the wrong work cycle" fix.