### PR TITLE
Deserialize download and view to the purl object

### DIFF
--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -16,12 +16,10 @@ module Embed
 
     attr_accessor :druid, :version_id, :type, :title, :use_and_reproduction, :copyright, :contents, :collections,
                   :license, :bounding_box, :embargo_release_date, :archived_site_url, :external_url,
-                  :embargoed, :stanford_only_unrestricted, :public, :controlled_digital_lending,
+                  :embargoed, :download, :view, :controlled_digital_lending,
                   :etag, :last_modified, :location_restriction, :restricted_location
 
     alias embargoed? embargoed
-    alias stanford_only_unrestricted? stanford_only_unrestricted
-    alias public? public
     alias controlled_digital_lending? controlled_digital_lending
 
     # @param [String] druid a druid without a namespace (e.g. "sx925dc9385")
@@ -33,6 +31,14 @@ module Embed
     # @returns [Bool] does this have any resources that can be embeded?
     def valid?
       contents.any?
+    end
+
+    def stanford_download?
+      download == 'stanford'
+    end
+
+    def public?
+      download == 'world'
     end
 
     def hierarchical_contents

--- a/app/models/embed/purl_json_loader.rb
+++ b/app/models/embed/purl_json_loader.rb
@@ -28,9 +28,9 @@ module Embed
         embargoed:,
         location_restriction:,
         restricted_location:,
-        stanford_only_unrestricted:,
-        controlled_digital_lending:,
-        public:
+        download:,
+        view:,
+        controlled_digital_lending:
       }
     end
 
@@ -65,16 +65,16 @@ module Embed
       fallback_message
     end
 
-    def stanford_only_unrestricted
-      json.dig('access', 'download') == 'stanford'
+    def download
+      json.dig('access', 'download')
+    end
+
+    def view
+      json.dig('access', 'view')
     end
 
     def controlled_digital_lending
       json.dig('access', 'controlledDigitalLending')
-    end
-
-    def public
-      json.dig('access', 'download') == 'world'
     end
 
     def archived_site_url

--- a/app/viewers/embed/viewer/authorization.rb
+++ b/app/viewers/embed/viewer/authorization.rb
@@ -12,7 +12,7 @@ module Embed
       def message
         return { type: 'embargo', message: embargo_message } if @purl_object.embargoed?
 
-        if @purl_object.stanford_only_unrestricted?
+        if @purl_object.stanford_download?
           return { type: 'stanford',
                    message: I18n.t('restrictions.stanford_only_file') }
         end
@@ -37,7 +37,7 @@ module Embed
       def embargo_message
         message = []
 
-        message << if @purl_object.stanford_only_unrestricted?
+        message << if @purl_object.stanford_download?
                      'Access is restricted to Stanford-affiliated patrons'
                    else
                      'Access is restricted'

--- a/spec/factories/purls.rb
+++ b/spec/factories/purls.rb
@@ -15,11 +15,7 @@ FactoryBot.define do
 
     trait :embargoed_stanford do
       embargoed
-      stanford_only_unrestricted { true }
-    end
-
-    trait :public do
-      public { true }
+      download { 'stanford' }
     end
 
     trait :file do
@@ -51,7 +47,7 @@ FactoryBot.define do
       druid { 'cz128vq0535' }
       type { 'geo' }
       bounding_box { [['-1.478794', '29.572742'], ['4.234077', '35.000308']] }
-      public { true }
+      download { 'world' }
       contents { [build(:resource, :file, files: [build(:resource_file, :world_downloadable, filename: 'data.zip'), build(:resource_file, :world_downloadable, filename: 'data_EPSG_4326.zip')]), build(:resource, :image)] }
     end
 

--- a/spec/features/document_viewer_spec.rb
+++ b/spec/features/document_viewer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'PDF Viewer', :js do
   end
 
   context 'when world visible' do
-    let(:purl) { build(:purl, :public, :document) }
+    let(:purl) { build(:purl, :document, download: 'world') }
 
     it 'renders the PDF viewer for documents' do
       expect(page).to have_css('.sul-embed-pdf')

--- a/spec/features/geo_viewer_spec.rb
+++ b/spec/features/geo_viewer_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'geo viewer', :js do
   end
 
   context 'with restricted purl' do
-    let(:purl) { build(:purl, :geo, public: false) }
+    let(:purl) { build(:purl, :geo, download: 'stanford') }
 
     before do
       visit_iframe_response

