### PR TITLE
show download all files links in geo viewer

### DIFF
--- a/app/components/embed/footer_component.html.erb
+++ b/app/components/embed/footer_component.html.erb
@@ -12,6 +12,7 @@
 
     <% if viewer.show_download? %>
       <button
+        id='sul-embed-download-panel-toggle'
         class='sul-embed-footer-tool btn btn-toolbar sul-i-download-3'
         aria-expanded='false' aria-label='<%= download_file_label %>'
         data-sul-embed-toggle='sul-embed-download-panel'>
@@ -25,6 +26,20 @@
       <a class='sul-embed-footer-tool btn btn-toolbar sul-i-navigation-next-4'
         href="<%= external_url %>" target='_parent'>
         <span class='sul-embed-sr-only'><%= external_url_text %></span>
+      </a>
+    <% end %>
+
+    <% if viewer.display_download_all? %>
+      <a id='sul-embed-footer-download-all' href='<%= viewer.download_url %>' target="_blank" rel="noopener noreferrer nofollow" data-controller="download" data-action="click->download#download">
+        <button class='sul-embed-footer-tool btn btn-toolbar sul-i-download-3' aria-label="download all files">
+          Download all <%= pluralize(viewer.purl_object.downloadable_files.length, "file") %>
+          (<%= viewer.pretty_filesize(viewer.purl_object.size) %>)
+          <% if viewer.any_stanford_only_files? %>
+            <span class="sul-embed-location-restricted-text sul-embed-stanford-only-text" aria-label="restricted to stanford">
+              <span class="sul-embed-text-hide"> Stanford only </span>
+            </span>
+          <% end %>
+        </button>
       </a>
     <% end %>
 

--- a/app/viewers/embed/viewer/common_viewer.rb
+++ b/app/viewers/embed/viewer/common_viewer.rb
@@ -26,6 +26,20 @@ module Embed
         nil
       end
 
+      def any_stanford_only_files?
+        @purl_object.all_resource_files.any?(&:stanford_only?)
+      end
+
+      # indicates if viewer should display the Download All link in footer (override in specific viewer classes)
+      def display_download_all?
+        false
+      end
+
+      # link that will download all of the files in this object
+      def download_url
+        "#{Settings.stacks_url}/object/#{@purl_object.druid}"
+      end
+
       def stylesheet
         "#{purl_object.type}.css"
       end

--- a/app/viewers/embed/viewer/file.rb
+++ b/app/viewers/embed/viewer/file.rb
@@ -64,14 +64,6 @@ module Embed
           @purl_object.downloadable_files.length < 3000
       end
 
-      def any_stanford_only_files?
-        @purl_object.all_resource_files.any?(&:stanford_only?)
-      end
-
-      def download_url
-        "#{Settings.stacks_url}/object/#{@purl_object.druid}"
-      end
-
       private
 
       def default_height

--- a/app/viewers/embed/viewer/geo.rb
+++ b/app/viewers/embed/viewer/geo.rb
@@ -40,6 +40,13 @@ module Embed
         index_map.present?
       end
 
+      # Returns true or false whether the viewer should display the Download All
+      # link. True for all geo objects, unless there is only one file
+      # (because the file download link will suffice for that)
+      def display_download_all?
+        @purl_object.downloadable_files.length > 1
+      end
+
       def external_url
         "#{Settings.geo_external_url}#{@embed_request.object_druid}"
       end

--- a/spec/factories/purls.rb
+++ b/spec/factories/purls.rb
@@ -52,7 +52,7 @@ FactoryBot.define do
       type { 'geo' }
       bounding_box { [['-1.478794', '29.572742'], ['4.234077', '35.000308']] }
       public { true }
-      contents { [build(:resource, :file, files: [build(:resource_file, filename: 'data.zip'), build(:resource_file, filename: 'data_EPSG_4326.zip')]), build(:resource, :image)] }
+      contents { [build(:resource, :file, files: [build(:resource_file, :world_downloadable, filename: 'data.zip'), build(:resource_file, :world_downloadable, filename: 'data_EPSG_4326.zip')]), build(:resource, :image)] }
     end
 
     trait :media do

--- a/spec/features/geo_viewer_spec.rb
+++ b/spec/features/geo_viewer_spec.rb
@@ -33,13 +33,17 @@ RSpec.describe 'geo viewer', :js do
     end
 
     it 'download toolbar/panel is present with download links' do
