### PR TITLE
show pdf location restriction banner per file

### DIFF
--- a/app/components/location_restriction_component.html.erb
+++ b/app/components/location_restriction_component.html.erb
@@ -1,0 +1,6 @@
+<div data-file-auth-target="locationRestriction" hidden>
+    <div class="authLinkWrapper">
+        <%= render Icons::LockGlobeComponent.new %>
+        <p class="loginMessage" data-file-auth-target="locationRestrictionMessage"></p>
+    </div>
+</div>

--- a/app/components/location_restriction_component.rb
+++ b/app/components/location_restriction_component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# This is only used by the PdfComponent
+class LocationRestrictionComponent < ViewComponent::Base
+end

--- a/app/components/pdf_component.html.erb
+++ b/app/components/pdf_component.html.erb
@@ -9,6 +9,7 @@
 
   <% component.with_authorization_messages do %>
     <%= render LoginComponent.new %>
+    <%= render LocationRestrictionComponent.new %>
     <%= render CompanionWindows::ContentNotAvailableComponent.new unless viewer.available? %>
   <% end %>
 

--- a/app/javascript/controllers/file_auth_controller.js
+++ b/app/javascript/controllers/file_auth_controller.js
@@ -286,22 +286,11 @@ export default class extends Controller {
   // This code depends on the text returned by probe service, so changes to the heading
   // should be reflected here as well.
   isLocationRestricted(json) {
-    if(json.status == '401' && 'heading' in json && 'en' in json.heading && json.heading.en.length
-      && json.heading.en[0].startsWith('Content is restricted to location'))
-      return true
-    return false
-  }
-
-  // Extract just the location from the message
-  extractRestrictedLocation(accessMessage) {
-    const probeServicePrefix = 'Content is restricted to location '
-    if(accessMessage != null && accessMessage.startsWith(probeServicePrefix))
-      return accessMessage.substring(probeServicePrefix.length, accessMessage.length)
-
-    return 'site visitors to the Stanford libraries'
+    return json.status == '401' && 'heading' in json && 'en' in json.heading && json.heading.en.length
+      && json.heading.en[0].startsWith('Access is restricted to the')
   }
 
   retrieveRestrictedLocationMessage(json) {
-    return 'Access is restricted to the ' + this.extractRestrictedLocation(json.heading.en[0]) + '. See Access conditions for more information.'
+    return json.heading.en[0]
   }
 }

--- a/app/javascript/controllers/file_auth_controller.js
+++ b/app/javascript/controllers/file_auth_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["container", "loginPanel", "messagePanel", "loginButton", "loginMessage"]
+  static targets = ["container", "loginPanel", "messagePanel", "loginButton", "loginMessage", "locationRestriction", "locationRestrictionMessage"]
 
   resources = {} // Hash of messageIds to resources
 
@@ -45,6 +45,7 @@ export default class extends Controller {
   }
 
   // Triggered when clicking on a thumbnail
