### PR TITLE
fix table overflowing out of viewer div

### DIFF
--- a/app/assets/stylesheets/companion_window.css
+++ b/app/assets/stylesheets/companion_window.css
@@ -317,6 +317,7 @@
     #main-display {
       display: flex;
       flex: 1 1 auto;
+      min-width: 0;
     }
   }
 


### PR DESCRIPTION
This closes #2415  but it is incredibly cramped on small screens due to the sidebar. @alundgard Do we want to collapse the sidebar on smaller screens like we do with media? https://github.com/sul-dlss/sul-embed/issues/2361 or was this ticket for all viewers?


https://github.com/user-attachments/assets/ea1004ad-38ad-4985-a968-e6161212760a

