### PR TITLE
Enable hide-title for component window viewers

### DIFF
--- a/app/components/companion_windows_component.html.erb
+++ b/app/components/companion_windows_component.html.erb
@@ -4,7 +4,11 @@
       <button data-action="click->companion-window#toggleLeft" aria-label="Display sidebar" aria-controls="left-drawer">
         <span class="button-label"><svg class="MuiSvgIcon-root" focusable="false" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"></path></svg></span>
       </button>
-      <h2 class=""><%= viewer.purl_object.title %></h2>
+      <% if display_header? %>
+        <h2 class=""><%= title %></h2>
+      <% else %>
+        <span style="flex-grow: 1"></span>
+      <% end %>
       <% header_buttons.each do |header_button| %>
         <%= header_button %>
       <% end %>

--- a/app/components/companion_windows_component.rb
+++ b/app/components/companion_windows_component.rb
@@ -18,8 +18,8 @@ class CompanionWindowsComponent < ViewComponent::Base
 
   attr_reader :viewer
 
-  delegate :purl_object, to: :viewer
-  delegate :downloadable_files, :druid, to: :purl_object
+  delegate :purl_object, :display_header?, to: :viewer
+  delegate :downloadable_files, :druid, :title, to: :purl_object
 
   def iiif_v3_manifest_url
     "#{Settings.purl_url}/#{druid}/iiif3/manifest"

--- a/spec/components/file_component_spec.rb
+++ b/spec/components/file_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe FileComponent, type: :component do
     Embed::Request.new(url: 'http://purl.stanford.edu/abc123', min_files_to_search: 1, new_viewer: 'true')
   end
   let(:viewer) { Embed::Viewer::File.new(request) }
-  let(:purl) { build(:purl, contents: resources) }
+  let(:purl) { build(:purl, :file, contents: resources) }
   let(:resources) { [build(:resource, :video, files: [build(:resource_file, :video, :stanford_only, label: 'Second Video')])] }
 
   before do
@@ -15,11 +15,24 @@ RSpec.describe FileComponent, type: :component do
     render_inline(described_class.new(viewer:))
   end
 
-  it 'returns html that has a body wrapped in a container' do
+  it 'displays the page' do
+    within 'header' do
+      expect(page).to have_content 'Title of the object'
+    end
     # visible :all because we display:none the container until we've loaded the CSS.
     expect(page).to have_css 'div.sul-embed-container', visible: :all
     expect(page).to have_content 'Search this list'
     expect(page).to have_css 'button[aria-label="Full screen"]', visible: :all
+  end
+
+  context 'when hide_title is passed' do
+    Embed::Request.new(url: 'http://purl.stanford.edu/abc123', min_files_to_search: 1, new_viewer: 'true', hide_title: 'true')
+
+    it 'displays the page' do
+      within 'header' do
+        expect(page).to have_no_content 'Title of the object'
+      end
+    end
   end
 
   context 'when a version id is supplied' do

