### PR TITLE
add su-underline to download modal, sidebar, contents, download link

### DIFF
--- a/app/assets/stylesheets/common.css
+++ b/app/assets/stylesheets/common.css
@@ -1,6 +1,7 @@
 /* For styles shared between the legacy and modern viewers */
 :root {
   --link-color: #006cb8;
+  --stanford-40-black: #ababa9;
 }
 /* From Bootstrap 5.3 */
 .visually-hidden-focusable:not(:focus):not(:focus-within):not(caption),
@@ -39,4 +40,8 @@ a:focus {
 
 .sul-embed-location-restricted-text {
   color: var(--stanford-digital-red);
+}
+
+.su-underline {
+  text-decoration: underline dotted var(--stanford-40-black) 1px;
 }

--- a/app/assets/stylesheets/file.css
+++ b/app/assets/stylesheets/file.css
@@ -57,6 +57,10 @@
 
   th,
   td {
+    a {
+      text-decoration: none;
+    }
+
     &:nth-of-type(2) {
       padding-inline: 1rem;
       text-align: center;

--- a/app/components/companion_windows/content_list_item_component.html.erb
+++ b/app/components/companion_windows/content_list_item_component.html.erb
@@ -1,7 +1,7 @@
 <li class="file-thumb">
   <%= render file_type_icon.new %>
 
-  <a href="#" data-action="click->content-list#<%= show_method %>" data-url="<%= url %>">
+  <a href="#" class="su-underline" data-action="click->content-list#<%= show_method %>" data-url="<%= url %>">
     <%= download_label %>
   </a>
   <%= render 'embed/restrictions_text_for_file', file: file %>

--- a/app/components/download/all_files_component.html.erb
+++ b/app/components/download/all_files_component.html.erb
@@ -1,5 +1,5 @@
 <% if display_download_all? %>
-  <a href='<%= download_url %>' target="_blank" rel="noopener noreferrer nofollow">
+  <a href='<%= download_url %>' target="_blank" class="su-underline" rel="noopener noreferrer nofollow">
     Download all <%= pluralize(downloadable_files.length, "file") %></a>
   <%= render Icons::StanfordOnlyComponent.new if any_stanford_only_files? %>
   (<%= pretty_filesize %>)

--- a/app/components/download/file_list_item_component.html.erb
+++ b/app/components/download/file_list_item_component.html.erb
@@ -1,5 +1,5 @@
 <li>
-  <a href='<%= url %>' target='_blank' rel='noopener noreferrer' download>
+  <a href='<%= url %>' target='_blank' rel='noopener noreferrer' class='su-underline' download>
     Download <%= download_label %>
   </a>
   <%= render 'embed/restrictions_text_for_file', file: file %>

--- a/app/components/embed/file/file_row_component.html.erb
+++ b/app/components/embed/file/file_row_component.html.erb
@@ -17,7 +17,8 @@
   <td role="gridcell">
     <% if download? %>
       <a href="<%= url %>" target='_blank' rel='noopener noreferrer' download>
-        <%= render Icons::DownloadComponent.new(classes: 'download-icon') %> Download
+        <%= render Icons::DownloadComponent.new(classes: 'download-icon') %>
+        <span class="su-underline">Download</span>
         <span class="sul-embed-sr-only visually-hidden"><%= title %></span>
       </a>
       <%= render 'embed/restrictions_text_for_file', file: file %>

--- a/app/javascript/controllers/iiif_metadata_controller.js
+++ b/app/javascript/controllers/iiif_metadata_controller.js
@@ -17,6 +17,7 @@ export default class extends Controller {
         node.setAttribute('target', '_blank')
         // Prevent https://www.owasp.org/index.php/Reverse_Tabnabbing
         node.setAttribute('rel', 'noopener noreferrer')
+        node.classList.add('su-underline')
         return `<dd>${node.outerHTML}</dd>`
       } else {
         return `<dd>${record}</dd>`

--- a/app/javascript/src/modules/thumbnail.js
+++ b/app/javascript/src/modules/thumbnail.js
@@ -36,7 +36,7 @@ export default class {
     return `<li class="media-thumb ${activeClass}" data-action="click->content-list#showMedia" data-content-list-target="listItem" data-content-list-index-param="${index}" style="position: relative;" aria-controls="main-display" role="tab">
         ${thumbnailIcon}
         <a class="stretched-link" href="#">
-          <span class="${labelClass}">
+          <span class="${labelClass} su-underline">
             ${stanfordOnlyScreenreaderText}${restrictedTextMarkup}
             ${this.truncateWithEllipsis(this.fileLabel, maxFileLabelLength)}
           </span>


### PR DESCRIPTION
closes #2454 
<img width="1201" alt="Screenshot 2025-02-18 at 5 17 04 PM" src="https://github.com/user-attachments/assets/5ee1c661-9ca6-4bfb-bbc6-16e08e781a79" />
<img width="1189" alt="Screenshot 2025-02-18 at 5 15 54 PM" src="https://github.com/user-attachments/assets/59c5c706-5029-42ab-b772-c0816943e40a" />
<img width="1179" alt="Screenshot 2025-02-18 at 5 15 38 PM" src="https://github.com/user-attachments/assets/f3b71edb-8899-4825-a35f-44734c72d6ec" />
