### PR TITLE
fix tooltips for fullscreen

### DIFF
--- a/app/javascript/controllers/tooltip_controller.js
+++ b/app/javascript/controllers/tooltip_controller.js
@@ -6,14 +6,15 @@ export default class extends Controller {
     this.tooltip = document.createElement("div")
     this.tooltip.classList.add('tooltip')
     this.tooltip.innerHTML = this.element.getAttribute('aria-label')
-    document.body.appendChild(this.tooltip);
+    this.tooltip.ariaHidden = 'true'
+    this.element.appendChild(this.tooltip)
 
-    this.popperInstance = createPopper(this.element, this.tooltip);
+    this.popperInstance = createPopper(this.element, this.tooltip)
   }
   show() {
     this.tooltip.classList.add('show')
 
-    this.popperInstance.update();
+    this.popperInstance.update()
   }
 
   hide() {


### PR DESCRIPTION
closes #2561 

This was happening because the tooltips where outside the fullscreen element. This moves the tooltips to next to the buttons they are targeting. This is why I added aria-hidden because it is repeat information that the screenreader does not need.