--- a/spec/components/media_component_spec.rb
+++ b/spec/components/media_component_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe MediaComponent, type: :component do
   end
   let(:purl_object) do
     instance_double(Embed::Purl,
-                    title: 'foo',
+                    title: 'Sample title',
                     purl_url: 'https://purl.stanford.edu/123',
                     manifest_json_url: 'https://purl.stanford.edu/123/iiif/manifest',
                     use_and_reproduction: '',
@@ -28,6 +28,9 @@ RSpec.describe MediaComponent, type: :component do
   end
 
   it 'displays the page' do
+    within 'header' do
+      expect(page).to have_content 'Sample title'
+    end
     # Accessabile dialog
     within 'dialog' do
       expect(page).to have_content 'To request a transcript or other accommodation'
@@ -37,5 +40,15 @@ RSpec.describe MediaComponent, type: :component do
     expect(page).to have_content 'Access is restricted to the reading room. See Access conditions for more information.'
     expect(page).to have_content 'Stanford users: log in to access all available features'
     expect(page).to have_content 'Access is restricted until the embargo has elapsed'
+  end
+
+  context 'when hide_title is passed' do
+    let(:embed_request) { Embed::Request.new(hide_title: 'true') }
+
+    it 'displays the page' do
+      within 'header' do
+        expect(page).to have_no_content 'Sample title'
+      end
+    end
   end
 end

--- a/spec/components/pdf_component_spec.rb
+++ b/spec/components/pdf_component_spec.rb
@@ -8,40 +8,46 @@ RSpec.describe PdfComponent, type: :component do
   let(:url) { 'https://purl.stanford.edu/sq929fn8035' }
   let(:embed_request) { Embed::Request.new(url:) }
   let(:viewer) { Embed::ViewerFactory.new(embed_request).viewer }
+  let(:user_agent_string) { '' }
 
   before do
+    vc_test_request.headers['User-Agent'] = user_agent_string
     stub_request(:get, 'https://purl.stanford.edu/sq929fn8035.json')
       .to_return(status: 200, body: pdf_public_json, headers: {})
+    render_inline(described_class.new(viewer:))
   end
 
-  it 'renders the full screen button by default' do
-    rendered_ng_doc_fragment = render_inline(described_class.new(viewer:))
-    expect(rendered_ng_doc_fragment.xpath('.//button[@aria-label="Full screen"]').count).to eq(1)
+  it 'draws the page' do
+    # The component has a hidden attribute which is removed by the javascript, so search with `visibile: :all'
+    expect(page).to have_css('button[aria-label="Full screen"]', visible: :all)
+    within 'header' do
+      expect(page).to have_content 'Fantasia Apocalyptica musical score (manuscript) : Four trumpets. Chapter 8'
+    end
+  end
+
+  context 'when hide_title is passed' do
+    let(:embed_request) { Embed::Request.new(url:, hide_title: 'true') }
+
+    it 'displays the page' do
+      within 'header' do
+        expect(page).to have_no_content 'Fantasia Apocalyptica musical score (manuscript) : Four trumpets. Chapter 8'
+      end
+    end
   end
 
   context 'when the browser is chrome' do
     let(:user_agent_string) { 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36' }
 
-    before do
-      vc_test_request.headers['User-Agent'] = user_agent_string
-    end
-
     it 'does not render the full screen button' do
-      rendered_ng_doc_fragment = render_inline(described_class.new(viewer:))
-      expect(rendered_ng_doc_fragment.xpath('.//button[@aria-label="Full screen"]').count).to eq(0)
+      expect(page).to have_no_css('button[aria-label="Full screen"]')
     end
   end
 
   context 'when the browser is Edge' do
     let(:user_agent_string) { 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 Edg/126.0.0.0' }
 
-    before do
-      vc_test_request.headers['User-Agent'] = user_agent_string
-    end
-
     it 'does not render the full screen button' do
-      rendered_ng_doc_fragment = render_inline(described_class.new(viewer:))
-      expect(rendered_ng_doc_fragment.xpath('.//button[@aria-label="Full screen"]').count).to eq(0)
+      expect(page).to have_no_css('button[aria-label="Full screen"]')
     end
   end
 end

--- a/test/components/previews/embed/media_component_preview.rb
+++ b/test/components/previews/embed/media_component_preview.rb
@@ -38,10 +38,14 @@ module Embed
       render_media_viewer_for(url: 'https://purl.stanford.edu/bc285ff3003')
     end
 
+    def hide_title
+      render_media_viewer_for(url: 'https://purl.stanford.edu/wz015vw6759', hide_title: 'true')
+    end
+
     private
 
-    def render_media_viewer_for(url:)
-      embed_request = Embed::Request.new(url:)
+    def render_media_viewer_for(**params)
+      embed_request = Embed::Request.new(**params)
       viewer = Embed::Viewer::Media.new(embed_request)
       render(MediaComponent.new(viewer:))
     end


### PR DESCRIPTION
This worked on the legacy viewers and Mirador, so this PR brings it to the new viewers.