### PR TITLE
remove duplicated code in legacy pdf viewer

### DIFF
--- a/app/components/embed/legacy_pdf_component.html.erb
+++ b/app/components/embed/legacy_pdf_component.html.erb
@@ -22,20 +22,6 @@
             class="btn sul-i-close sul-close-fullscreen-button"
             id="close-full-screen-button">
           </button>
-          <button aria-label="Next page" class="button next-page">
-            <i class="sul-i-arrow-right-8"></i>
-          </button>
-          <div id="pdf-viewer" class="pdf-viewer"
-            data-pdf-url="<%= viewer.pdf_files.first %>"
-            data-location-restricted="<%= viewer.all_documents_location_restricted? %>"
-          >
-            <div class="loading-spinner"></div>
-            <canvas></canvas>
-            <button
-              aria-label="Exit full screen"
-              class="sul-embed-btn sul-i-close sul-close-fullscreen-button"
-              id="close-full-screen-button">
-            </button>
           </div>
           <% # NOTE: Remove legacy_pdf_viewer.js file when this component is removed %>
           <%= javascript_pack_tag('legacy_pdf_viewer') %>


### PR DESCRIPTION
Legacy PDF viewer had some code duplicated by mistake during recent work.  This prevented page flipping and incorrectly placed the footer.  This fixes it.