### PR TITLE
Add tooltip to parent #sul-embed-object so it will appear above viewer and work in fullscreen mode

### DIFF
--- a/app/javascript/controllers/tooltip_controller.js
+++ b/app/javascript/controllers/tooltip_controller.js
@@ -7,7 +7,10 @@ export default class extends Controller {
     this.tooltip.classList.add('tooltip')
     this.tooltip.innerHTML = this.element.getAttribute('aria-label')
     this.tooltip.ariaHidden = 'true'
-    this.element.appendChild(this.tooltip)
+    // tooltip must be appended to a parent of any part of the viewer
+    // that might otherwise cover it and be within the area shown in
+    // fullscreen mode.
+    this.element.closest('#sul-embed-object').appendChild(this.tooltip)
 
     this.popperInstance = createPopper(this.element, this.tooltip)
   }


### PR DESCRIPTION
Fixes #2576

Before:
<img width="224" alt="Screenshot 2025-02-20 at 4 44 22 PM" src="https://github.com/user-attachments/assets/2a48ec75-8e72-4ee0-8952-39141edb2602" />

After:
<img width="308" alt="Screenshot 2025-02-20 at 4 36 26 PM" src="https://github.com/user-attachments/assets/06a40954-ecd6-4e16-9428-f8c93f95e976" />
