### PR TITLE
fix label_of_filename for pdfs

### DIFF
--- a/app/models/embed/purl/resource_file.rb
+++ b/app/models/embed/purl/resource_file.rb
@@ -51,7 +51,7 @@ module Embed
       end
 
       def label_or_filename
-        return text_representation_label if caption? || transcript?
+        return text_representation_label if (caption? || transcript?) && !pdf? && !image?
 
         label.presence || filename
       end


### PR DESCRIPTION
We only want text_representation_label for media not pdfs