### PR TITLE
Scope embed modal styles to .sul-embed-embed-this-form; fixes stanford-only icon alignment

### DIFF
--- a/app/assets/stylesheets/companion_window.css
+++ b/app/assets/stylesheets/companion_window.css
@@ -143,17 +143,19 @@ body {
         background: none;
       }
 
-      svg {
-        vertical-align: middle;
-      }
+      .sul-embed-embed-this-form {
+        svg {
+          vertical-align: middle;
+        }
 
-      ul {
-        list-style: none;
-        padding: 0px;
+        ul {
+          list-style: none;
+          padding: 0px;
 
-        li {
-          margin-left: var(--drawer-content-padding);
-          margin-bottom: 1rem;
+          li {
+            margin-left: var(--drawer-content-padding);
+            margin-bottom: 1rem;
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes #2759 

Before:
<img width="604" alt="Screenshot 2025-03-07 at 10 41 59 AM" src="https://github.com/user-attachments/assets/0bfe31a6-1176-4870-85c7-6a3ee80537a8" />

After:
<img width="605" alt="Screenshot 2025-03-07 at 10 41 32 AM" src="https://github.com/user-attachments/assets/9e5c2eb7-7c2f-43d8-a89c-02d107f28af4" />
