### PR TITLE
Revert part of 961dc7fefb8c0739e1e2c888fe5802cb306094d5

### DIFF
--- a/app/components/media_component.html.erb
+++ b/app/components/media_component.html.erb
@@ -48,7 +48,7 @@
       <div data-auth-restriction-target="locationRestriction" hidden>
         <div class="authLinkWrapper">
           <%= render Icons::LockGlobeComponent.new %>
-          <p class="loginMessage"><%= I18n.t('restrictions.restricted_access', location: purl_object.restricted_location) %></p>
+          <p class="loginMessage">Access is restricted to the reading room. See Access conditions for more information.</p>
         </div>
       </div>
       <div data-auth-restriction-target="stanfordRestriction" hidden>


### PR DESCRIPTION
This message is handled by the front end for the media viewer.  It's confusing if we have auth on both the front end and the backend and we're unsure of which code governs what the user sees.

https://github.com/sul-dlss/sul-embed/blob/main/app/javascript/controllers/auth_restriction_controller.js\#L51-L55