### PR TITLE
disable the fullscreen button for the native PDF viewer in Chromium based browsers

### DIFF
--- a/app/components/embed/companion_windows_component.rb
+++ b/app/components/embed/companion_windows_component.rb
@@ -31,5 +31,12 @@ module Embed
 
       true
     end
+
+    def requested_by_chromium?
+      user_agent_str = request.headers['User-Agent']
+      return true if user_agent_str.match(%r{Chrome/\d+}) || user_agent_str.match(%r{Edg/\d+})
+
+      false
+    end
   end
 end

--- a/app/components/embed/legacy_pdf_component.rb
+++ b/app/components/embed/legacy_pdf_component.rb
@@ -4,7 +4,7 @@
 #  1. The "pdfjs-dist" package in package.json
 #  2. The entire app/javascript/src/modules/pdf_viewer.js file
 #  3. The entire app/javascript/packs/legacy_pdf_viewer.js file
-#  4. The legacy_pdf_viewer feature flag in settings.
+#  4. The legacy_pdf_viewer feature flag in settings (in this codebase and in shared_configs).
 #  5. The reference to the feature flag and LegacyPdfComponent in app/viewers/embed/viewer/pdf_viewer.rb
 #  6. The app/stylesheets/pdf.scss file and references to it in package.json
 module Embed

--- a/app/components/embed/pdf_component.html.erb
+++ b/app/components/embed/pdf_component.html.erb
@@ -1,10 +1,14 @@
 <%= render Embed::CompanionWindowsComponent.new(viewer:, stimulus_controller: 'file-auth') do |component| %>
   <% component.with_header_button do %>
+    <%# chromium has a bug preventing the esc key from exiting full screen in some situations, see
+        https://issues.chromium.org/issues/40131988 and https://github.com/sul-dlss/sul-embed/issues/2162 %>
+    <% unless component.requested_by_chromium? %>
       <button
         aria-label="Full screen"
         class="btn sul-i-expand-1 sul-fullscreen-button"
         id="full-screen-button">
       </button>
+    <% end %>
   <% end %>
   <% component.with_body do %>
     <div class="sul-embed-body" style="width: 100%">

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -43,7 +43,7 @@ collections_to_show_attribution:
 analytics_debug: true
 min_files_to_search_default: 10
 enabled_features:
-  legacy_pdf_viewer: true # true shows the PDF.js based PDF viewer, false uses <object> tag for browser PDF rendering
+  legacy_pdf_viewer: false # true shows the PDF.js based PDF viewer, false uses <object> tag for browser PDF rendering
 
 language_subtag_registry:
   path: vendor/data/language-subtag-registry

--- a/spec/components/embed/companion_windows_component_spec.rb
+++ b/spec/components/embed/companion_windows_component_spec.rb
@@ -3,9 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Embed::CompanionWindowsComponent, type: :component do
+  subject(:companion_windows_component) { described_class.new(viewer:) }
+
   before do
     allow(embed_request).to receive(:purl_object).and_return(purl_object)
-    render_inline(described_class.new(viewer:))
+    render_inline(companion_windows_component)
   end
 
   let(:embed_request) { Embed::Request.new({}) }
@@ -30,5 +32,33 @@ RSpec.describe Embed::CompanionWindowsComponent, type: :component do
     expect(page).to have_content 'About this item'
     expect(page).to have_content 'Media content'
     expect(page).to have_content 'Rights'
