### PR TITLE
Stop running tests on ruby 3.3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["3.3", "3.4"]
+        ruby: ["3.4"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby


### PR DESCRIPTION
We've deployed version 3.4