### PR TITLE
Set height instead of max-height on companion-window-component-body

### DIFF
--- a/app/assets/stylesheets/companion_window.css
+++ b/app/assets/stylesheets/companion_window.css
@@ -350,7 +350,7 @@ body {
     ); /* the 5px is for the outer border and the top red border */
     display: flex;
     flex-grow: 1;
-    max-height: var(--body-height);
+    height: var(--body-height);
 
     #main-display {
       display: flex;


### PR DESCRIPTION
Relates to #2550

Part of what's causing the initial map zoom/pan to be incorrect for the new geo viewer is that it gets initialized before the containing companion window has expanded to its max height. So leaflet is calculating the initial fitbounds with a much smaller height than we'd expect.

I can fix this by setting `height` instead of `max-height` on `.companion-window-component-body`. Is there a reason we should prefer `max-height` here though? I couldn't seen any negative impact in my testing.

I think we probably also need to add something that re-calculates fitbounds when the left-drawer opens, but I'd rather deal with that in a separate PR.