### PR TITLE
Align dropdown labels and icons to middle

### DIFF
--- a/app/assets/stylesheets/companion_window.css
+++ b/app/assets/stylesheets/companion_window.css
@@ -220,12 +220,13 @@ body {
       .modal-component-label {
         font-size: 1rem;
         line-height: 1.6em;
+        vertical-align: middle;
       }
 
       .modal-component-icon {
         min-width: 32px;
-        vertical-align: middle;
         color: var(--button-color);
+        vertical-align: middle;
       }
 
       &:hover {


### PR DESCRIPTION
Fixes #2586 