### PR TITLE
Wrap video with an element that contains all the stimulus attributes

### DIFF
--- a/app/components/media/tag_component.rb
+++ b/app/components/media/tag_component.rb
@@ -49,11 +49,26 @@ module Media
       asset_url('waveform-audio-poster.svg')
     end
 
-    def media_element
+    def media_element # rubocop:disable Metrics/MethodLength
       render WrapperComponent.new(thumbnail: thumbnail_url, file:, type:,
                                   size: @resource_iteration.size,
                                   resource_index: @resource_iteration.index) do
-        media_tag
+        # We use this div, to hold stimulus controller/actions, because videoJS duplicates these attributes if they are
+        # on the <video> tag directly
+        tag.div(
+          style: 'height: 100%',
+          data: {
+            auth_url: authentication_url,
+            index: @resource_iteration.index,
+            media_tag_target: 'authorizeableResource',
+            controller: 'media-player',
+            action: 'media-seek@window->media-player#seek ' \
+                    'fullscreenchange@window->media-player#fullscreenChange ' \
+                    'auth-success@window->media-player#initializeVideoJSPlayer'
+          }
+        ) do
+          media_tag
+        end
       end
     end
 
@@ -68,15 +83,6 @@ module Media
       tag.video(
         preload: restricted? ? 'none' : 'auto',
         id: "sul-embed-media-#{@resource_iteration.index}",
-        data: {
-          auth_url: authentication_url,
-          index: @resource_iteration.index,
-          media_tag_target: 'authorizeableResource',
-          controller: 'media-player',
-          action: 'media-seek@window->media-player#seek ' \
-                  'fullscreenchange@window->media-player#fullscreenChange ' \
-                  'auth-success@window->media-player#initializeVideoJSPlayer'
-        },
         poster: poster_url_for,
         controls: 'controls',
         class: 'sul-embed-media-file',

--- a/app/javascript/controllers/media_player_controller.js
+++ b/app/javascript/controllers/media_player_controller.js
@@ -3,8 +3,8 @@ import videojs from 'video.js'
 
 export default class extends Controller {
   initializeVideoJSPlayer() {
-    this.element.classList.add('video-js', 'vjs-default-skin')
-    this.player = videojs(this.element.id,
+    this.videoElement().classList.add('video-js', 'vjs-default-skin')
+    this.player = videojs(this.videoElement().id,
                           { responsive: true,
                             userActions: { hotkeys: true }
                           })
@@ -22,7 +22,7 @@ export default class extends Controller {
       const event = new CustomEvent('time-update', { detail: timestamp })
       window.dispatchEvent(event)
     })
-    
+
     this.player.index = this.element.dataset.index;
 
     this.player.on('loadedmetadata', (evt) => {
@@ -59,9 +59,13 @@ export default class extends Controller {
   // "this.player" was returning undefined, so we are relying on the element id to
   // retrieve the player
   seek(event) {
-    const playerObject =  videojs(this.element.id)
+    const playerObject =  videojs(this.videoElement().id)
     if (playerObject) {
       playerObject.currentTime(event.detail)
     }
+  }
+
+  videoElement() {
+    return this.element.querySelector('video')
   }
 }

--- a/spec/components/media/tag_component_spec.rb
+++ b/spec/components/media/tag_component_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Media::TagComponent, type: :component do
     end
 
     it 'includes a data attribute that includes the url to check the users auth status' do
-      expect(page).to have_css('video[data-auth-url]', visible: :all)
-      auth_url = page.all('video[data-auth-url]', visible: :all).first['data-auth-url']
+      expect(page).to have_css('[data-auth-url]', visible: :all)
+      auth_url = page.all('[data-auth-url]', visible: :all).first['data-auth-url']
       expect(auth_url).to eq(Settings.streaming.auth_url)
     end
 
@@ -41,8 +41,8 @@ RSpec.describe Media::TagComponent, type: :component do
     let(:resource) { build(:resource, :video, files: [build(:media_file, :video, :stanford_only)]) }
 
     it 'includes a data attribute that includes the url to check the users auth status' do
-      expect(page).to have_css('video[data-auth-url]', visible: :all)
-      auth_url = page.all('video[data-auth-url]', visible: :all).first['data-auth-url']
+      expect(page).to have_css('[data-auth-url]', visible: :all)
+      auth_url = page.all('[data-auth-url]', visible: :all).first['data-auth-url']
       expect(auth_url).to eq(Settings.streaming.auth_url)
     end
   end
@@ -52,8 +52,8 @@ RSpec.describe Media::TagComponent, type: :component do
     let(:resource) { build(:resource, :video, files: [build(:media_file, :video, :world_downloadable)]) }
 
     it 'includes a data attribute that includes the url to check the users auth status' do
-      expect(page).to have_css('video[data-auth-url]', visible: :all)
-      auth_url = page.all('video[data-auth-url]', visible: :all).first['data-auth-url']
+      expect(page).to have_css('[data-auth-url]', visible: :all)
+      auth_url = page.all('[data-auth-url]', visible: :all).first['data-auth-url']
       expect(auth_url).to eq(Settings.streaming.auth_url)
     end
 


### PR DESCRIPTION
We can't put these on the video tag or videojs will clone them onto an element that it creates

Fixes #2700 