### PR TITLE
Display the login banners as headers

### DIFF
--- a/app/components/pdf_component.html.erb
+++ b/app/components/pdf_component.html.erb
@@ -7,19 +7,23 @@
     <%= render CompanionWindows::FullscreenButtonComponent.new  %>
   <% end unless requested_by_chromium? %>
 
+  <% component.with_authorization_messages do %>
+    <%= render LoginComponent.new %>
+    <%= render ContentNotAvailableComponent.new unless viewer.available? %>
+  <% end %>
+
   <% component.with_body do %>
+    <div data-controller="locked-poster" data-action="auth-success@window->locked-poster#hide auth-denied@window->locked-poster#show" tabindex="-1" role="presentation" style="flex: 1 0 100%; text-align: center;" <%= 'hidden' if viewer.available? %>>
+      <%= render LockedStatusComponent.new %>
+    </div>
     <div class="sul-embed-body" style="flex-basis: 100%">
       <div style="display: flex; flex-direction: column; height: 100%">
         <% if viewer.available? %>
-              <%= render LoginComponent.new %>
-              <div class="sul-embed-pdf" style="height: 100%"
-                data-controller="pdf"
-                data-fullscreen-target="area"
-                data-action="iiif-manifest-received@window->file-auth#parseFiles auth-success@window->pdf#show">
-              </div>
-        <% else %>
-          <%= render ContentNotAvailableComponent.new %>
-          <%= render LockedStatusComponent.new %>
+          <div class="sul-embed-pdf" style="height: 100%"
+            data-controller="pdf"
+            data-fullscreen-target="area"
+            data-action="iiif-manifest-received@window->file-auth#parseFiles auth-success@window->pdf#show">
+          </div>
         <% end %>
       </div>
     </div>

--- a/app/javascript/controllers/file_auth_controller.js
+++ b/app/javascript/controllers/file_auth_controller.js
@@ -211,7 +211,12 @@ export default class extends Controller {
 
   // Show login message and link provided by auth service
   loginNeeded(activeAccessService, messageId) {
-    if (!this.loginPanelTarget.hidden) return // no action needed if the login window is already there
+    // we want to ensure that show the login for the first resource
+    if (this.resources[messageId].contentResourceId !== this.firstFile) return
+
+    // This allows the lock window to show
+    const event = new CustomEvent('auth-denied', { activeAccessService: activeAccessService })
+    window.dispatchEvent(event)
 
     this.messagePanelTarget.hidden = true
     this.loginPanelTarget.hidden = false

--- a/app/javascript/controllers/locked_poster_controller.js
+++ b/app/javascript/controllers/locked_poster_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  // Display the lock
+  show() {
+    this.element.hidden = false
+  }
+
+  hide() {
+    this.element.hidden = true
+  }
+}


### PR DESCRIPTION
This provides parity with the media viewer
<img width="1708" alt="Screenshot 2025-02-18 at 1 08 29 PM" src="https://github.com/user-attachments/assets/483a0ab0-c045-459f-a8c4-2a2d48b698a5" />

closes [#2320](https://github.com/sul-dlss/sul-embed/issues/2320)
closes [#2521](https://github.com/sul-dlss/sul-embed/issues/2521)
