### PR TITLE
[refactor] Deserialize access attributes

### DIFF
--- a/app/components/embed/file/file_row_component.rb
+++ b/app/components/embed/file/file_row_component.rb
@@ -3,6 +3,8 @@
 module Embed
   module File
     class FileRowComponent < ViewComponent::Base
+      # @param [Embed::Viewer::File]
+      # @param [Embed::Purl::ResourceFile] file
       def initialize(viewer:, file:, pos_in_set: nil, set_size: nil, level: 0)
         @viewer = viewer
         @file = file

--- a/app/models/embed/purl/file_json_deserializer.rb
+++ b/app/models/embed/purl/file_json_deserializer.rb
@@ -18,22 +18,6 @@ module Embed
         @filename ||= @file.fetch('filename')
       end
 
-      def stanford_only
-        view == 'stanford'
-      end
-
-      def location_restricted
-        download == 'location-based'
-      end
-
-      def world_downloadable
-        download == 'world'
-      end
-
-      def stanford_only_downloadable
-        download == 'stanford'
-      end
-
       def download
         @file.fetch('access').fetch('download')
       end
@@ -60,10 +44,8 @@ module Embed
           size: @file.fetch('size'),
           role: @file['use'],
           filename:,
-          stanford_only:,
-          location_restricted:,
-          world_downloadable:,
-          stanford_only_downloadable:
+          download:,
+          view:
         )
 
         if klass == MediaFile

--- a/app/models/embed/purl/resource_file.rb
+++ b/app/models/embed/purl/resource_file.rb
@@ -15,14 +15,9 @@ module Embed
         end
       end
 
-      attr_accessor :druid, :label, :filename, :mimetype, :size, :role,
-                    :world_downloadable, :stanford_only, :location_restricted, :stanford_only_downloadable
+      attr_accessor :druid, :label, :filename, :mimetype, :size, :role, :download, :view
 
       alias title filename
-      alias world_downloadable? world_downloadable
-      alias stanford_only? stanford_only
-      alias location_restricted? location_restricted
-      alias stanford_only_downloadable? stanford_only_downloadable
 
       ##
       # Creates a file url for stacks
@@ -56,6 +51,22 @@ module Embed
       def downloadable?
         (world_downloadable? || stanford_only_downloadable?) &&
           NON_DOWNLOADABLE_ROLES.exclude?(role)
+      end
+
+      def stanford_only?
+        view == 'stanford'
+      end
+
+      def location_restricted?
+        download == 'location-based'
+      end
+
+      def world_downloadable?
+        download == 'world'
+      end
+
+      def stanford_only_downloadable?
+        download == 'stanford'
       end
 
       def hierarchical_title

--- a/spec/factories/files.rb
+++ b/spec/factories/files.rb
@@ -101,19 +101,19 @@ FactoryBot.define do
   end
 
   trait :stanford_only do
-    stanford_only { true }
-    stanford_only_downloadable { true }
+    view { 'stanford' }
+    download { 'stanford' }
   end
 
   trait :world_downloadable do
-    world_downloadable { true }
+    download { 'world' }
   end
 
   trait :no_download do
-    world_downloadable { false }
+    download { 'none' }
   end
 
   trait :location_restricted do
-    location_restricted { true }
+    download { 'location-based' }
   end
 end


### PR DESCRIPTION
Rather than decoding the attributes while deserializing.  This is now possible that we've migrated completely to cocina.  The old way was a bit confusing but supported both the XML and JSON serialization