### PR TITLE
Remove extra margin around the file label

### DIFF
--- a/app/assets/stylesheets/file.scss
+++ b/app/assets/stylesheets/file.scss
@@ -125,5 +125,9 @@ body {
 
   .sul-embed-filename-cell {
     padding-right: 10px;
+
+    .tree-label {
+      margin: 0;
+    }
   }
 }

--- a/app/components/embed/file_row_component.html.erb
+++ b/app/components/embed/file_row_component.html.erb
@@ -8,13 +8,13 @@
       <div style="max-width: 95%; overflow-wrap: break-word;">
         <%= title %>
         <% if label %>
-          <p data-tree-role="label"><%= label %></p>
+          <p data-tree-role="label" class="tree-label"><%= label %></p>
         <% end %>
       </div>
     </div>
   </td>
   <td role="gridcell"><%= file_size_text%></td>
-  <td role="gridcell">    
+  <td role="gridcell">
     <% if download? %>
       <a href="<%= url %>" target='_blank' rel='noopener noreferrer' download>
         <i class='sul-i-download-3'></i>


### PR DESCRIPTION
This was caused by 07568d0f78fb429c2a2c46c3ae817ddc825dc927


Before:
![Screenshot 2024-08-12 at 4 01 34 PM](https://github.com/user-attachments/assets/481a05ab-e91f-4444-8d9f-26233144ee2d)

After:
<img width="579" alt="Screenshot 2024-08-13 at 8 01 23 AM" src="https://github.com/user-attachments/assets/55e79478-ed63-45c4-9257-8e71e1e10196">