--- a/spec/lib/embed/viewer/geo_spec.rb
+++ b/spec/lib/embed/viewer/geo_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Embed::Viewer::Geo do
     subject(:options) { geo_viewer.map_element_options }
 
     context 'with public content' do
-      let(:purl) { build(:purl, bounding_box: [['-1.478794', '29.572742'], ['4.234077', '35.000308']], public: true) }
+      let(:purl) { build(:purl, bounding_box: [['-1.478794', '29.572742'], ['4.234077', '35.000308']], download: 'world') }
 
       it 'has the required options' do
         expect(options).to include({ style: 'flex: 1', id: 'sul-embed-geo-map',
@@ -32,7 +32,7 @@ RSpec.describe Embed::Viewer::Geo do
     end
 
     context 'with restricted content' do
-      let(:purl) { build(:purl, bounding_box: [['38.298673', '-123.387626'], ['39.399103', '-122.528843']], public: false) }
+      let(:purl) { build(:purl, bounding_box: [['38.298673', '-123.387626'], ['39.399103', '-122.528843']], download: 'stanford') }
 
       it 'has the required options' do
         expect(options).to include({ style: 'flex: 1', id: 'sul-embed-geo-map',

--- a/spec/models/embed/purl_json_loader_spec.rb
+++ b/spec/models/embed/purl_json_loader_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Embed::PurlJsonLoader do
       context 'with a public purl with file type' do
         let(:json) { file_purl_json }
 
-        it { is_expected.to include({ title: 'File Title', type: 'file', embargoed: false, public: true }) }
+        it { is_expected.to include({ title: 'File Title', type: 'file', embargoed: false, download: 'world' }) }
 
         it 'has contents' do
           expect(data[:contents]).to all(be_a(Embed::Purl::Resource))
@@ -41,7 +41,7 @@ RSpec.describe Embed::PurlJsonLoader do
       context 'with a public purl with collection type' do
         let(:json) { collection_purl_json }
 
-        it { is_expected.to include({ title: 'captioned media', type: 'collection', embargoed: false, public: false }) }
+        it { is_expected.to include({ title: 'captioned media', type: 'collection', embargoed: false, download: nil }) }
 
         it 'has empty contents' do
           expect(data[:contents]).to all(be_a(Embed::Purl::Resource))
@@ -51,19 +51,19 @@ RSpec.describe Embed::PurlJsonLoader do
       context 'with a stanford only purl with file type' do
         let(:json) { stanford_restricted_file_purl_json }
 
-        it { is_expected.to include({ type: 'file', embargoed: false, public: false, stanford_only_unrestricted: true }) }
+        it { is_expected.to include({ type: 'file', embargoed: false, download: 'stanford', view: 'stanford' }) }
       end
 
       context 'with an embargoed purl with file type' do
         let(:json) { embargoed_file_purl_json }
 
-        it { is_expected.to include({ embargoed: true, embargo_release_date: '2053-12-21', public: false }) }
+        it { is_expected.to include({ embargoed: true, embargo_release_date: '2053-12-21', download: 'stanford' }) }
       end
 
       context 'with a location based embargoed purl' do
         let(:json) { location_embargoed_file_purl_json }
 
-        it { is_expected.to include({ embargoed: true, restricted_location: 'Special Collections reading room', embargo_release_date: '2053-12-21', public: false }) }
+        it { is_expected.to include({ embargoed: true, restricted_location: 'Special Collections reading room', embargo_release_date: '2053-12-21', download: 'location-based' }) }
       end
 
       context 'with a was seed' do

--- a/spec/models/embed/purl_spec.rb
+++ b/spec/models/embed/purl_spec.rb
@@ -67,20 +67,6 @@ RSpec.describe Embed::Purl do
     end
   end
 
-  describe '#public?' do
-    context 'when an item is public' do
-      subject(:purl) { described_class.new(public: true) }
-
-      it { is_expected.to be_public }
-    end
-
-    context 'when an item is not public' do
-      subject(:purl) { described_class.new(public: false) }
-
-      it { is_expected.not_to be_public }
-    end
-  end
-
   describe 'embargo_release_date' do
     let(:purl) { described_class.new(embargo_release_date: '2053-12-21') }
 


### PR DESCRIPTION
We no longer need more abstract terms, since we don't also need to support XML