### PR TITLE
add in leaflet opacity slider, update code to accomodate geojson

### DIFF
--- a/app/assets/stylesheets/companion_window.scss
+++ b/app/assets/stylesheets/companion_window.scss
@@ -235,7 +235,7 @@
   }
 
   .header-background {
-    background: #f4f4f4;
+    background: $color-fog-light;
     display: flex;
     flex-shrink: 0;
     padding-left: var(--drawer-content-padding);

--- a/app/assets/stylesheets/geo.scss
+++ b/app/assets/stylesheets/geo.scss
@@ -67,3 +67,92 @@
     // scss-lint:enable SelectorDepth
   }
 }
+
+.opacity-control {
+  background-color: #a9acb1;
+  border-radius: 15px;
+  color: black;
+  font: bold 18px 'Lucida Console', Monaco, monospace;
+  display: block;
+  height: 200px;
+  left: 11px;
+  position: relative;
+  top: 15px;
+  width: 5px;
+
+  .opacity-handle {
+    background-color: #fff;
+    border-radius: 4px;
+    border: 1px solid #eee;
+    cursor: ns-resize;
+    font-size: 10px;
+    height: 26px;
+    left: -11px;
+    line-height: 26px;
+    position: absolute;
+    text-align: center;
+    top: 0;
+    width: 26px;
+    z-index: 20;
+    box-shadow: 0 1px 5px rgba(0,0,0,0.65);
+
+    &:hover {
+      background-color: $color-fog-light;
+    }
+  }
+
+  .opacity-arrow-up {
+    color: #aaa;
+    position: absolute;
+    top: -11px;
+    text-align: center;
+    width: 100%;
+
+    &:before {
+      content: '=';
+    }
+  }
+
+  .opacity-arrow-down {
+    bottom: -10px;
+    color: #aaa;
+    position: absolute;
+    text-align: center;
+    width: 100%;
+
+    &:before {
+      content: '=';
+    }
+  }
+
+  .opacity-bottom {
+    background-color: #017afd;
+    border-radius: 15px;
+    display: block;
+    height: 100%;
+    top: 30px;
+    left: 0px;
+    position: relative;
+    width: 5px;
+  }
+
+  // Area underneath slider to prevent unintentioned map clicks
+  .opacity-area {
+    padding: 14px;
+    cursor: default;
+    height: 200px;
+    left: -11px;
+    position: absolute;
+    top: 0px;
+    width: 20px;
+  }
+}
+
+.opacity-control.unselectable {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}

--- a/app/assets/stylesheets/palette.scss
+++ b/app/assets/stylesheets/palette.scss
@@ -2,6 +2,7 @@
 //   https://github.com/sul-dlss/sul_styles/blob/master/app/assets/stylesheets/sul-styles/su_web_colors.scss
 //   https://github.com/sul-dlss/sul_styles/blob/master/app/assets/stylesheets/sul-styles/su_primary_colors.scss
 $color-cardinal-red: #8c1515;
+$color-fog-light: #f4f4f4;
 // $color-dark-red: #820000;
 // $color-gray: #3f3c30;
 // $color-black: #000;

