### PR TITLE
Drop druid: prefix from stacks url

### DIFF
--- a/app/models/embed/purl/resource_file.rb
+++ b/app/models/embed/purl/resource_file.rb
@@ -36,8 +36,10 @@ module Embed
         uri.to_s
       end
 
+      # @return [String] the URL for the file in stacks.  We don't add a druid: prefix, so that the file URLs are
+      #                  consistent with how the URLs are formed in a IIIF manifest
       def stacks_url
-        "#{Settings.stacks_url}/file/druid:#{@druid}"
+        "#{Settings.stacks_url}/file/#{@druid}"
       end
 
       def versioned_stacks_url

--- a/spec/components/file_component_spec.rb
+++ b/spec/components/file_component_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe FileComponent, type: :component do
 
     it 'adds a Stanford specific embargo message with links still present' do
       expect(page).to have_css('div[aria-label="Access message"]', visible: :all, text: 'Access is restricted to Stanford-affiliated patrons until 21-Dec-2053')
-      expect(page).to have_css('tr[data-tree-role="leaf"] a[href="https://stacks.stanford.edu/file/druid:bc123df4567/Title%20of%20the%20PDF.pdf"]', visible: :all)
+      expect(page).to have_css('tr[data-tree-role="leaf"] a[href="https://stacks.stanford.edu/file/bc123df4567/Title%20of%20the%20PDF.pdf"]', visible: :all)
     end
 
     it 'includes an element with a stanford icon class (with screen reader text)' do
@@ -133,7 +133,7 @@ RSpec.describe FileComponent, type: :component do
 
       it 'leaves correctly formatted filenames alone' do
         link = page.find('tr[data-tree-role="leaf"] a', match: :first, visible: :all)
-        expect(link['href']).to eq('https://stacks.stanford.edu/file/druid:bc123df4567/Title_of_the_PDF.pdf')
+        expect(link['href']).to eq('https://stacks.stanford.edu/file/bc123df4567/Title_of_the_PDF.pdf')
       end
     end
 
@@ -142,7 +142,7 @@ RSpec.describe FileComponent, type: :component do
 
       it 'encodes them' do
         link = page.find('tr[data-tree-role="leaf"] a', match: :first, visible: :all)
-        expect(link['href']).to eq('https://stacks.stanford.edu/file/druid:bc123df4567/%23Title%20of%20the%20PDF.pdf')
+        expect(link['href']).to eq('https://stacks.stanford.edu/file/bc123df4567/%23Title%20of%20the%20PDF.pdf')
       end
     end
   end

--- a/spec/components/legacy/download/geo_component_spec.rb
+++ b/spec/components/legacy/download/geo_component_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Legacy::Download::GeoComponent, type: :component do
 
     it 'generates a file list' do
       expect(page).to have_css 'li', visible: :all, count: 3
-      expect(page).to have_link href: 'https://stacks.stanford.edu/file/druid:bc123df4567/data.zip?download=true', visible: :all
+      expect(page).to have_link href: 'https://stacks.stanford.edu/file/bc123df4567/data.zip?download=true', visible: :all
     end
   end
 

--- a/spec/components/legacy/file_component_spec.rb
+++ b/spec/components/legacy/file_component_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Legacy::FileComponent, type: :component do
 
     it 'adds a Stanford specific embargo message with links still present' do
       expect(page).to have_css('.sul-embed-embargo-message', visible: :all, text: 'Access is restricted to Stanford-affiliated patrons until 21-Dec-2053')
-      expect(page).to have_css('tr[data-tree-role="leaf"] a[href="https://stacks.stanford.edu/file/druid:bc123df4567/Title%20of%20the%20PDF.pdf"]', visible: :all)
+      expect(page).to have_css('tr[data-tree-role="leaf"] a[href="https://stacks.stanford.edu/file/bc123df4567/Title%20of%20the%20PDF.pdf"]', visible: :all)
     end
 
     it 'includes an element with a stanford icon class (with screen reader text)' do
@@ -124,7 +124,7 @@ RSpec.describe Legacy::FileComponent, type: :component do
       it 'leaves correctly formatted filenames alone' do
         expect(page).to have_css '.sul-embed-body.sul-embed-file', visible: :all
         link = page.find('tr[data-tree-role="leaf"] a', match: :first, visible: :all)
-        expect(link['href']).to eq('https://stacks.stanford.edu/file/druid:bc123df4567/Title_of_the_PDF.pdf')
+        expect(link['href']).to eq('https://stacks.stanford.edu/file/bc123df4567/Title_of_the_PDF.pdf')
       end
     end
 
