### PR TITLE
Extract a separate stylesheet for the pdf viewer

### DIFF
--- a/app/assets/stylesheets/companion_window.css
+++ b/app/assets/stylesheets/companion_window.css
@@ -486,10 +486,6 @@
   }
 }
 
-.sul-embed-pdf {
-  min-height: 90vh;
-}
-
 .no-bullets {
   list-style-type: none;
 }

--- a/app/assets/stylesheets/pdf.css
+++ b/app/assets/stylesheets/pdf.css
@@ -1,0 +1,5 @@
+@import url("companion_window.css");
+
+.sul-embed-pdf {
+  min-height: 90vh;
+}

--- a/app/viewers/embed/viewer/pdf_viewer.rb
+++ b/app/viewers/embed/viewer/pdf_viewer.rb
@@ -12,7 +12,7 @@ module Embed
       end
 
       def stylesheet
-        'companion_window.css'
+        'pdf.css'
       end
 
       def pdf_files


### PR DESCRIPTION
This provides parity with the other viewers and doesn't polute the companion_window.css