### PR TITLE
Pin model-viewer to v3.4.0

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -40,5 +40,5 @@ pin "videojs-vtt.js", to: "https://ga.jspm.io/npm:videojs-vtt.js@0.15.5/lib/brow
 
 pin "openseadragon", to: "https://ga.jspm.io/npm:openseadragon@4.1.0/build/openseadragon/openseadragon.js"
 pin "fscreen", to: "https://ga.jspm.io/npm:fscreen@1.2.0/dist/fscreen.cjs.js"
-pin "@google/model-viewer", to: "https://cdn.jsdelivr.net/npm/@google/model-viewer/dist/model-viewer-module.min.js"
+pin "@google/model-viewer", to: "https://cdn.jsdelivr.net/npm/@google/model-viewer@3.4.0/dist/model-viewer-module.min.js"
 pin "three", to: "https://ga.jspm.io/npm:three@0.160.1/build/three.module.js"


### PR DESCRIPTION
This fixes an error with model-viewer's dependency on three.js
that was causing CI failures starting at 577f2e4.

Our importmap dependency on model-viewer was unpinned, so this
pins it and keeps it at v3.4 instead of v3.5.
