### PR TITLE
Remove link from within li with role=tab

### DIFF
--- a/app/assets/stylesheets/content_list.css
+++ b/app/assets/stylesheets/content_list.css
@@ -31,20 +31,6 @@
       mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='MuiSvgIcon-root AudioFileSharp' focusable='false' aria-hidden='true' viewBox='0 0 24 24'%3E%3Cpath d='M14 2H4v20h16V8zm2 11h-3v3.75c0 1.24-1.01 2.25-2.25 2.25S8.5 17.99 8.5 16.75s1.01-2.25 2.25-2.25c.46 0 .89.14 1.25.38V11h4zm-3-4V3.5L18.5 9z'%3E%3C/path%3E%3C/svg%3E");
     }
 
-    /* Stretched links
-           https://github.com/twbs/bootstrap/blob/c28934cb1871d6b6bd6a866660493a1137de17c6/scss/helpers/_stretched-link.scss */
-    .stretched-link {
-      &::after {
-        position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
-        z-index: 1;
-        content: "";
-      }
-    }
-
     .square-icon {
       float: left;
     }
@@ -70,6 +56,7 @@
   }
 
   .media-thumb {
+    cursor: pointer;
     height: var(--thumb-height);
     text-align: center;
   }

--- a/app/javascript/src/modules/thumbnail.js
+++ b/app/javascript/src/modules/thumbnail.js
@@ -32,15 +32,12 @@ export default class {
       maxFileLabelLength -= restrictedText.length
     }
 
-    // Note: the "position: relative" is required for the stretched-link style.
-    return `<li class="media-thumb ${activeClass}" data-action="click->content-list#showMedia" data-content-list-target="listItem" data-content-list-index-param="${index}" style="position: relative;" aria-controls="main-display" role="tab">
+    return `<li class="media-thumb ${activeClass}" data-action="click->content-list#showMedia keydown.enter->content-list#showMedia" data-content-list-target="listItem" data-content-list-index-param="${index}" aria-controls="main-display" role="tab" tabindex="0">
         ${thumbnailIcon}
-        <a class="stretched-link" href="#">
-          <span class="${labelClass} su-underline">
-            ${stanfordOnlyScreenreaderText}${restrictedTextMarkup}
-            ${this.truncateWithEllipsis(this.fileLabel, maxFileLabelLength)}
-          </span>
-        </a>
+        <span class="${labelClass} su-underline">
+          ${stanfordOnlyScreenreaderText}${restrictedTextMarkup}
+          ${this.truncateWithEllipsis(this.fileLabel, maxFileLabelLength)}
+        </span>
       </li>`
   }
 


### PR DESCRIPTION
Part of #2597 (the PDF viewer content list also needs to be fixed, but I'll do that as a separate PR if this approach looks okay.)

This removes the the link from within the list with role "tab". [All descendants of a tab role element are presentational](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role#all_descendants_are_presentational). The accessibility error is because a presentational element (the link) is receiving keyboard focus. I've added `tabindex=0` to the li so that it can receive keyboard focus. The tab can still be activated by click or by keyboard.