### PR TITLE
Increase companion drawer-width by 5px to 310px; fixes #2105

### DIFF
--- a/app/assets/stylesheets/companion_window.scss
+++ b/app/assets/stylesheets/companion_window.scss
@@ -39,7 +39,7 @@
 
 .companion-window-component {
   --active-color: rgb(140, 21, 21);
-  --drawer-width: 305px;
+  --drawer-width: 310px;
   --font-size-base: 14px;
   --tab-width: 48px;
   --tab-height: 48px;


### PR DESCRIPTION
We were still seeing problems with the file display on Chrome and FireFox on Windows after increasing the padding in #2127.  This adds 5px to the drawer width which fixes the display problem on Windows.

Before:
<img width="325" alt="Screenshot 2024-03-27 at 9 35 34 AM" src="https://github.com/sul-dlss/sul-embed/assets/458247/cb27f690-945e-4b2f-ae3d-88a977b0b4f5">

After:
<img width="343" alt="Screenshot 2024-03-27 at 9 35 23 AM" src="https://github.com/sul-dlss/sul-embed/assets/458247/0b274bf2-193e-48a2-a453-b454523a126a">
