### PR TITLE
Remove link from within list with role=tab (PDF content list)

### DIFF
--- a/app/assets/stylesheets/content_list.css
+++ b/app/assets/stylesheets/content_list.css
@@ -4,6 +4,7 @@
 
   .media-thumb,
   .file-thumb {
+    cursor: pointer;
     list-style-type: none;
     border: 1px solid var(--border-color);
     margin-bottom: 0.5rem;
@@ -56,7 +57,6 @@
   }
 
   .media-thumb {
-    cursor: pointer;
     height: var(--thumb-height);
     text-align: center;
   }

--- a/app/components/document/content_list_item_component.html.erb
+++ b/app/components/document/content_list_item_component.html.erb
@@ -1,8 +1,8 @@
-<li class="file-thumb" aria-controls="main-display" role="tab">
+<li class="file-thumb" aria-controls="main-display" data-action="click->content-list#<%= show_method %> keydown.enter->content-list#<%= show_method %>" data-url="<%= url %>" role="tab" tabindex="0">
   <%= render file_type_icon.new %>
 
-  <a href="#" class="su-underline" data-action="click->content-list#<%= show_method %>" data-url="<%= url %>">
+  <span class="su-underline">
     <%= download_label %>
-  </a>
+  </span>
   <%= render 'embed/restrictions_text_for_file', file: file %>
 </li>

--- a/app/javascript/controllers/content_list_controller.js
+++ b/app/javascript/controllers/content_list_controller.js
@@ -18,13 +18,11 @@ export default class extends Controller {
     window.dispatchEvent(event)
 
     this.listItemTargets.forEach((target) => {
-      target.classList.remove('active')
-      target.setAttribute("aria-selected", false)
+      this.unsetActive(target)
     })
 
     const target = this.listItemTargets.find(element => element.dataset.contentListIndexParam == evt.params.index)
-    target.classList.add('active')
-    target.setAttribute("aria-selected", true)
+    this.setActive(target)
   }
 
   // Show a different PDF when the user selects it in the list
@@ -33,9 +31,22 @@ export default class extends Controller {
     evt.preventDefault()
     const fileUri = evt.currentTarget.dataset.url
     window.dispatchEvent(new CustomEvent('auth-success', { detail: fileUri }))
-    if (document.querySelector('.file-thumb.active')){
-      document.querySelector('.file-thumb.active').classList.remove('active')
+
+    const fileThumbActive = document?.querySelector('.file-thumb.active')
+    if (fileThumbActive){
+      this.unsetActive(fileThumbActive)
     }
-    evt.target.parentElement.classList.add('active')
+
+    this.setActive(evt.currentTarget)
+  }
+
+  setActive(target) {
+    target.setAttribute("aria-selected", true)
+    target.classList.add('active')
+  }
+
+  unsetActive(target) {
+    target.setAttribute("aria-selected", false)
+    target.classList.remove('active')
   }
 }


### PR DESCRIPTION
Fixes #2597
Fixes #2674

- Removes the link from within the list with role="tab" since the tab should be the keyboard accessible target.
- Adds aria-selected true/false so assistive tools can identify and announce the selected tab.