### PR TITLE
The geo sidebar should be open by default

### DIFF
--- a/app/javascript/src/modules/geo_viewer.js
+++ b/app/javascript/src/modules/geo_viewer.js
@@ -261,7 +261,7 @@ export default {
                     <h3>Features</h3>
                     <i class="sul-i-arrow-up-8"></i>
                   </div>
-                  <div class="sul-embed-geo-sidebar-content" style="display: none" aria-hidden="true">Click the map to inspect features.</div>
+                  <div class="sul-embed-geo-sidebar-content">Click the map to inspect features.</div>
                 </div>`
   },
 


### PR DESCRIPTION
Fixes #2431

This was caused by a regression introduced in #2375