### PR TITLE
don't render videojs full screen button when in fullscreen for safari

### DIFF
--- a/app/components/media/tag_component.rb
+++ b/app/components/media/tag_component.rb
@@ -74,6 +74,7 @@ module Media
           media_tag_target: 'authorizeableResource',
           controller: 'media-player',
           action: 'media-seek@window->media-player#seek ' \
+                  'fullscreenchange@window->media-player#fullscreenChange ' \
                   'auth-success@window->media-player#initializeVideoJSPlayer'
         },
         poster: poster_url_for,

--- a/app/javascript/controllers/media_player_controller.js
+++ b/app/javascript/controllers/media_player_controller.js
@@ -37,6 +37,18 @@ export default class extends Controller {
     })
   }
 
+  // Don't show videojs fullscreen button when sul-embed is in fullscreen
+  // Only used in safari (see #2567)
+  fullscreenChange(event) {
+    if (!/^((?!chrome|android).)*safari/i.test(navigator.userAgent)) return;
+    if (event.srcElement.classList.contains('video-js') || !this.player) return;
+    if (document.fullscreenElement !== null) {
+      this.player.controlBar.fullscreenToggle.hide();
+    } else {
+      this.player.controlBar.fullscreenToggle.show();
+    }
+  }
+
   // Listen for events emitted by cue_controller.js to jump to a particular time
   // "this.player" was returning undefined, so we are relying on the element id to
   // retrieve the player


### PR DESCRIPTION
checked in firefox, chrome and safari

closes #2567 