### PR TITLE
Remove redundant access message banner div

### DIFF
--- a/app/components/embed/file/auth_messages_component.html.erb
+++ b/app/components/embed/file/auth_messages_component.html.erb
@@ -1,8 +1,6 @@
-<div role="banner" aria-label="Access message">
-  <div class="authLinkWrapper">
-    <%= render icon.new %>
-    <p class="loginMessage">
-      <%= message[:message] %>
-    </p>
-  </div>
+<div class="authLinkWrapper">
+  <%= render icon.new %>
+  <p class="loginMessage">
+    <%= message[:message] %>
+  </p>
 </div>

--- a/spec/components/embed/file/auth_messages_component_spec.rb
+++ b/spec/components/embed/file/auth_messages_component_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Embed::File::AuthMessagesComponent, type: :component do
 
     it 'has svg and message' do
       expect(page).to have_css('svg')
-      expect(page).to have_css('div[aria-label="Access message"]')
+      expect(page).to have_css('.authLinkWrapper')
       expect(page).to have_content('Embargo message')
     end
   end
@@ -24,7 +24,7 @@ RSpec.describe Embed::File::AuthMessagesComponent, type: :component do
 
     it 'has svg and message' do
       expect(page).to have_css('svg')
-      expect(page).to have_css('div[aria-label="Access message"]')
+      expect(page).to have_css('.authLinkWrapper')
       expect(page).to have_content('Location restricted message')
     end
   end


### PR DESCRIPTION
`Embed::File::AuthMessagesComponent` gets rendered within `CompanionWindowsComponent#authorization_messages` that already wraps auth messages in this div. We don't need this twice.
<img width="588" alt="Screenshot 2025-03-10 at 11 10 27 AM" src="https://github.com/user-attachments/assets/3a37c671-2c36-42c7-9519-cf5b1accc161" />
