### PR TITLE
align stanford only icon differently based on location in viewer

### DIFF
--- a/app/assets/stylesheets/common.css
+++ b/app/assets/stylesheets/common.css
@@ -29,13 +29,18 @@ a:focus {
 
 /* TODO: Remove this class and replace with Icons::StanfordOnlyComponent when we remove legacy file viewer */
 .sul-embed-stanford-only-text {
+  --vertical-align-position: top;
   background:
     url("stanford_s.svg") no-repeat left,
     none;
   display: inline-block;
   height: 15px;
   width: 15px;
-  vertical-align: top;
+  vertical-align: var(--vertical-align-position);
+}
+
+.left-drawer .sul-embed-stanford-only-text {
+  --vertical-align-position: sub;
 }
 
 .sul-embed-location-restricted-text {


### PR DESCRIPTION
closes #2741 
<img width="782" alt="Screenshot 2025-03-04 at 3 16 57 PM" src="https://github.com/user-attachments/assets/1282ccc5-f902-4c01-afc1-7b44abf9da57" />
<img width="1092" alt="Screenshot 2025-03-04 at 3 16 52 PM" src="https://github.com/user-attachments/assets/8fa221f5-7a52-4b5c-93c9-21b81f5dd694" />
