### PR TITLE
Set drawer-content-padding: 0.7rem to allow space for scrollbar

### DIFF
--- a/app/assets/stylesheets/companion_window.scss
+++ b/app/assets/stylesheets/companion_window.scss
@@ -43,7 +43,7 @@
   --font-size-base: 14px;
   --tab-width: 48px;
   --tab-height: 48px;
-  --drawer-content-padding: 1rem;
+  --drawer-content-padding: 0.7rem;
   --text-color: rgba(0, 0, 0, 0.87);
   --border-color: #5f574f;
   --button-color: #454545;


### PR DESCRIPTION
Fixes #2105

Allows for correct display of files list if the OS is set to always display scrollbars.

**Before:**
<img width="770" alt="Screenshot 2024-03-22 at 5 32 41 PM" src="https://github.com/sul-dlss/sul-embed/assets/458247/10114b91-fda2-466f-8dc1-c47973ca8773">

**After:**
<img width="771" alt="Screenshot 2024-03-22 at 5 32 08 PM" src="https://github.com/sul-dlss/sul-embed/assets/458247/bb2e4325-d996-4c9a-8aec-5626d560a571">

Test records:
https://purl.stanford.edu/pq271rp1793
https://purl.stanford.edu/dc682mb8493
