### PR TITLE
Set transform-origin in center of rotating caret

### DIFF
--- a/app/assets/stylesheets/file.css
+++ b/app/assets/stylesheets/file.css
@@ -121,6 +121,7 @@
   tr[aria-expanded="true"] > td:first-child::before,
   td[aria-expanded="true"]:first-child::before {
     transform: rotate(90deg);
+    transform-origin: center center;
   }
 
   .sul-embed-filename-cell,


### PR DESCRIPTION
This prevents the rotation from messing with the row padding.

closes #2478