### PR TITLE
fix levels for file display

### DIFF
--- a/app/components/embed/file/dir_row_component.rb
+++ b/app/components/embed/file/dir_row_component.rb
@@ -20,7 +20,7 @@ module Embed
       end
 
       def first_td_style
-        "padding-left: #{((level - 1) * 4) + 2}ch;"
+        "padding-left: #{((level - 1) * 2) + 1.5}ch;"
       end
     end
   end

--- a/app/components/file_component.html.erb
+++ b/app/components/file_component.html.erb
@@ -48,7 +48,8 @@
           </tr>
         </thead>
         <tbody>
-          <%= render Embed::File::DirRowComponent.new(viewer: viewer, dir: viewer.purl_object.hierarchical_contents)%>
+          <%# we set the level to -1 because without it, the level starts at 1 and that creates odd tabbing issues. %>
+          <%= render Embed::File::DirRowComponent.new(viewer: viewer, dir: viewer.purl_object.hierarchical_contents, level: -1)%>
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
This solves two problems:
1. There is tabbing on the parent (top level) folder. The old viewer (and figmas) have the "File name" heading and first folder tabbed at the same level. This was fixed by moving aria-level on back 1 (instead of 1, 0, instead of 2, 1, etc). This is what **level_step**
2. Files in the folders had the same tabbing as their parent folder. Fixed by regression to **"padding-left: #{((level - 1) * 2) + 1.5}ch;"**
![Screenshot 2025-02-14 at 4 30 21 PM](https://github.com/user-attachments/assets/34efcac4-a667-4058-bbd0-024c174ea1a9)

closes #2512 