### PR TITLE
Set .locked-status to  display: block so lock image will center

### DIFF
--- a/app/assets/stylesheets/locked_status.css
+++ b/app/assets/stylesheets/locked_status.css
@@ -1,4 +1,5 @@
 .locked-status {
+  display: block;
   overflow: hidden;
   height: 100%;
   text-align: center;


### PR DESCRIPTION
Fixes #2696 

Before:
<img width="1135" alt="Screenshot 2025-03-03 at 9 41 40 AM" src="https://github.com/user-attachments/assets/a0b4c4a4-c2b0-424f-a9e9-b1edaa914827" />

After:
<img width="1149" alt="Screenshot 2025-03-03 at 9 41 31 AM" src="https://github.com/user-attachments/assets/024fb3dc-715f-40ac-be24-24affffdf1c4" />
