### PR TITLE
Use new headless Chrome for testing

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,16 +15,16 @@ require 'view_component/system_test_helpers'
 
 # Capybara 3.40.0 started using the new chrome headless by default:
 # https://developer.chrome.com/docs/chromium/new-headless
-# We need a driver with the "--headless=old" argument until
-# our tests work with "new".
-Capybara.register_driver :selenium_chrome_headless_old do |app|
+# Their default selenium_chrome_headless driver definition includes
+# --disable-site-isolation-trials. Some embed tests will crash Chrome with
+# that option.
+Capybara.register_driver :selenium_chrome_headless do |app|
   browser_options = Selenium::WebDriver::Chrome::Options.new
-  browser_options.add_argument('--headless=old')
-  browser_options.add_argument('--disable-site-isolation-trials')
+  browser_options.add_argument('--headless=new')
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
 
-Capybara.javascript_driver = :selenium_chrome_headless_old
+Capybara.javascript_driver = :selenium_chrome_headless
 Capybara.enable_aria_label = true
 Capybara.default_max_wait_time = ENV['CI'] ? 30 : 5
 


### PR DESCRIPTION
Switch to the new headless Chrome for testing.

With `--headless=old` we did need `--disable-site-isolation-trials` or some tests would fail.

The new headless Chrome crashes on some embed tests with that option. Capybara's default driver definition includes this option. Here we redefine it without that option.