### PR TITLE
Convert m3 SASS to CSS

### DIFF
--- a/app/assets/stylesheets/m3.css
+++ b/app/assets/stylesheets/m3.css
@@ -25,13 +25,13 @@
     0 1px 3px 0 rgba(0, 0, 0, 0.2),
     0 1px 1px 0 rgba(0, 0, 0, 0.2),
     0 2px 1px -1px rgba(0, 0, 0, 0.2);
-  height: calc(100vh - 3px); // Give a little space for the box shadow
+  height: calc(100vh - 3px); /* Give a little space for the box shadow */
   margin: 0 1px 3px 0;
   position: relative;
 
-  // For single-window M3 embeds, this will be overriden by Mirador 3's
-  // selected window top-bar styling, but if there are mulitple
-  // windows, it will give the unselected windows a visible border.
+  /* For single-window M3 embeds, this will be overriden by Mirador 3's
+     selected window top-bar styling, but if there are mulitple
+     windows, it will give the unselected windows a visible border. */
   .mirador-window-top-bar {
     border-top-color: var(--gray-80);
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/sul-dlss/sul-embed/issues"
   },
   "scripts": {
-    "build:css": "sass ./app/assets/stylesheets/legacy_file.scss:./app/assets/builds/legacy_file.css ./app/assets/stylesheets/legacy_geo.scss:./app/assets/builds/legacy_geo.css ./app/assets/stylesheets/m3.scss:./app/assets/builds/m3.css ./app/assets/stylesheets/legacy_model.scss:./app/assets/builds/legacy_model.css ./app/assets/stylesheets/legacy_was_seed.scss:./app/assets/builds/legacy_was_seed.css ./app/assets/stylesheets/sul_icons.scss:./app/assets/builds/sul_icons.css --no-source-map --load-path=node_modules --load-path=vendor/assets/javascripts"
+    "build:css": "sass ./app/assets/stylesheets/legacy_file.scss:./app/assets/builds/legacy_file.css ./app/assets/stylesheets/legacy_geo.scss:./app/assets/builds/legacy_geo.css ./app/assets/stylesheets/legacy_model.scss:./app/assets/builds/legacy_model.css ./app/assets/stylesheets/legacy_was_seed.scss:./app/assets/builds/legacy_was_seed.css ./app/assets/stylesheets/sul_icons.scss:./app/assets/builds/sul_icons.css --no-source-map --load-path=node_modules --load-path=vendor/assets/javascripts"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
This allows us to stop compiling sass (once the legacy viewers are removed).