### PR TITLE
move geo color coding to settings.yml

### DIFF
--- a/app/javascript/src/modules/geo_viewer.js
+++ b/app/javascript/src/modules/geo_viewer.js
@@ -91,9 +91,9 @@ export default {
     }
 
     if (availability) {
-      style.color = '#1eb300';
+      style.color = this.dataAttributes.geoViewerColors.available;
     } else {
-      style.color = '#b3001e';
+      style.color = this.dataAttributes.geoViewerColors.unavailable;
     }
     return style;
   },
@@ -188,7 +188,7 @@ export default {
     var opacity = this.layer ? this.layer.options.opacity : data.options.fillOpacity ? data.options.fillOpacity : data.options.opacity;
     var geoJSON = false;
     var layer;
-    var color = 'blue';
+    var color = this.dataAttributes.geoViewerColors.selected;
     if (data._latlngs) {
       layer = L.polygon(data._latlngs, {
         color: color,

--- a/app/viewers/embed/viewer/geo.rb
+++ b/app/viewers/embed/viewer/geo.rb
@@ -21,6 +21,7 @@ module Embed
           options['data-layers'] = "druid:#{@purl_object.druid}"
         end
         options['data-index-map'] = index_map.file_url if index_map?
+        options['data-geo-viewer-colors'] = Settings.geo_viewer_colors.to_json
         options
       end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,6 +8,10 @@ iiif_info_url: "https://library.stanford.edu/iiif/viewers"
 enable_media_viewer?: <%= true %>
 geo_external_url: "https://earthworks.stanford.edu/catalog/stanford-"
 geo_wms_url: "https://geowebservices.stanford.edu/geoserver/wms/"
+geo_viewer_colors:
+  selected: 'blue'
+  available: '#1eb300'
+  unavailable: '#b3001e'
 resource_types_that_contain_thumbnails:
   - audio
   - file


### PR DESCRIPTION
1. This should make updating the colors for https://github.com/sul-dlss/earthworks/issues/1094 easier, and make updating in future easier
2. Matches how earthworks sets colors in settings (less complicated due to the number of maps we handle)
3. Doesn't require users to dig into the code to find how to update these colors.