--- a/app/javascript/src/modules/geo_viewer.js
+++ b/app/javascript/src/modules/geo_viewer.js
@@ -1,235 +1,226 @@
-(function( global ) {
-  'use strict';
-  var Module = (function() {
-    var dataAttributes;
-    var map;
-    var $el;
+import './leaflet_opacity'
+export default {
+  isDefined: function (object) {
+    return typeof object !== 'undefined';
+  },
+  init: function (options) {
+    this.$el = jQuery('#sul-embed-geo-map');
+    this.dataAttributes = this.$el.data();
 
-    var isDefined = function(object) {
-       return typeof object !== 'undefined';
-    };
+    this.map = L.map('sul-embed-geo-map', options).fitBounds(this.dataAttributes.boundingBox);
 
-    return {
-      init: function(options) {
-        $el = jQuery('#sul-embed-geo-map');
-        dataAttributes = $el.data();
+    L.tileLayer('https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
+      maxZoom: 19,
+      attribution: '&copy; <a href="http://www.openstreetmap.org/copyrigh' +
+        't">OpenStreetMap</a>, Tiles courtesy of <a href="http://hot.open' +
+        'streetmap.org/" target="_blank" rel="noopener noreferrer">Humanitarian OpenStreetMap Team<' +
+        '/a>',
+    }).addTo(this.map);
 
-        map = L.map('sul-embed-geo-map', options).fitBounds(dataAttributes.boundingBox);
+    this.addVisualizationLayer();
 
-        L.tileLayer('https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
-          maxZoom: 19,
-          attribution: '&copy; <a href="http://www.openstreetmap.org/copyrigh' +
-            't">OpenStreetMap</a>, Tiles courtesy of <a href="http://hot.open' +
-            'streetmap.org/" target="_blank" rel="noopener noreferrer">Humanitarian OpenStreetMap Team<' +
-            '/a>',
-        }).addTo(map);
+    this.map.invalidateSize();
+  },
+  addVisualizationLayer: function () {
+    const dataAttributes = this.dataAttributes;
+    var hasWmsUrl = this.isDefined(dataAttributes.wmsUrl);
+    var hasLayers = this.isDefined(dataAttributes.layers);
+    var indexMapUrl = dataAttributes.indexMap;
 
-        Module.addVisualizationLayer();
-        map.invalidateSize();
-      },
-      addVisualizationLayer: function() {
-        var hasWmsUrl = isDefined(dataAttributes.wmsUrl);
-        var hasLayers = isDefined(dataAttributes.layers);
-        var indexMapUrl = dataAttributes.indexMap;
-
-        if (isDefined(indexMapUrl)) {
-          // Index map viewer
-          var geoJSONLayer;
-          var _this = this;
-          $.getJSON(indexMapUrl, function(data) {
-            geoJSONLayer = L.geoJson(data,
-              {
-                style: function(feature) {
-                  return _this.availabilityStyle(feature.properties.available);
-                },
-                onEachFeature: function(feature, layer) {
-                  // Add a hover label for the label property
-                  if (feature.properties.label !== null) {
-                    layer.bindTooltip(feature.properties.label);
-                  }
-                  // If it is available add clickable info
-                  if (feature.properties.available !== null) {
-                    layer.on('click', function(e) {
-                      _this.indexMapInspection(e);
-                    });
-                  }
-                },
-                // For point index maps, use circle markers
-                pointToLayer: function (feature, latlng) {
-                  return L.circleMarker(latlng);
-                }
-              }).addTo(map);
-              map.fitBounds(geoJSONLayer.getBounds());
-              Module.setupSidebar();
-          });
-        } else if (hasWmsUrl && hasLayers) {
-          // Feature inspection for public layers
-          L.tileLayer.wms(dataAttributes.wmsUrl, {
-              layers: dataAttributes.layers,
-              format: 'image/png',
-              transparent: true,
-              tiled: true
-          }).addTo(map);
-          Module.setupSidebar();
-          Module.setupFeatureInspection();
-        } else {
-          // Restricted layers
-          L.rectangle(dataAttributes.boundingBox, {color: '#0000FF', weight: 4})
-            .addTo(map);
-        }
-      },
-      availabilityStyle: function(availability) {
-        var style = {
-          radius: 4,
-          weight: 1,
-        };
-        // Style the colors based on availability
-        if (typeof(availability) === 'undefined') {
-          return style; // default Leaflet style colorings
-        }
-
-        if (availability) {
-          style.color = '#1eb300';
-        } else {
-          style.color = '#b3001e';
-        }
-        return style;
-      },
-      indexMapInfo(data) {
-        let output = '<div class="index-map-info">'
-        if (data.title)
-          output = output.concat(`<h3>${data.title}</h3>`)
-        output = output.concat("<div>")
-        if (data.thumbnailUrl)
-          output = output.concat(`<img src="${data.thumbnailUrl}" style="max-width: 100%; height: auto;" alt="">`)        
-        output = output.concat("<dl>")
-        if (data.websiteUrl)
-          output = output.concat(`<a target="_blank" href="${data.websiteUrl}">View this map</a>`)
-        if (data.downloadUrl)
-          output = output.concat(`<dt>Download</dt><dd><a target="_blank" href="${data.downloadUrl}">${data.downloadUrl}</a></dd>`)
-        if (data.recordIdentifier)
-          output = output.concat(`<dt>Record Identifier</dt><dd><a target="_blank" href="${data.recordIdentifier}">${data.recordIdentifier}</a></dd>`)
-        if (data.label)
-          output = output.concat(`<dt>Label</dt><dd>${data.label}</dd>`)   
-        if (data.note)
-          output = output.concat(`<dt>Note</dt><dd>${data.note}</dd>`)   
-        return output.concat("</dl></div></div>")
-      },
-      indexMapInspection: function(e) {
-        var thumbDeferred = $.Deferred();
-        var data = e.target.feature.properties;
-        var _this = this;
-        $.when(thumbDeferred).done(function() {
-          _this.openSidebarWithContent(_this.indexMapInfo(data));
-        });
-
-        if (data.iiifUrl) {
-          $.getJSON(data.iiifUrl, function(manifestResponse) {
-            if (manifestResponse.thumbnail['@id'] !== null) {
-              data.thumbnailUrl = manifestResponse.thumbnail['@id'];
-              thumbDeferred.resolve();
+    if (this.isDefined(indexMapUrl)) {
+      // Index map viewer
+      var geoJSONLayer;
+      var _this = this;
+      $.getJSON(indexMapUrl, function (data) {
+        geoJSONLayer = L.geoJson(data,
+          {
+            style: function (feature) {
+              return _this.availabilityStyle(feature.properties.available);
+            },
+            onEachFeature: function (feature, layer) {
+              feature.properties.geoJSON = true;
+              // Add a hover label for the label property
+              if (feature.properties.label !== null) {
+                layer.bindTooltip(feature.properties.label);
+              }
+              // If it is available add clickable info
+              if (feature.properties.available !== null) {
+                layer.on('click', function (e) {
+                  _this.indexMapInspection(e);
+                });
+              }
+            },
+            // For point index maps, use circle markers
+            pointToLayer: function (feature, latlng) {
+              return L.circleMarker(latlng);
             }
-          });
-        } else {
+          }).addTo(_this.map);
+        _this.map.fitBounds(geoJSONLayer.getBounds());
+        _this.setupSidebar();
+        _this.map.addControl(new L.Control.LayerOpacity(geoJSONLayer));
+      });
+    } else if (hasWmsUrl && hasLayers) {
+      // Feature inspection for public layers
+      const layer = L.tileLayer.wms(dataAttributes.wmsUrl, {
+        layers: dataAttributes.layers,
+        format: 'image/png',
+        transparent: true,
+        opacity: .75,
+        tiled: true
+      })
+      layer.addTo(this.map);
+      this.setupSidebar();
+      this.setupFeatureInspection();
+      this.map.addControl(new L.Control.LayerOpacity(layer));
+    } else {
+      // Restricted layers
+      L.rectangle(dataAttributes.boundingBox, { color: '#0000FF', weight: 4 })
+        .addTo(this.map);
+    }
+  },
+  availabilityStyle: function (availability) {
+    var style = {
+      radius: 4,
+      weight: 1,
+    };
+    // Style the colors based on availability
+    if (typeof (availability) === 'undefined') {
+      return style; // default Leaflet style colorings
+    }
+
+    if (availability) {
+      style.color = '#1eb300';
+    } else {
+      style.color = '#b3001e';
+    }
+    return style;
+  },
+  indexMapInfo(data) {
+    let output = '<div class="index-map-info">'
+    if (data.title)
+      output = output.concat(`<h3>${data.title}</h3>`)
+    output = output.concat("<div>")
+    if (data.thumbnailUrl)
+      output = output.concat(`<img src="${data.thumbnailUrl}" style="max-width: 100%; height: auto;" alt="">`)
+    output = output.concat("<dl>")
+    if (data.websiteUrl)
+      output = output.concat(`<a target="_blank" href="${data.websiteUrl}">View this map</a>`)
+    if (data.downloadUrl)
+      output = output.concat(`<dt>Download</dt><dd><a target="_blank" href="${data.downloadUrl}">${data.downloadUrl}</a></dd>`)
+    if (data.recordIdentifier)
+      output = output.concat(`<dt>Record Identifier</dt><dd><a target="_blank" href="${data.recordIdentifier}">${data.recordIdentifier}</a></dd>`)
+    if (data.label)
+      output = output.concat(`<dt>Label</dt><dd>${data.label}</dd>`)
+    if (data.note)
+      output = output.concat(`<dt>Note</dt><dd>${data.note}</dd>`)
+    return output.concat("</dl></div></div>")
+  },
+  indexMapInspection: function (e) {
+    var thumbDeferred = $.Deferred();
+    var data = e.target.feature.properties;
+    var _this = this;
+    $.when(thumbDeferred).done(function () {
+      _this.openSidebarWithContent(_this.indexMapInfo(data));
+    });
+
+    if (data.iiifUrl) {
+      $.getJSON(data.iiifUrl, function (manifestResponse) {
+        if (manifestResponse.thumbnail['@id'] !== null) {
+          data.thumbnailUrl = manifestResponse.thumbnail['@id'];
           thumbDeferred.resolve();
         }
-      },
-      setupFeatureInspection: function() {
-        var _this = this;
-        map.on('click', function(e) {
-          // Return early if original target is not actually the map
-          if (e.originalEvent.target.id !== 'sul-embed-geo-map') {
+      });
+    } else {
+      thumbDeferred.resolve();
+    }
+  },
+  setupFeatureInspection: function () {
+    var _this = this;
+    this.map.on('click', function (e) {
+      // Return early if original target is not actually the map
+      if (e.originalEvent.target.id !== 'sul-embed-geo-map') {
+        return;
+      }
+      var wmsoptions = {
+        LAYERS: _this.dataAttributes.layers,
+        BBOX: _this.map.getBounds().toBBoxString(),
+        WIDTH: Math.round($('#sul-embed-geo-map').width()),
+        HEIGHT: Math.round($('#sul-embed-geo-map').height()),
+        QUERY_LAYERS: _this.dataAttributes.layers,
+        X: Math.round(e.containerPoint.x),
+        Y: Math.round(e.containerPoint.y),
+        SERVICE: 'WMS',
+        VERSION: '1.1.1',
+        REQUEST: 'GetFeatureInfo',
+        STYLES: '',
+        SRS: 'EPSG:4326',
+        EXCEPTIONS: 'application/json',
+        INFO_FORMAT: 'application/json'
+      };
+      $.ajax({
+        type: 'GET',
+        url: _this.dataAttributes.wmsUrl,
+        data: wmsoptions,
+        success: function (data) {
+          // Handle the case where GeoServer returns a 200 but with an exception;
+          if (data.exceptions && data.exceptions.length > 0) {
             return;
           }
-          var wmsoptions = {
-            LAYERS: dataAttributes.layers,
-            BBOX: map.getBounds().toBBoxString(),
-            WIDTH: Math.round($('#sul-embed-geo-map').width()),
-            HEIGHT: Math.round($('#sul-embed-geo-map').height()),
-            QUERY_LAYERS: dataAttributes.layers,
-            X: Math.round(e.containerPoint.x),
-            Y: Math.round(e.containerPoint.y),
-            SERVICE: 'WMS',
-            VERSION: '1.1.1',
-            REQUEST: 'GetFeatureInfo',
-            STYLES: '',
-            SRS: 'EPSG:4326',
-            EXCEPTIONS: 'application/json',
-            INFO_FORMAT: 'application/json'
-          };
-          $.ajax({
-            type: 'GET',
-            url: dataAttributes.wmsUrl,
-            data: wmsoptions,
-            success: function(data) {
-              // Handle the case where GeoServer returns a 200 but with an exception;
-              if (data.exceptions && data.exceptions.length > 0) {
-                return;
-              }
-              var html = '<dl class="inline-flex">';
-              $.each(data.features, function(i, val) {
-                Object.keys(val.properties).forEach(function(key) {
-                  html += L.Util.template('<dt>{k}</dt><dd>{v}</dd>', {k: key, v: val.properties[key]});
-                });
-              });
-              html += '</dl>';
-              _this.openSidebarWithContent(html);
-            }
+          var html = '<dl class="inline-flex">';
+          $.each(data.features, function (i, val) {
+            Object.keys(val.properties).forEach(function (key) {
+              html += L.Util.template('<dt>{k}</dt><dd>{v}</dd>', { k: key, v: val.properties[key] });
+            });
           });
-        });
-      },
-      openSidebarWithContent: function(html) {
-        $el
-          .find('.sul-embed-geo-sidebar')
-          .removeClass('collapsed')
-          .find('.sul-embed-geo-sidebar-content')
-          .html(html)
-          .slideDown(400)
-          .css({'height': map.getSize().y - 90})
-          .attr('aria-hidden', false);
-      },
-      geoSidebar: function() {
-        return `<div class="sul-embed-geo-sidebar">
+          html += '</dl>';
+          _this.openSidebarWithContent(html);
+        }
+      });
+    });
+  },
+  openSidebarWithContent: function (html) {
+    this.$el
+      .find('.sul-embed-geo-sidebar')
+      .removeClass('collapsed')
+      .find('.sul-embed-geo-sidebar-content')
+      .html(html)
+      .slideDown(400)
+      .css({ 'height': this.map.getSize().y - 90 })
+      .attr('aria-hidden', false);
+  },
+  geoSidebar: function () {
+    return `<div class="sul-embed-geo-sidebar">
                   <div class="sul-embed-geo-sidebar-header">
                     <h3>Features</h3>
                     <i class="sul-i-arrow-up-8"></i>
                   </div>
                   <div class="sul-embed-geo-sidebar-content">Click the map to inspect features.</div>
                 </div>`
-      },
-      setupSidebar: function() {
-        L.control.custom({
-          position: 'topright',
-          content: this.geoSidebar(),
-          classes: '',
-          events: {
-            click: function(e) {
-              // When clicking outside of icon
-              if (e.target.localName !== 'i') {
-                return;
-              }
-              // When bar is not collapsed
-              var $container = $(e.target).parent().parent();
-              if (!$container.hasClass('collapsed')) {
-                $('.sul-embed-geo-sidebar-content').slideUp(400, function() {
-                  $container.addClass('collapsed');
-                }).attr('aria-hidden', true);
-              } else {
-                $('.sul-embed-geo-sidebar-content').slideDown(400, function() {
-                  $container.removeClass('collapsed');
-                }).attr('aria-hidden', false);
-              }
-            }
+  },
+  setupSidebar: function () {
+    L.control.custom({
+      position: 'topright',
+      content: this.geoSidebar(),
+      classes: '',
+      events: {
+        click: function (e) {
+          // When clicking outside of icon
+          if (e.target.localName !== 'i') {
+            return;
           }
-        }).addTo(map);
-      },
-    };
-  })();
-
-  // Basic support of CommonJS module for import into test
-  if (typeof exports === "object") {
-    module.exports = Module;
-  }
-
-  global.GeoViewer = Module;
-})(this || {});
+          // When bar is not collapsed
+          var $container = $(e.target).parent().parent();
+          if (!$container.hasClass('collapsed')) {
+            $('.sul-embed-geo-sidebar-content').slideUp(400, function () {
+              $container.addClass('collapsed');
+            }).attr('aria-hidden', true);
+          } else {
+            $('.sul-embed-geo-sidebar-content').slideDown(400, function () {
+              $container.removeClass('collapsed');
+            }).attr('aria-hidden', false);
+          }
+        }
+      }
+    }).addTo(this.map);
+  },
+};

--- a/app/javascript/src/modules/leaflet_opacity.js
+++ b/app/javascript/src/modules/leaflet_opacity.js
@@ -1,0 +1,105 @@
+// Adopts the Mapbox opacity control into a Leaflet plugin
+import L from "leaflet";
+
+!function(global) {
+  'use strict';
+
+  L.Control.LayerOpacity = L.Control.extend({
+    initialize: function(layer) {
+      var options = { position: 'topleft' };
+
+      // check if layer is actually a layer group
+      if (typeof layer.getLayers !== 'undefined') {
+        const layers = layer.getLayers();
+        // Check if geoJSON. Layer control is different between geoJSON and WMS layer
+        this.geoJSON = layers[0].feature.properties.geoJSON;
+
+        // add first layer from layer group to options
+        options.layer = layers[0];
+        if (this.geoJSON){ options.layers = layers; }
+      } else {
+
+        // add layer to options
+        options.layer = layer;
+      }
+
+      L.Util.setOptions(this, options);
+    },
+
+    onAdd: function(map) {
+      var container = L.DomUtil.create('div', 'opacity-control unselectable'),
+        controlArea = L.DomUtil.create('div', 'opacity-area', container),
+        handle = L.DomUtil.create('div', 'opacity-handle', container),
+        handleArrowUp = L.DomUtil.create('div', 'opacity-arrow-up', handle),
+        handleText = L.DomUtil.create('div', 'opacity-text', handle),
+        handleArrowDown = L.DomUtil.create('div', 'opacity-arrow-down', handle),
+        bottom = L.DomUtil.create('div', 'opacity-bottom', container);
+
+      L.DomEvent.stopPropagation(container);
+      L.DomEvent.disableClickPropagation(container);
+
+      this.setListeners(handle, bottom, handleText);
+      const opacity = this.geoJSON ? this.options.layer.options.fillOpacity : this.options.layer.options.opacity;
+      const opacityPercentage = parseInt(opacity * 100);
+      handle.style.top = `calc(100% - ${opacityPercentage}% - 12px)`;
+      bottom.style.top = `calc(100% - ${opacityPercentage}%)`;
+      bottom.style.height = `${opacityPercentage}%`;
+      handle.setAttribute("tabindex", "0")
+      handleText.innerHTML = opacityPercentage + '%';
+      return container;
+    },
+
+    updateMapOpacity: function(opacity) {
+      if (this.geoJSON) {
+        this.options.layers.forEach((element) => element.setStyle({'fillOpacity': opacity}));
+      } else {
+        this.options.layer.setOpacity(opacity);
+      }
+    },
+
+    setListeners: function(handle, bottom, handleText) {
+      var _this = this,
+        start = false,
+        startTop;
+      L.DomEvent.on(document, 'mousemove', function(e) {
+        if (!start) return;
+        var percentInverse = Math.max(0, Math.min(200, startTop + parseInt(e.clientY, 10) - start)) / 2;
+        handle.style.top = ((percentInverse * 2) - 13) + 'px';
+        handleText.innerHTML = Math.round((1 - (percentInverse / 100)) * 100) + '%';
+        bottom.style.height = Math.max(0, (((100 - percentInverse) * 2) - 13)) + 'px';
+        bottom.style.top = Math.min(200, (percentInverse * 2) + 13) + 'px';
+        _this.updateMapOpacity((1 - (percentInverse / 100)))
+      });
+
+      L.DomEvent.on(handle, 'keydown', function(e) {
+        const opacity = _this.geoJSON ? _this.options.layer.style.fillOpacity : _this.options.layer.options.opacity;
+        const step = 1;
+        var newOpacity;
+        if (e.key == 'ArrowDown'){
+          newOpacity = opacity * 100 - step;
+        } else if (e.key == 'ArrowUp') {
+          newOpacity = opacity * 100 + step;
+        } else {
+          return;
+        }
+        if (newOpacity > 100 || newOpacity < 0) { return; }
+        newOpacity = Math.round(newOpacity)
+        handle.style.top = `calc(100% - ${newOpacity}% - 12px)`;
+        handleText.innerHTML = newOpacity + "%";
+        bottom.style.height = newOpacity + "%";
+        bottom.style.top = `calc(100% - ${newOpacity}%)`;
+        _this.updateMapOpacity(newOpacity / 100)
+      });
+
+      L.DomEvent.on(handle, 'mousedown', function(e) {
+        start = parseInt(e.clientY, 10);
+        startTop = handle.offsetTop - 12;
+        return false;
+      });
+
+      L.DomEvent.on(document, 'mouseup', function(e) {
+        start = null;
+      });
+    }
+  });
+}(this);

--- a/spec/javascripts/geo/geo_viewer_spec.js
+++ b/spec/javascripts/geo/geo_viewer_spec.js
@@ -1,4 +1,4 @@
-const GeoViewer = require('../../../app/javascript/src/modules/geo_viewer.js');
+import GeoViewer from '../../../app/javascript/src/modules/geo_viewer.js';
 
 describe('geo_viewer.js', () => {
   describe('loads and makes available modules', () => {


### PR DESCRIPTION
This PR:

1. Moves var Module = (function()  to export default so we can import leaflet_opacity (when I tried with var Module I was unable to import files
2. Updates the opacity on the WMS layer to 75%
3. adds and opacity slider.

**When looking at the file changes, turning on hide whitespace will make the changes more clear. I had to fix the tabbing with change 1**


Closes #254 
<img width="880" alt="Screenshot 2024-07-09 at 1 24 08 PM" src="https://github.com/sul-dlss/sul-embed/assets/19173991/846b5400-dcf8-4923-81d0-53c3877048a3">
<img width="890" alt="Screenshot 2024-07-09 at 1 23 59 PM" src="https://github.com/sul-dlss/sul-embed/assets/19173991/195771e4-3df3-4b53-baf4-d4a33244ffc8">

