### PR TITLE
fix point not having icon

### DIFF
--- a/app/javascript/src/modules/geo_viewer.js
+++ b/app/javascript/src/modules/geo_viewer.js
@@ -197,7 +197,20 @@ export default {
         fillOpacity: opacity
       })
     } else {
-      layer = L.geoJSON(data, {color: color, opacity: opacity})
+      layer = L.geoJSON(data, {
+        color: color,
+        opacity: opacity,
+        pointToLayer: function(feature, latlng) {
+          return L.circleMarker(latlng, {
+            radius: 8,
+            fillColor: color,
+            color: color,
+            weight: 1,
+            opacity: opacity,
+            fillOpacity: opacity
+          });
+        }
+      })
       geoJSON = true;
     }
     layer.customProperty = { 'addToOpacitySlider': true, geoJSON: geoJSON };


### PR DESCRIPTION
When you click on a section here: https://purl.stanford.edu/rn106gn9916 you will get a broken image because leaflet uses map marker icons by default for geojson points. This PR updates the point to use a circle.

<img width="1379" alt="Screenshot 2024-08-08 at 2 07 28 PM" src="https://github.com/user-attachments/assets/14b8016d-c933-452a-ad57-cce61be415f4">
