### PR TITLE
Add common.css to the media viewer

### DIFF
--- a/app/assets/stylesheets/media.css
+++ b/app/assets/stylesheets/media.css
@@ -1,6 +1,7 @@
 @import url("companion_window.css");
 @import url("content_list.css");
 @import url("locked_status.css");
+@import url("common.css"); /* needed for .sul-embed-stanford-only-text on download */
 
 /* VideoJS CSS overrides for responsive layout
    See http://andreassauer.name/experimente/video-js/demo.html */


### PR DESCRIPTION
This is needed to display the stanford only icon on the download modal Fixes #2572

<img width="625" alt="Screenshot 2025-02-20 at 6 49 59 AM" src="https://github.com/user-attachments/assets/075b0930-e88e-4465-9d16-cddfcf6182ae" />