@@ -134,7 +134,7 @@ RSpec.describe Legacy::FileComponent, type: :component do
       it 'encodes them' do
         expect(page).to have_css '.sul-embed-body.sul-embed-file', visible: :all
         link = page.find('tr[data-tree-role="leaf"] a', match: :first, visible: :all)
-        expect(link['href']).to eq('https://stacks.stanford.edu/file/druid:bc123df4567/%23Title%20of%20the%20PDF.pdf')
+        expect(link['href']).to eq('https://stacks.stanford.edu/file/bc123df4567/%23Title%20of%20the%20PDF.pdf')
       end
     end
   end

--- a/spec/components/media/tag_component_spec.rb
+++ b/spec/components/media/tag_component_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Media::TagComponent, type: :component do
     let(:resource) { build(:resource, :video) }
 
     it 'has a track element' do
-      expect(page).to have_css('track[src="https://stacks.stanford.edu/file/druid:bc123df4567/abc_123_cap.vtt"]')
+      expect(page).to have_css('track[src="https://stacks.stanford.edu/file/bc123df4567/abc_123_cap.vtt"]')
     end
 
     context 'with captions for multiple languages' do

--- a/spec/features/geo_viewer_spec.rb
+++ b/spec/features/geo_viewer_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe 'geo viewer', :js do
           # find this svg element on the page.
           # We also need to explicitly wait for the JS to run.
           expect(page).to have_css('.sul-embed-geo', count: 1, visible: :visible)
-          expect(page).to have_css "[data-index-map=\"https://stacks.stanford.edu/file/druid:ts545zc6250/#{filename}\"]"
+          expect(page).to have_css "[data-index-map=\"https://stacks.stanford.edu/file/ts545zc6250/#{filename}\"]"
           # only count paths within .leaflet-overlay-pane for testing
           # (page.body contains SVG logos we don't care to count)
           find '.leaflet-overlay-pane'
@@ -124,7 +124,7 @@ RSpec.describe 'geo viewer', :js do
           # find this svg element on the page.
           # We also need to explicitly wait for the JS to run.
           expect(page).to have_css('.sul-embed-geo', count: 1, visible: :visible)
-          expect(page).to have_css "[data-index-map=\"https://stacks.stanford.edu/file/druid:ts545zc6250/#{filename}\"]"
+          expect(page).to have_css "[data-index-map=\"https://stacks.stanford.edu/file/ts545zc6250/#{filename}\"]"
         end
       end
     end

--- a/spec/models/embed/purl/resource_file_spec.rb
+++ b/spec/models/embed/purl/resource_file_spec.rb
@@ -28,19 +28,19 @@ RSpec.describe Embed::Purl::ResourceFile do
     let(:resource) { instance_double(Embed::Purl::Resource, druid: 'abc123') }
     let(:resource_file) { described_class.new(druid: 'abc123', filename:) }
 
-    it 'creates a stacks file url' do
-      expect(resource_file.file_url).to eq 'https://stacks.stanford.edu/file/druid:abc123/cool_file'
+    it 'creates a stacks file url without a prefix' do
+      expect(resource_file.file_url).to eq 'https://stacks.stanford.edu/file/abc123/cool_file'
     end
 
     it 'adds a download param' do
-      expect(resource_file.file_url(download: true)).to eq 'https://stacks.stanford.edu/file/druid:abc123/cool_file?download=true'
+      expect(resource_file.file_url(download: true)).to eq 'https://stacks.stanford.edu/file/abc123/cool_file?download=true'
     end
 
     context 'when there are special characters in the file name' do
       let(:filename) { '[Dissertation] micro-TEC vfinal (for submission)-augmented.pdf' }
 
       it 'escapes them' do
-        expect(resource_file.file_url).to eq 'https://stacks.stanford.edu/file/druid:abc123/%5BDissertation%5D%20micro-TEC%20vfinal%20%28for%20submission%29-augmented.pdf'
+        expect(resource_file.file_url).to eq 'https://stacks.stanford.edu/file/abc123/%5BDissertation%5D%20micro-TEC%20vfinal%20%28for%20submission%29-augmented.pdf'
       end
     end
 
@@ -49,7 +49,7 @@ RSpec.describe Embed::Purl::ResourceFile do
 
       it 'allows them' do
         expect(resource_file.file_url)
-          .to eq 'https://stacks.stanford.edu/file/druid:abc123/path/to/%5BDissertation%5D%20micro-TEC%20vfinal%20%28for%20submission%29-augmented.pdf'
+          .to eq 'https://stacks.stanford.edu/file/abc123/path/to/%5BDissertation%5D%20micro-TEC%20vfinal%20%28for%20submission%29-augmented.pdf'
       end
     end
   end


### PR DESCRIPTION
This makes the URL consistent with how they are in the IIIF manifest, which makes it possible to compare them.