### PR TITLE
Link to collection without requiring a second lookup

### DIFF
--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -63,6 +63,12 @@ module Embed
       "#{Settings.purl_url}/#{@druid}"
     end
 
+    def first_collection_url
+      return if collections.blank?
+
+      "#{Settings.purl_url}/#{collections.first}"
+    end
+
     def manifest_json_url
       "#{Settings.purl_url}/#{druid}/iiif/manifest"
     end

--- a/app/views/embed/iframe.html.erb
+++ b/app/views/embed/iframe.html.erb
@@ -20,7 +20,7 @@
     <%= javascript_importmap_tags @embed_response.viewer.importmap if @embed_response.viewer.importmap %>
     <%= stylesheet_link_tag @embed_response.viewer.stylesheet %>
     <%= stylesheet_link_tag 'sul_icons.css' %>
-    <%= tag :link, rel: "up", href: Embed::Purl.find(@embed_response.request.purl_object.collections.first).purl_url if @embed_response && @embed_response.request.purl_object.collections.any? %>
+    <%= tag :link, rel: "up", href: @embed_response.request.purl_object.first_collection_url if @embed_response && @embed_response.request.purl_object.first_collection_url %>
   </head>
   <body>
     <%= render @embed_response.viewer.component.new(viewer: @embed_response.viewer) %>


### PR DESCRIPTION
Fixes #2154

The link is only used for analytics, so it shouldn't matter if the collection is dark or not