### PR TITLE
Find constituent records for virtual objects when loading from JSON

### DIFF
--- a/app/models/embed/purl_json_loader.rb
+++ b/app/models/embed/purl_json_loader.rb
@@ -90,9 +90,24 @@ module Embed
     end
 
     def contents
-      # NOTE: collections don't have structural.contains
+      # NOTE: collections don't have structural
+      return [] unless json['structural']
+
       Array(json.dig('structural', 'contains')).map do |file_set_json|
         Purl::ResourceJsonDeserializer.new(@druid, file_set_json).deserialize
+      end + external_resources(Array(json.dig('structural', 'hasMemberOrders', 0, 'members')))
+    end
+
+    def external_resources(identifiers)
+      identifiers.map do |identifier|
+        druid = identifier.delete_prefix('druid:')
+        component = Embed::Purl.find(druid)
+        Purl::Resource.new(
+          druid:,
+          type: component.type,
+          description: component.title,
+          files: []
+        )
       end
     end
 

--- a/app/viewers/embed/viewer_factory.rb
+++ b/app/viewers/embed/viewer_factory.rb
@@ -2,6 +2,7 @@
 
 module Embed
   class ViewerFactory
+    # @param [Embed::Request] request
     def initialize(embed_request)
       @embed_request = embed_request
       raise Embed::Purl::ResourceNotEmbeddable unless embed_request.purl_object.valid?

--- a/lib/embed/request.rb
+++ b/lib/embed/request.rb
@@ -58,6 +58,7 @@ module Embed
       url[/\w*$/]
     end
 
+    # @return [Embed::Purl]
     def purl_object
       @purl_object ||= Purl.find(object_druid)
     end

--- a/lib/embed/response.rb
+++ b/lib/embed/response.rb
@@ -5,6 +5,8 @@ module Embed
     attr_reader :request
 
     delegate :height, :width, to: :viewer
+
+    # @param [Embed::Request] request
     def initialize(request)
       @request = request
     end

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -82,6 +82,37 @@ module PurlFixtures # rubocop:disable Metrics/ModuleLength
     JSON
   end
 
+  def virtual_object_purl_json
+    <<~JSON
+      {
+        "type": "https://cocina.sul.stanford.edu/models/object",
+        "label": "File Title",
+        "description": {
+          "title": [
+            {
+              "value": "File Title"
+            }
+          ]
+        },
+        "access": {
+          "view": "world",
+          "download": "world",
+          "license": "https://creativecommons.org/publicdomain/mark/1.0/"
+        },
+        "structural": {
+          "contains": [],
+          "hasMemberOrders": [
+            {
+              "members": [
+                "druid:kq126jw7402"
+              ]
+            }
+          ]
+        }
+      }
+    JSON
+  end
+
   def collection_purl_json
     <<~JSON
       {

--- a/spec/models/embed/purl_json_loader_spec.rb
+++ b/spec/models/embed/purl_json_loader_spec.rb
@@ -63,6 +63,19 @@ RSpec.describe Embed::PurlJsonLoader do
         end
       end
 
+      context 'with a virtual object' do
+        let(:json) { virtual_object_purl_json }
+        let(:associate) { Embed::Purl.new }
+
+        before do
+          allow(Embed::Purl).to receive(:find).with('kq126jw7402').and_return(associate)
+        end
+
+        it 'has contents' do
+          expect(data[:contents].first.druid).to eq 'kq126jw7402'
+        end
+      end
+
       describe 'license' do
         context 'with a creative commons license' do
           let(:json) { file_purl_json }


### PR DESCRIPTION
This was causing the viewer to not display on https://sul-purl-stage.stanford.edu/fb255qn5259 because the item was seen as not to have any content.