### PR TITLE
don't preload restricted content

### DIFF
--- a/app/components/media/tag_component.rb
+++ b/app/components/media/tag_component.rb
@@ -77,8 +77,13 @@ module Media
       /^((?!chrome|android).)*safari/i.match?(request.headers['User-Agent'])
     end
 
+    def restricted?
+      @file.stanford_only? || @file.location_restricted?
+    end
+
     def media_tag # rubocop:disable Metrics/MethodLength
       tag.send(media_tag_name,
+               preload: restricted? ? 'none' : 'auto',
                id: "sul-embed-media-#{@resource_iteration.index}",
                data: {
                  auth_url: authentication_url,


### PR DESCRIPTION
closes #2146 

I know this is only happening in firefox, but we shouldn't be trying to preload restricted content no matter what the browser is. It is a waste of processing power for an item that we know can't be viewed unless the user logs in. We might as well tell the browsers to try.