### PR TITLE
Update IIIF link to https://iiif.io

### DIFF
--- a/app/javascript/src/modules/m3_viewer.js
+++ b/app/javascript/src/modules/m3_viewer.js
@@ -43,7 +43,7 @@ export default {
             'https://embed.stanford.edu/iframe?url=https://purl.stanford.edu/$1',
           ],
         },
-        dragAndDropInfoLink: 'https://library.stanford.edu/projects/international-image-interoperability-framework/viewers',
+        dragAndDropInfoLink: 'https://iiif.io',
         shareLink: {
           enabled: true,
           manifestIdReplacePattern: [


### PR DESCRIPTION
After some discussion with Sarah we decided to update the IIIF links to https://iiif.io