### PR TITLE
only load osd viewer when users click on it

### DIFF
--- a/app/components/media/preview_image_component.rb
+++ b/app/components/media/preview_image_component.rb
@@ -24,7 +24,9 @@ module Media
       thumb_url = stacks_square_url(druid, file.title, size: '74,73')
       render WrapperComponent.new(thumbnail: thumb_url, file:, type:, resource_index:, size:) do
         tag.div(class: 'osd', id: "openseadragon-#{resource_index}",
-                data: { controller: 'osd', osd_url_value:, osd_nav_images_value: })
+                data: { controller: 'osd', osd_url_value:, osd_nav_images_value:,
+                        index: resource_index,
+                        action: 'thumbnail-clicked@window->osd#initializeViewer' })
       end
     end
 

--- a/app/javascript/controllers/osd_controller.js
+++ b/app/javascript/controllers/osd_controller.js
@@ -7,10 +7,14 @@ export default class extends Controller {
     navImages: Object,
   }
 
-  connect() {
+  initializeViewer(evt) {
     // Customize the error message displayed to users:
     OpenSeadragon.setString('Errors.OpenFailed', 'Restricted')
-    OpenSeadragon({
+
+    // only load viewer if the image has been clicked in the sidebar
+    // and the viewer has never been initialized.
+    if (this.viewer || this.element.dataset.index != String(evt.detail.index)) return;
+    this.viewer = OpenSeadragon({
       id: this.element.id,
       tileSources: [this.urlValue],
       prefixUrl: '',


### PR DESCRIPTION
Previously we were loading the OSD viewer on every image when the page loaded. This makes it so the OSD viewer is only initialized after the user selects an image from the sidebar. If the thumbnail has already been clicked or it isn't the correct thumbnail, the viewer won't initialize.

closes #2355  