### PR TITLE
Use i18n for text differences between viewer types

### DIFF
--- a/app/components/companion_windows_component.html.erb
+++ b/app/components/companion_windows_component.html.erb
@@ -43,7 +43,7 @@
 
         <% if render_content_list_panel? %>
           <section id="object-content" role="tabpanel">
-            <%= render ContentListComponent.new(viewer:, heading: viewer.content_heading) %>
+            <%= render ContentListComponent.new(viewer:) %>
           </section>
         <% end %>
 

--- a/app/components/content_list_component.rb
+++ b/app/components/content_list_component.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 class ContentListComponent < ViewComponent::Base
-  def initialize(viewer:, heading:)
+  def initialize(viewer:)
     @viewer = viewer
-    @heading = heading
   end
 
-  attr_reader :viewer, :heading
+  attr_reader :viewer
+
+  def heading
+    t('content_list_heading', scope: viewer.i18n_path)
+  end
 end

--- a/app/viewers/embed/viewer/common_viewer.rb
+++ b/app/viewers/embed/viewer/common_viewer.rb
@@ -106,8 +106,12 @@ module Embed
         !embed_request.hide_title?
       end
 
+      def i18n_path
+        "viewers.#{self.class.name.demodulize.underscore}"
+      end
+
       def iframe_title
-        I18n.t("viewers.#{self.class.name.demodulize.underscore}.title", default: 'Viewer')
+        I18n.t('title', default: 'Viewer', scope: i18n_path)
       end
 
       private

--- a/app/viewers/embed/viewer/media.rb
+++ b/app/viewers/embed/viewer/media.rb
@@ -11,11 +11,6 @@ module Embed
         'media'
       end
 
-      # The heading shown in the Content List of the CompanionWindowComponent
-      def content_heading
-        'Media content'
-      end
-
       private
 
       def default_height

--- a/app/viewers/embed/viewer/pdf_viewer.rb
+++ b/app/viewers/embed/viewer/pdf_viewer.rb
@@ -38,11 +38,6 @@ module Embed
         document_resource_files.first&.downloadable?
       end
 
-      # The heading shown in the Content List of the CompanionWindowComponent
-      def content_heading
-        'Contents'
-      end
-
       private
 
       def document_resource_files

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -32,7 +32,7 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations.
-  # config.i18n.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,12 +21,12 @@
 
 en:
   restrictions:
-    not_accessible: 'This item cannot be accessed online. See Access conditions for more information.'
-    logged_in: 'Logged in.'
+    not_accessible: "This item cannot be accessed online. See Access conditions for more information."
+    logged_in: "Logged in."
   date:
     formats:
-      sul: '%d-%b-%Y'
-      sul_was_long: '%d %B %Y'
+      sul: "%d-%b-%Y"
+      sul_was_long: "%d %B %Y"
   number:
     human:
       storage_units:
@@ -34,20 +34,22 @@ en:
           kb: kB # This is the SI unit for 10^3
   viewers:
     file:
-      title: 'File viewer'
+      title: "File viewer"
     geo:
-      title: 'Geospatial viewer'
+      title: "Geospatial viewer"
     m3_viewer:
-      title: 'Image viewer'
+      title: "Image viewer"
     media:
-      title: 'Media viewer'
+      title: "Media viewer"
+      content_list_heading: Media content
     pdf_viewer:
-      title: 'PDF viewer'
+      title: "PDF viewer"
+      content_list_heading: Contents
     model_viewer:
-      title: '3-D object viewer'
+      title: "3-D object viewer"
     was_seed:
-      title: 'File viewer'
+      title: "File viewer"
   download_files:
-    zero: 'No file available for download'
-    one: '1 file available for download'
-    other: '%{count} files available for download'
+    zero: "No file available for download"
+    one: "1 file available for download"
+    other: "%{count} files available for download"


### PR DESCRIPTION
because i18n is the built in solution for text labels, which we are already using extensively.  We don't need to maintain a separate way of doing this in the class.  Additionally, it's will become even more important as we implement new viewers (see https://github.com/sul-dlss/sul-embed/pull/2331).