### PR TITLE
make mediaplayer controls responsive

### DIFF
--- a/app/javascript/controllers/media_player_controller.js
+++ b/app/javascript/controllers/media_player_controller.js
@@ -4,7 +4,7 @@ import videojs from 'video.js';
 export default class extends Controller {
   initializeVideoJSPlayer() {
     this.element.classList.add('video-js', 'vjs-default-skin')
-    this.player = videojs(this.element.id)
+    this.player = videojs(this.element.id, {"responsive": true})
     this.player.on('loadedmetadata', () => {
       const event = new CustomEvent('media-loaded', { detail: this.player })
       window.dispatchEvent(event)


### PR DESCRIPTION
![Screenshot 2024-11-20 at 12 06 54 PM](https://github.com/user-attachments/assets/77647f1a-8598-4cfc-a1ba-7518cd078fbc)


When you resize purl to a smaller size the controls get cut off. This fixes that.


![Screenshot 2024-11-20 at 1 07 41 PM](https://github.com/user-attachments/assets/beaf1e7c-a668-4383-8a65-dee0133745cd)