+  // Leads to authorization check of the file and displays the correct access banner or renders viewer
   authFileAndDisplay(event) {
     const document = this.documents.find((document) => document.id == event.detail.fileUri)
     if (document)
@@ -56,6 +57,8 @@ export default class extends Controller {
   // Try to render the resource, checks for any required authorization and shows login window if needed
   maybeDrawContentResource(contentResource) {
     console.debug("Now figure out if we can render", contentResource)
+    // Ensure location restriction banner is hidden by default in case it was visible for the previous document 
+    this.locationRestrictionTarget.hidden = true
     if (!contentResource.service) {
       // no auth service is present, just render the resource
       this.renderViewer({ fileUri: contentResource.id })
@@ -135,6 +138,10 @@ export default class extends Controller {
     this.queryProbeService(messageId)
       .then((result) => this.renderViewer(result))
       .catch((json) => {
+        if(this.isLocationRestricted(json)) {
+          this.handleLocationRestricted(json, accessService)
+          return
+        }
         console.debug("Probe failed or access denied/restricted", json)
         // Check if non-expired token already exists in local storage,
         // and if it exists, query probe service with it
@@ -258,5 +265,43 @@ export default class extends Controller {
 
   hideMessagePanel() {
     this.messagePanelTarget.hidden = true
+  }
+
+  // To see if item is restricted by location, check the probe service json response
+  handleLocationRestricted(json, accessService) {
+    // The probe auth service is called for each file separately.
+    // If the location restriction target is available, then trigger auth denied message.
+    // The event will lead to the locked icon being displayed for this item
+    // This allows the lock window to show
+    const event = new CustomEvent('auth-denied', { accessService: accessService })
+    window.dispatchEvent(event)
+    // Make the location restricted banner visible
+    this.locationRestrictionTarget.hidden = false
+    // Display the location restriction message based on the authorization response
+    this.locationRestrictionMessageTarget.innerHTML = this.retrieveRestrictedLocationMessage(json)
+
+  }
+
+  // Checks the result of the probe auth request to see if access is restricted to location
+  // This code depends on the text returned by probe service, so changes to the heading
+  // should be reflected here as well.
+  isLocationRestricted(json) {
+    if(json.status == '401' && 'heading' in json && 'en' in json.heading && json.heading.en.length
+      && json.heading.en[0].startsWith('Content is restricted to location'))
+      return true
+    return false
+  }
+
+  // Extract just the location from the message
+  extractRestrictedLocation(accessMessage) {
+    const probeServicePrefix = 'Content is restricted to location '
+    if(accessMessage != null && accessMessage.startsWith(probeServicePrefix))
+      return accessMessage.substring(probeServicePrefix.length, accessMessage.length)
+
+    return 'site visitors to the Stanford libraries'
+  }
+
+  retrieveRestrictedLocationMessage(json) {
+    return 'Access is restricted to the ' + this.extractRestrictedLocation(json.heading.en[0]) + '. See Access conditions for more information.'
   }
 }

--- a/app/viewers/embed/viewer/document_viewer.rb
+++ b/app/viewers/embed/viewer/document_viewer.rb
@@ -31,7 +31,7 @@ module Embed
       # as well as location restricted.  Authorization for other documents will be
       # checked as the user clicks on items in the content side bar.
       def available?
-        !(document_resource_files.first&.no_download?)
+        !document_resource_files.first&.no_download?
       end
 
       private

--- a/app/viewers/embed/viewer/document_viewer.rb
+++ b/app/viewers/embed/viewer/document_viewer.rb
@@ -31,7 +31,7 @@ module Embed
       # as well as location restricted.  Authorization for other documents will be
       # checked as the user clicks on items in the content side bar.
       def available?
-        document_resource_files.first&.downloadable? || document_resource_files.first&.location_restricted?
+        !(document_resource_files.first&.no_download?)
       end
 
       private

--- a/app/viewers/embed/viewer/document_viewer.rb
+++ b/app/viewers/embed/viewer/document_viewer.rb
@@ -27,15 +27,11 @@ module Embed
         true
       end
 
-      def all_documents_location_restricted?
-        document_resource_files.all?(&:location_restricted?)
-      end
-
-      # this indicates if the PDF is downloadable (though it could be stanford only)
-      # Stanford only and location restrictions are handled via a separate authorization flow,
-      # since it is possible for people to do something about the restriction
+      # This indicates if the first PDF is downloadable (though it could be stanford only)
+      # as well as location restricted.  Authorization for other documents will be
+      # checked as the user clicks on items in the content side bar.
       def available?
-        document_resource_files.first&.downloadable?
+        document_resource_files.first&.downloadable? || document_resource_files.first&.location_restricted?
       end
 
       private

--- a/spec/components/location_restriction_component_spec.rb
+++ b/spec/components/location_restriction_component_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LocationRestrictionComponent, type: :component do
+  before do
+    render_inline(described_class.new)
+  end
+
+  # The location restriction banner is hidden so search with visible: :all
+  it 'renders banner target for the file auth controller' do
+    expect(page).to have_css('div[data-file-auth-target="locationRestriction"]', visible: :all)
+  end
+
+  it 'renders message target for the file auth controller' do
+    expect(page).to have_css('p[data-file-auth-target="locationRestrictionMessage"]', visible: :all)
+  end
+end

--- a/spec/components/pdf_component_spec.rb
+++ b/spec/components/pdf_component_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe PdfComponent, type: :component do
     end
   end
 
+  it 'includes access restriction method section' do
+    expect(page).to have_css('div[data-file-auth-target="locationRestriction"]', visible: :all)
+  end
+
   context 'when hide_title is passed' do
     let(:embed_request) { Embed::Request.new(url:, hide_title: 'true') }
 

--- a/spec/lib/embed/viewer/document_viewer_spec.rb
+++ b/spec/lib/embed/viewer/document_viewer_spec.rb
@@ -34,12 +34,12 @@ RSpec.describe Embed::Viewer::DocumentViewer do
   end
 
   describe '#available?' do
-    context 'when the first file in the documents is location restricted and not downloadable' do
+    context 'when the first file in the documents is location restricted and downloadable' do
       let(:purl) do
         instance_double(
           Embed::Purl,
           contents: [
-            instance_double(Embed::Purl::Resource, type: 'document', files: [instance_double(Embed::Purl::ResourceFile, title: 'doc-abc123.pdf', location_restricted?: true, downloadable?: false)])
+            instance_double(Embed::Purl::Resource, type: 'document', files: [instance_double(Embed::Purl::ResourceFile, title: 'doc-abc123.pdf', location_restricted?: true, no_download?: false)])
           ],
           druid: 'abc123'
         )
@@ -48,18 +48,31 @@ RSpec.describe Embed::Viewer::DocumentViewer do
       it { expect(pdf_viewer.available?).to be true }
     end
 
-    context 'when the first file in the document is downloadable and not location restricted' do
+    context 'when the first file in the document is not location restricted and downloadable' do
       let(:purl) do
         instance_double(
           Embed::Purl,
           contents: [
-            instance_double(Embed::Purl::Resource, type: 'document', files: [instance_double(Embed::Purl::ResourceFile, title: 'doc-abc123.pdf', location_restricted?: false, downloadable?: true)])
+            instance_double(Embed::Purl::Resource, type: 'document', files: [instance_double(Embed::Purl::ResourceFile, title: 'doc-abc123.pdf', location_restricted?: false, no_download?: false)])
           ],
           druid: 'abc123'
         )
       end
 
       it { expect(pdf_viewer.available?).to be true }
+    end
+    context 'when the first file in the document is not downloadable' do
+      let(:purl) do
+        instance_double(
+          Embed::Purl,
+          contents: [
+            instance_double(Embed::Purl::Resource, type: 'document', files: [instance_double(Embed::Purl::ResourceFile, title: 'doc-abc123.pdf', location_restricted?: false, no_download?: true)])
+          ],
+          druid: 'abc123'
+        )
+      end
+
+      it { expect(pdf_viewer.available?).to be false }
     end
   end
 end

--- a/spec/lib/embed/viewer/document_viewer_spec.rb
+++ b/spec/lib/embed/viewer/document_viewer_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe Embed::Viewer::DocumentViewer do
 
       it { expect(pdf_viewer.available?).to be true }
     end
+
     context 'when the first file in the document is not downloadable' do
       let(:purl) do
         instance_double(

--- a/spec/lib/embed/viewer/document_viewer_spec.rb
+++ b/spec/lib/embed/viewer/document_viewer_spec.rb
@@ -33,33 +33,33 @@ RSpec.describe Embed::Viewer::DocumentViewer do
     end
   end
 
-  describe '#all_documents_location_restricted?' do
-    context 'when all the files in the documents are location restricted' do
+  describe '#available?' do
+    context 'when the first file in the documents is location restricted and not downloadable' do
       let(:purl) do
         instance_double(
           Embed::Purl,
           contents: [
-            instance_double(Embed::Purl::Resource, type: 'document', files: [instance_double(Embed::Purl::ResourceFile, title: 'doc-abc123.pdf', location_restricted?: true)])
+            instance_double(Embed::Purl::Resource, type: 'document', files: [instance_double(Embed::Purl::ResourceFile, title: 'doc-abc123.pdf', location_restricted?: true, downloadable?: false)])
           ],
           druid: 'abc123'
         )
       end
 
-      it { expect(pdf_viewer.all_documents_location_restricted?).to be true }
+      it { expect(pdf_viewer.available?).to be true }
     end
 
-    context 'when all the files in the documents are not location restricted' do
+    context 'when the first file in the document is downloadable and not location restricted' do
       let(:purl) do
         instance_double(
           Embed::Purl,
           contents: [
-            instance_double(Embed::Purl::Resource, type: 'document', files: [instance_double(Embed::Purl::ResourceFile, title: 'doc-abc123.pdf', location_restricted?: false)])
+            instance_double(Embed::Purl::Resource, type: 'document', files: [instance_double(Embed::Purl::ResourceFile, title: 'doc-abc123.pdf', location_restricted?: false, downloadable?: true)])
           ],
           druid: 'abc123'
         )
       end
 
-      it { expect(pdf_viewer.all_documents_location_restricted?).to be false }
+      it { expect(pdf_viewer.available?).to be true }
     end
   end
 end


### PR DESCRIPTION
Closes #2360  

What this pull request does:

- Sets up a location restricted banner that is hidden when the page loads
- Changes the logic for when the viewer is available. It is now true unless the status for the first file is "not downloadable"
- Sets up  the file auth controller to check the location restriction message from stacks, and then show the location restriction banner and update the message to be the one returned from stacks


Note: This should work in staging, but the stacks changes will need to be pushed to production first for these embed changes to work in production 