### PR TITLE
Let modal use up more vertical space

### DIFF
--- a/app/assets/stylesheets/companion_window.css
+++ b/app/assets/stylesheets/companion_window.css
@@ -104,7 +104,6 @@ body {
   .modal-container {
     max-width: var(--modal-max-width);
     width: 79vw;
-    max-height: 79vh;
     padding: 0px;
     margin: auto;
     border: none;
@@ -124,7 +123,7 @@ body {
 
     .modal-main {
       color: var(--text-color);
-      max-height: 35vh;
+      max-height: 60vh;
       overflow-y: auto;
       padding: 0 2rem;
 


### PR DESCRIPTION
Before:
<img width="915" alt="Screenshot 2025-03-04 at 2 14 49 PM" src="https://github.com/user-attachments/assets/b42130fe-7738-423a-a448-b90386bc0149" />

After:
<img width="914" alt="Screenshot 2025-03-04 at 2 14 31 PM" src="https://github.com/user-attachments/assets/6a4f3d14-a7fc-404e-9450-570210e3e96a" />
