### PR TITLE
Extract a DownloadDialogComponent

### DIFF
--- a/app/components/companion_windows_component.html.erb
+++ b/app/components/companion_windows_component.html.erb
@@ -79,26 +79,9 @@
     <button data-action="click->companion-window#closeModal">Close</button>
   </dialog>
 
-  <dialog aria-labelledby="download-modal-header" class="modal-container" data-companion-window-target="downloadModal" data-action="click->companion-window#handleBackdropClicks" id="download">
-    <header class="modal-header" id="download-modal-header">
-      Download
-    </header>
-
-    <section class='sul-embed-downloads'>
-      <% if downloadable_files.present? %>
-        <h3 class='sul-embed-options-label modal-subheader'>
-          Files
-        </h3>
-        <ul>
-          <%= render Download::FileListItemComponent.with_collection(downloadable_files, show_headers: show_headers?) %>
-        </ul>
-      <% else %>
-        <p>No downloads available</p>
-      <% end %>
-    </section>
-
-    <button data-action="click->companion-window#closeModal">Close</button>
-  </dialog>
+  <%= render Download::DialogComponent.new do %>
+    <%= render Download::AllFilesComponent.new(viewer:) %>
+  <% end %>
 
   <%= dialog %>
 </div>

--- a/app/components/companion_windows_component.rb
+++ b/app/components/companion_windows_component.rb
@@ -37,11 +37,4 @@ class CompanionWindowsComponent < ViewComponent::Base
 
     false
   end
-
-  # We use this in the download FileListComponent to determine if we need to group files.
-  # For example, if a media file has a caption or transcript
-  # we will want to group the caption with the media file.
-  def show_headers?
-    downloadable_files.any? { |file| file.caption? || file.transcript? }
-  end
 end

--- a/app/components/download/all_files_component.html.erb
+++ b/app/components/download/all_files_component.html.erb
@@ -1,0 +1,10 @@
+<% if downloadable_files.present? %>
+  <h3 class='sul-embed-options-label modal-subheader'>
+    Files
+  </h3>
+  <ul>
+    <%= render Download::FileListItemComponent.with_collection(downloadable_files, show_headers: show_headers?) %>
+  </ul>
+<% else %>
+  <p>No downloads available</p>
+<% end %>

--- a/app/components/download/all_files_component.rb
+++ b/app/components/download/all_files_component.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Download
+  class AllFilesComponent < ViewComponent::Base
+    # @param [#purl_object] viewer
+    def initialize(viewer:)
+      @viewer = viewer
+    end
+
+    attr_reader :viewer
+
+    delegate :purl_object, to: :viewer
+    delegate :downloadable_files, to: :purl_object
+
+    # Determine if we need to group files.
+    # For example, if a media file has a caption or transcript
+    # we will want to group the caption with the media file.
+    def show_headers?
+      downloadable_files.any? { |file| file.caption? || file.transcript? }
+    end
+  end
+end

--- a/app/components/download/dialog_component.html.erb
+++ b/app/components/download/dialog_component.html.erb
@@ -1,0 +1,11 @@
+  <dialog aria-labelledby="download-modal-header" class="modal-container" data-companion-window-target="downloadModal" data-action="click->companion-window#handleBackdropClicks" id="download">
+    <header class="modal-header" id="download-modal-header">
+      Download
+    </header>
+
+    <section class='sul-embed-downloads'>
+      <%= content %>
+    </section>
+
+    <button data-action="click->companion-window#closeModal">Close</button>
+  </dialog>

--- a/app/components/download/dialog_component.rb
+++ b/app/components/download/dialog_component.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Download
+  class DialogComponent < ViewComponent::Base
+  end
+end

--- a/spec/components/companion_windows_component_spec.rb
+++ b/spec/components/companion_windows_component_spec.rb
@@ -37,30 +37,6 @@ RSpec.describe CompanionWindowsComponent, type: :component do
     expect(page).to have_content 'Rights'
   end
 
