### PR TITLE
don't display fullscreen icon on ios devices

### DIFF
--- a/app/components/companion_windows/fullscreen_button_component.rb
+++ b/app/components/companion_windows/fullscreen_button_component.rb
@@ -2,5 +2,10 @@
 
 module CompanionWindows
   class FullscreenButtonComponent < ViewComponent::Base
+    def render?
+      # Currently the fullscreen api does not support fullscreen on WebView on iOS
+      # https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API#api.document.fullscreenenabled
+      request.user_agent.exclude?('iPhone')
+    end
   end
 end


### PR DESCRIPTION
closes #2580 

I tested this with Firefox's responsive design mode. The have apple profiles, and this worked there.