### PR TITLE
Leave room for the border to show

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -14,6 +14,7 @@ body {
 .sul-embed-container {
   background: $white-color;
   border: 1px solid $color-pantone-405;
+  box-sizing: border-box;
   color: $sul-font-color;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
box-sizing: border-box allows the border to be included in the height calculation.

Fixes #2245