### PR TITLE
Change iiif link to https://library.stanford.edu/iiif

### DIFF
--- a/app/javascript/src/modules/m3_viewer.js
+++ b/app/javascript/src/modules/m3_viewer.js
@@ -43,7 +43,7 @@ export default {
             'https://embed.stanford.edu/iframe?url=https://purl.stanford.edu/$1',
           ],
         },
-        dragAndDropInfoLink: 'https://library.stanford.edu/iiif-viewers',
+        dragAndDropInfoLink: 'https://library.stanford.edu/iiif',
         shareLink: {
           enabled: true,
           manifestIdReplacePattern: [

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,7 +4,7 @@ purl_read_timeout: 20
 purl_conn_timeout: 2
 purl_feedback_email: "some-email-address@distribution-list-host.stanford.edu"
 stacks_url: "https://stacks.stanford.edu"
-iiif_info_url: "https://library.stanford.edu/iiif/viewers"
+iiif_info_url: "https://library.stanford.edu/iiif"
 enable_media_viewer?: <%= true %>
 geo_external_url: "https://earthworks.stanford.edu/catalog/stanford-"
 geo_wms_url: "https://geowebservices.stanford.edu/geoserver/wms/"


### PR DESCRIPTION
Fixes the IIIF link. See https://github.com/sul-dlss/SearchWorks/issues/4374