### PR TITLE
Cocina uses `languageTag` not `language`

### DIFF
--- a/app/models/embed/purl/file_json_deserializer.rb
+++ b/app/models/embed/purl/file_json_deserializer.rb
@@ -47,7 +47,7 @@ module Embed
           mimetype: @file.fetch('hasMimeType'),
           size: @file.fetch('size'),
           role: @file['use'],
-          language: @file['language'],
+          language: @file['languageTag'],
           filename:,
           stanford_only:,
           location_restricted:,


### PR DESCRIPTION
Maybe fixes #2171?