### PR TITLE
Remove unused icon option

### DIFF
--- a/app/components/media/wrapper_component.rb
+++ b/app/components/media/wrapper_component.rb
@@ -21,8 +21,7 @@ module Media
                 location_restricted: @file.location_restricted?,
                 file_label: @file.label_or_filename,
                 media_tag_target: 'mediaWrapper',
-                thumbnail_url: @thumbnail.presence,
-                default_icon: @type == 'audio' ? 'sul-i-file-music-1' : 'sul-i-file-video-3'
+                thumbnail_url: @thumbnail.presence
               },
               # When rendering this component, show only the first media wrapper component
               hidden: !@resource_index.zero?) do

--- a/spec/components/media/wrapper_component_spec.rb
+++ b/spec/components/media/wrapper_component_spec.rb
@@ -19,24 +19,6 @@ RSpec.describe Media::WrapperComponent, type: :component do
     render
   end
 
-  describe 'data-default-icon attribute' do
-    let(:file) { instance_double(Embed::Purl::ResourceFile, stanford_only?: false, location_restricted?: false, label_or_filename: 'ignored') }
-
-    context 'with audio' do
-      it 'renders the page' do
-        expect(page).to have_css('[data-default-icon="sul-i-file-music-1"]')
-      end
-    end
-
-    context 'with video' do
-      let(:type) { 'video' }
-
-      it 'renders the page' do
-        expect(page).to have_css('[data-default-icon="sul-i-file-video-3"]')
-      end
-    end
-  end
-
   describe 'data-stanford-only attribute' do
     context 'with Stanford only files' do
       let(:file) { instance_double(Embed::Purl::ResourceFile, stanford_only?: true, location_restricted?: false, label_or_filename: 'ignored') }


### PR DESCRIPTION
This was used in the legacy media viewer which has been removed. See https://github.com/sul-dlss/sul-embed/commit/41ee4ba342d43ee9b1207b0124f605ebfce6ecfa\#diff-85f540687348bc19839e05c7d58a6b7df20886ac2bd6f4617e02c0e2b2ee6ccbR51