### PR TITLE
Put missing role on the document viewer list

### DIFF
--- a/app/components/companion_windows/content_list_item_component.html.erb
+++ b/app/components/companion_windows/content_list_item_component.html.erb
@@ -1,4 +1,4 @@
-<li class="file-thumb">
+<li class="file-thumb" aria-controls="main-display" role="tab">
   <%= render file_type_icon.new %>
 
   <a href="#" class="su-underline" data-action="click->content-list#<%= show_method %>" data-url="<%= url %>">


### PR DESCRIPTION
The document viewer was drawing this list on the backend, but the media viewer draws this on the frontend (in [src/modules/thumbnail.js](https://github.com/sul-dlss/sul-embed/blob/main/app/javascript/src/modules/thumbnail.js#L36)).  This PR brings these two into synch and fixes the problem of a tablist with no children with tab roles.

Fixes #2604