+  end
+
+  describe 'requested_by_chromium?' do
+    before { vc_test_request.headers['User-Agent'] = user_agent_string }
+
+    context 'with a realistic sample Firefox user agent string' do
+      let(:user_agent_string) { 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:127.0) Gecko/20100101 Firefox/127.0' }
+
+      it 'returns false' do
+        expect(companion_windows_component.requested_by_chromium?).to be false
+      end
+    end
+
+    context 'with a realistic sample Chrome user agent string' do
+      let(:user_agent_string) { 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36' }
+
+      it 'returns true' do
+        expect(companion_windows_component.requested_by_chromium?).to be true
+      end
+    end
+
+    context 'with a realistic sample Edge user agent string' do
+      let(:user_agent_string) { 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 Edg/126.0.0.0' }
+
+      it 'returns true' do
+        expect(companion_windows_component.requested_by_chromium?).to be true
+      end
+    end
   end
 end

--- a/spec/components/embed/pdf_component_spec.rb
+++ b/spec/components/embed/pdf_component_spec.rb
@@ -3,13 +3,34 @@
 require 'rails_helper'
 
 RSpec.describe Embed::PdfComponent, type: :component do
-  pending "add some examples to (or delete) #{__FILE__}"
+  include PurlFixtures
 
-  # it "renders something useful" do
-  #   expect(
-  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
-  #   ).to include(
-  #     "Hello, components!"
-  #   )
-  # end
+  let(:url) { 'https://purl.stanford.edu/sq929fn8035' }
+  let(:embed_request) { Embed::Request.new(url:) }
+  let(:viewer) { Embed::ViewerFactory.new(embed_request).viewer }
+
+  before do
+    stub_request(:get, 'https://purl.stanford.edu/sq929fn8035.json')
+      .to_return(status: 200, body: pdf_public_json, headers: {})
+  end
+
+  it 'renders the full screen button by default' do
+    rendered_ng_doc_fragment = render_inline(described_class.new(viewer:))
+    expect(rendered_ng_doc_fragment.xpath('.//button[@id="full-screen-button" and @aria-label="Full screen"]').count).to eq(1)
+  end
+
+  context 'when the browser is chromium based' do
+    let(:companion_windows_component) { Embed::CompanionWindowsComponent.new(viewer:, stimulus_controller: 'file-auth') }
+
+    before do
+      allow(Embed::CompanionWindowsComponent).to receive(:new).with(viewer:, stimulus_controller: 'file-auth').and_return(companion_windows_component)
+      allow(companion_windows_component).to receive(:requested_by_chromium?).and_return(true)
+    end
+
+    it 'does not render the full screen button' do
+      rendered_ng_doc_fragment = render_inline(described_class.new(viewer:))
+      expect(rendered_ng_doc_fragment.xpath('.//button[@id="full-screen-button"]').count).to eq(0)
+      expect(rendered_ng_doc_fragment.xpath('.//button[@aria-label="Full screen"]').count).to eq(0)
+    end
+  end
 end

--- a/spec/features/pdf_viewer_spec.rb
+++ b/spec/features/pdf_viewer_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe 'PDF Viewer', :js do
     end
 
     it 'has working panels' do
+      skip 'native PDF viewer does not show panels' unless Settings.enabled_features.legacy_pdf_viewer
+
       expect(page).to have_css('.sul-embed-metadata-panel', visible: :all)
       within '.sul-embed-footer-toolbar' do
         first('button').click
@@ -28,7 +30,7 @@ RSpec.describe 'PDF Viewer', :js do
     let(:purl) { build(:purl, :document_no_download) }
 
     it 'renders the PDF viewer for documents with restriction message' do
-      expect(page).to have_css('.sul-embed-pdf')
+      expect(page).to have_css('.sul-embed-pdf') if Settings.enabled_features.legacy_pdf_viewer
       expect(page).to have_content('This item cannot be accessed online')
     end
   end

--- a/spec/fixtures/purl_fixtures.rb
+++ b/spec/fixtures/purl_fixtures.rb
@@ -475,4 +475,561 @@ module PurlFixtures # rubocop:disable Metrics/ModuleLength
       }
     JSON
   end
+
+  def pdf_public_json
+    <<~JSON
+    {
+      "cocinaVersion": "0.75.0",
+      "type": "https://cocina.sul.stanford.edu/models/document",
+      "externalIdentifier": "druid:sq929fn8035",
+      "label": "Fantasia Apocalyptica musical score (manuscript) : Four trumpets. Chapter 8",
+      "version": 5,
+      "access": {
+        "view": "world",
+        "download": "world",
+        "controlledDigitalLending": false,
+        "copyright": "Copyright (c) The Board of Trustees of the Leland Stanford Junior University. All rights reserved.",
+        "useAndReproductionStatement": "The materials are open for research use and may be used freely for non-commercial purposes with an attribution. For commercial permission requests, please contact the Stanford University Archives (universityarchives@stanford.edu)."
+      },
+      "administrative": {
+        "hasAdminPolicy": "druid:vk498gk9921",
+        "releaseTags": [
+          {
+            "who": "dhartwig",
+            "what": "collection",
+            "date": "2018-09-04T19:11:27.000+00:00",
+            "to": "Searchworks",
+            "release": true
+          }
+        ]
+      },
+      "description": {
+        "title": [
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Fantasia Apocalyptica musical score (manuscript)",
+                "type": "main title",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Four trumpets",
+                "type": "subtitle",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Chapter 8",
+                "type": "part number",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [
+          {
+            "name": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Knuth, Donald Ervin, 1938-",
+                "uri": "http://id.loc.gov/authorities/names/n79135509",
+                "identifier": [],
+                "source": {
+                  "code": "naf",
+                  "uri": "http://id.loc.gov/authorities/names/",
+                  "note": []
+                },
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "type": "person",
+            "status": "primary",
+            "role": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Composer",
+                "code": "cmp",
+                "uri": "http://id.loc.gov/vocabulary/relators/cmp",
+                "identifier": [],
+                "source": {
+                  "code": "marcrelator",
+                  "uri": "http://id.loc.gov/vocabulary/relators/",
+                  "note": []
+                },
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "identifier": [],
+            "note": [],
+            "parallelContributor": []
+          }
+        ],
+        "event": [
+          {
+            "structuredValue": [],
+            "type": "production",
+            "displayLabel": "Place of creation",
+            "date": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "2018-08-08",
+                "type": "creation",
+                "status": "primary",
+                "encoding": {
+                  "code": "w3cdtf",
+                  "note": []
+                },
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "contributor": [],
+            "location": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Piteå (Sweden)",
+                "code": "sw",
+                "uri": "http://id.loc.gov/authorities/names/n80162583",
+                "identifier": [],
+                "source": {
+                  "code": "marccountry",
+                  "uri": "http://id.loc.gov/authorities/names/",
+                  "note": []
+                },
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "identifier": [],
+            "note": [],
+            "parallelEvent": []
+          }
+        ],
+        "form": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "scores",
+            "type": "genre",
+            "uri": "http://vocab.getty.edu/aat/300026427",
+            "identifier": [],
+            "source": {
+              "code": "aat",
+              "uri": "http://vocab.getty.edu/aat",
+              "note": []
+            },
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "text",
+            "type": "resource type",
+            "identifier": [],
+            "source": {
+              "value": "MODS resource types",
+              "note": []
+            },
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "manuscripts",
+            "type": "form",
+            "uri": "http://vocab.getty.edu/aat/300028569",
+            "identifier": [],
+            "source": {
+              "code": "aat",
+              "uri": "http://vocab.getty.edu/aat",
+              "note": []
+            },
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "access",
+            "type": "reformatting quality",
+            "identifier": [],
+            "source": {
+              "value": "MODS reformatting quality terms",
+              "note": []
+            },
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "application/pdf",
+            "type": "media type",
+            "identifier": [],
+            "source": {
+              "value": "IANA media types",
+              "note": []
+            },
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "1 text file",
+            "type": "extent",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "reformatted digital",
+            "type": "digital origin",
+            "identifier": [],
+            "source": {
+              "value": "MODS digital origin terms",
+              "note": []
+            },
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "geographic": [],
+        "language": [
+          {
+            "appliesTo": [],
+            "code": "eng",
+            "groupedValue": [],
+            "note": [],
+            "parallelValue": [],
+            "source": {
+              "code": "iso639-2b",
+              "uri": "http://id.loc.gov/vocabulary/iso639-2",
+              "note": []
+            },
+            "structuredValue": [],
+            "uri": "http://id.loc.gov/vocabulary/iso639-2/eng",
+            "value": "English"
+          }
+        ],
+        "note": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Fantasia Apocalyptica is a multimedia work for pipe organ, accompanied by several video tracks. It can be regarded as a somewhat literal translation of the Biblical book of Revelation into music.",
+            "identifier": [],
+            "displayLabel": "Abstract",
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "identifier": [],
+        "subject": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Apocalypse in music",
+            "type": "topic",
+            "uri": "http://id.loc.gov/authorities/subjects/sh2011005782",
+            "identifier": [],
+            "source": {
+              "code": "lcsh",
+              "uri": "http://id.loc.gov/authorities/subjects/",
+              "note": []
+            },
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "access": {
+          "url": [],
+          "physicalLocation": [
+            {
+              "structuredValue": [],
+              "parallelValue": [],
+              "groupedValue": [],
+              "value": "SC0097",
+              "type": "shelf locator",
+              "identifier": [],
+              "note": [],
+              "appliesTo": []
+            }
+          ],
+          "digitalLocation": [],
+          "accessContact": [
+            {
+              "structuredValue": [],
+              "parallelValue": [],
+              "groupedValue": [],
+              "value": "Stanford University. Libraries. Department of Special Collections and University Archives",
+              "type": "repository",
+              "uri": "http://id.loc.gov/authorities/names/no2014019980",
+              "identifier": [],
+              "source": {
+                "code": "naf",
+                "note": []
+              },
+              "note": [],
+              "valueLanguage": {
+                "code": "eng",
+                "note": [],
+                "source": {
+                  "code": "iso639-2b",
+                  "note": []
+                },
+                "valueScript": {
+                  "code": "Latn",
+                  "note": [],
+                  "source": {
+                    "code": "iso15924",
+                    "note": []
+                  }
+                }
+              },
+              "appliesTo": []
+            }
+          ],
+          "digitalRepository": [],
+          "note": []
+        },
+        "relatedResource": [
+          {
+            "type": "part of",
+            "displayLabel": "Finding Aid",
+            "title": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Donald E. Knuth Papers (SC0097)",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "contributor": [],
+            "event": [],
+            "form": [],
+            "language": [],
+            "note": [],
+            "identifier": [],
+            "subject": [],
+            "access": {
+              "url": [
+                {
+                  "structuredValue": [],
+                  "parallelValue": [],
+                  "groupedValue": [],
+                  "value": "https://oac.cdlib.org/findaid/ark:/13030/kt2k4035s1/",
+                  "identifier": [],
+                  "note": [],
+                  "appliesTo": []
+                }
+              ],
+              "physicalLocation": [],
+              "digitalLocation": [],
+              "accessContact": [],
+              "digitalRepository": [],
+              "note": []
+            },
+            "relatedResource": []
+          },
+          {
+            "type": "in series",
+            "displayLabel": "2018-132",
+            "title": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Accession",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "contributor": [],
+            "event": [],
+            "form": [],
+            "language": [],
+            "note": [],
+            "identifier": [],
+            "subject": [],
+            "relatedResource": []
+          }
+        ],
+        "marcEncodedData": [],
+        "adminMetadata": {
+          "contributor": [
+            {
+              "name": [
+                {
+                  "structuredValue": [],
+                  "parallelValue": [],
+                  "groupedValue": [],
+                  "code": "CSt",
+                  "uri": "http://id.loc.gov/vocabulary/organizations/cst",
+                  "identifier": [],
+                  "source": {
+                    "code": "marcorg",
+                    "uri": "http://id.loc.gov/vocabulary/organizations",
+                    "note": []
+                  },
+                  "note": [],
+                  "appliesTo": []
+                }
+              ],
+              "type": "organization",
+              "role": [
+                {
+                  "structuredValue": [],
+                  "parallelValue": [],
+                  "groupedValue": [],
+                  "value": "original cataloging agency",
+                  "identifier": [],
+                  "note": [],
+                  "appliesTo": []
+                }
+              ],
+              "identifier": [],
+              "note": [],
+              "parallelContributor": []
+            }
+          ],
+          "event": [],
+          "language": [
+            {
+              "appliesTo": [],
+              "code": "eng",
+              "groupedValue": [],
+              "note": [],
+              "parallelValue": [],
+              "source": {
+                "code": "iso639-2b",
+                "uri": "http://id.loc.gov/vocabulary/iso639-2",
+                "note": []
+              },
+              "status": "primary",
+              "structuredValue": [],
+              "uri": "http://id.loc.gov/vocabulary/iso639-2/eng",
+              "value": "English"
+            }
+          ],
+          "note": [
+            {
+              "structuredValue": [],
+              "parallelValue": [],
+              "groupedValue": [],
+              "value": "human prepared",
+              "type": "record origin",
+              "identifier": [],
+              "note": [],
+              "appliesTo": []
+            }
+          ],
+          "metadataStandard": [],
+          "identifier": []
+        },
+        "purl": "https://purl.stanford.edu/sq929fn8035"
+      },
+      "identification": {
+        "catalogLinks": [],
+        "sourceId": "sul:SC0097_2018-123_FA_ms_08"
+      },
+      "structural": {
+        "contains": [
+          {
+            "type": "https://cocina.sul.stanford.edu/models/resources/document",
+            "externalIdentifier": "https://cocina.sul.stanford.edu/fileSet/sq929fn8035-sq929fn8035_1",
+            "label": "File 1",
+            "version": 4,
+            "structural": {
+              "contains": [
+                {
+                  "type": "https://cocina.sul.stanford.edu/models/file",
+                  "externalIdentifier": "https://cocina.sul.stanford.edu/file/sq929fn8035-sq929fn8035_1/SC0097_2018-123_FA_ms_08.pdf",
+                  "label": "SC0097_2018-123_FA_ms_08.pdf",
+                  "filename": "SC0097_2018-123_FA_ms_08.pdf",
+                  "size": 12150692,
+                  "version": 4,
+                  "hasMimeType": "application/pdf",
+                  "hasMessageDigests": [
+                    {
+                      "type": "sha1",
+                      "digest": "dd2ff01460fb2e1d8d0aaba542c243317da07e69"
+                    },
+                    {
+                      "type": "md5",
+                      "digest": "7e0c891151af86c47b5abe2028cb0d50"
+                    }
+                  ],
+                  "access": {
+                    "view": "world",
+                    "download": "world",
+                    "controlledDigitalLending": false
+                  },
+                  "administrative": {
+                    "publish": true,
+                    "sdrPreserve": true,
+                    "shelve": true
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "hasMemberOrders": [],
+        "isMemberOf": [
+          "druid:yz684ny6367"
+        ]
+      },
+      "created": "2023-01-24T00:45:39.000+00:00",
+      "modified": "2023-01-24T00:45:39.000+00:00",
+      "lock": "druid:sq929fn8035=0"
+    }
+    JSON
+  end
 end


### PR DESCRIPTION
closes #2162

firefox:
![Screenshot 2024-06-20 at 11 58 26 AM](https://github.com/sul-dlss/sul-embed/assets/7741604/870b904c-f6e2-44f8-82e0-3e9eb6ca298d)

chrome:
![Screenshot 2024-06-20 at 12 04 13 PM](https://github.com/sul-dlss/sul-embed/assets/7741604/57799d22-a1c6-4be9-943e-7d6ffa65ec0a)

edge (uses chromium as its rendering engine, and has the same problem with the esc key not working to exit from full screen):
![Screenshot 2024-06-20 at 12 04 47 PM](https://github.com/sul-dlss/sul-embed/assets/7741604/a9e12ecb-3df0-4147-8050-e88ea9862df7)