-      find('button.sul-embed-footer-tool.sul-i-download-3').click
+      find('button#sul-embed-download-panel-toggle').click
       expect(find('.sul-embed-download-panel', visible: :all).find('.sul-embed-panel-body', visible: :all)).to have_css('li', count: 1, text: 'data.zip')
     end
 
     it 'includes proper attributes for a _blank target on the download links' do
-      find('button.sul-embed-footer-tool.sul-i-download-3').click
+      find('button#sul-embed-download-panel-toggle').click
       expect(find('.sul-embed-download-panel', visible: :all).find('.sul-embed-panel-body', visible: :all)).to have_css('li a[target="_blank"][rel="noopener noreferrer"]', count: 3)
+    end
+
+    it 'download all file link is present' do
+      expect(page).to have_css('#sul-embed-footer-download-all')
     end
 
     it 'shows the sidebar with attribute information after map is clicked' do

--- a/spec/lib/embed/viewer/common_viewer_spec.rb
+++ b/spec/lib/embed/viewer/common_viewer_spec.rb
@@ -69,4 +69,36 @@ RSpec.describe Embed::Viewer::CommonViewer do
       expect(file_viewer.iframe_title).to eq 'File viewer'
     end
   end
+
+  describe '#any_stanford_only_files' do
+    subject { file_viewer.any_stanford_only_files? }
+
+    before do
+      allow(Embed::Purl).to receive(:find).and_return(purl)
+    end
+
+    let(:purl) { build(:purl) }
+
+    context 'when one or more files are stanford only' do
+      let(:purl) do
+        build(:purl, contents: [build(:resource, :file, files: [build(:resource_file, :stanford_only)])])
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when no files are stanford only' do
+      let(:purl) do
+        build(:purl, contents: [build(:resource, :file, files: [build(:resource_file)])])
+      end
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#download_url' do
+    subject { file_viewer.download_url }
+
+    it { is_expected.to eq 'https://stacks.stanford.edu/object/abc123' }
+  end
 end

--- a/spec/lib/embed/viewer/file_spec.rb
+++ b/spec/lib/embed/viewer/file_spec.rb
@@ -201,36 +201,4 @@ RSpec.describe Embed::Viewer::File do
       it { is_expected.to be false }
     end
   end
-
-  describe '#any_stanford_only_files' do
-    subject { file_viewer.any_stanford_only_files? }
-
-    before do
-      allow(Embed::Purl).to receive(:find).and_return(purl)
-    end
-
-    let(:purl) { build(:purl) }
-
-    context 'when one or more files are stanford only' do
-      let(:purl) do
-        build(:purl, contents: [build(:resource, :file, files: [build(:resource_file, :stanford_only)])])
-      end
-
-      it { is_expected.to be true }
-    end
-
-    context 'when no files are stanford only' do
-      let(:purl) do
-        build(:purl, contents: [build(:resource, :file, files: [build(:resource_file)])])
-      end
-
-      it { is_expected.to be false }
-    end
-  end
-
-  describe '#download_url' do
-    subject { file_viewer.download_url }
-
-    it { is_expected.to eq 'https://stacks.stanford.edu/object/abc123' }
-  end
 end

--- a/test/components/previews/embed/geo_component_preview.rb
+++ b/test/components/previews/embed/geo_component_preview.rb
@@ -6,8 +6,12 @@ module Embed
   class GeoComponentPreview < ViewComponent::Preview
     layout 'preview/geo'
 
-    def public
-      render_viewer_for(url: 'https://purl.stanford.edu/bc843cm1713')
+    def public_raster
+      render_viewer_for(url: 'https://purl.stanford.edu/tg926kp6619')
+    end
+
+    def public_vector
+      render_viewer_for(url: 'https://purl.stanford.edu/cz128vq0535')
     end
 
     private


### PR DESCRIPTION
Fixes #2099 

For Geo objects, when there is more than 1 downloadable file present in an object, show the "Download all files" link, the same as is done for File objects.  This link will download a ZIP file with all of the files in the object (which may itself include ZIPs). 

This will work right now for all Geo objects, but if we don't want to release just yet, we could wait and/or put a feature flag in.

This is what it looks like (exactly the same as the File viewer):

![Screen Shot 2024-02-01 at 12 09 10 PM](https://github.com/sul-dlss/sul-embed/assets/47137/bf8c725c-c5c4-488f-bb76-78241d10b030)