-  describe 'with downloadable files' do
-    let(:media_file) { instance_double(Embed::Purl::ResourceFile, title: 'file-abc123.pdf', file_url: '//one', caption?: false, transcript?: false, label_or_filename: 'media filename', location_restricted?: false, stanford_only?: false, size: 100) }
-    let(:caption_file) { instance_double(Embed::Purl::ResourceFile, title: 'file-abc123.vtt', file_url: '//one', caption?: true, transcript?: false, label_or_filename: 'caption filename', location_restricted?: false, stanford_only?: false, size: 100) }
-
-    context 'when there are no media files' do
-      let(:downloadable_files) { [media_file] }
-
-      it 'does not have extra headings' do
-        expect(page).to have_content 'Download media filename'
-        expect(page).to have_no_css('h4', text: 'media filename', visible: :hidden)
-      end
-    end
-
-    context 'when there are media files' do
-      let(:downloadable_files) { [media_file, caption_file] }
-
-      it 'does have extra headings' do
-        expect(page).to have_content 'Download media filename'
-        expect(page).to have_content 'Download caption filename'
-        expect(page).to have_css('h4', text: 'media filename', visible: :hidden)
-      end
-    end
-  end
-
   describe 'requested_by_chromium?' do
     before { vc_test_request.headers['User-Agent'] = user_agent_string }
 

--- a/spec/components/download/all_files_component_spec.rb
+++ b/spec/components/download/all_files_component_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Download::AllFilesComponent, type: :component do
+  subject(:component) { described_class.new(viewer:) }
+
+  before do
+    allow(embed_request).to receive(:purl_object).and_return(purl_object)
+    render_inline(component)
+  end
+
+  let(:embed_request) { Embed::Request.new({}) }
+  let(:viewer) do
+    Embed::Viewer::Media.new(embed_request)
+  end
+
+  let(:downloadable_files) { [] }
+  let(:purl_object) do
+    instance_double(Embed::Purl,
+                    title: 'foo',
+                    purl_url: 'https://purl.stanford.edu/123',
+                    manifest_json_url: 'https://purl.stanford.edu/123/iiif/manifest',
+                    use_and_reproduction: '',
+                    copyright: '',
+                    license: '',
+                    druid: '123',
+                    version_id: nil,
+                    contents: [],
+                    downloadable_files:,
+                    downloadable_transcript_files?: false)
+  end
+
+  let(:media_file) { instance_double(Embed::Purl::ResourceFile, title: 'file-abc123.pdf', file_url: '//one', caption?: false, transcript?: false, label_or_filename: 'media filename', location_restricted?: false, stanford_only?: false, size: 100) }
+  let(:caption_file) { instance_double(Embed::Purl::ResourceFile, title: 'file-abc123.vtt', file_url: '//one', caption?: true, transcript?: false, label_or_filename: 'caption filename', location_restricted?: false, stanford_only?: false, size: 100) }
+
+  context 'when there are no media files' do
+    let(:downloadable_files) { [media_file] }
+
+    it 'does not have extra headings' do
+      expect(page).to have_content 'Download media filename'
+      expect(page).to have_no_css('h4', text: 'media filename')
+    end
+  end
+
+  context 'when there are media files' do
+    let(:downloadable_files) { [media_file, caption_file] }
+
+    it 'does have extra headings' do
+      expect(page).to have_content 'Download media filename'
+      expect(page).to have_content 'Download caption filename'
+      expect(page).to have_css('h4', text: 'media filename')
+    end
+  end
+end

--- a/spec/components/download/dialog_component_spec.rb
+++ b/spec/components/download/dialog_component_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Download::DialogComponent, type: :component do
+  subject(:component) { described_class.new }
+
+  before do
+    render_inline(component) do
+      'Stuff'
+    end
+  end
+
+  it 'has a content block' do
+    expect(page).to have_content 'Download'
+    expect(page).to have_content 'Stuff'
+  end
+end


### PR DESCRIPTION
We need to allow for variability in which component is show in the download dialog.  The designs for the File component only need 'download all' in this dialog rather than the full list.