### PR TITLE
Adjust auth bar font size and padding to match designs

### DIFF
--- a/app/assets/stylesheets/companion_window.css
+++ b/app/assets/stylesheets/companion_window.css
@@ -22,7 +22,8 @@ body {
   display: flex;
   background-color: var(--active-color);
   color: white;
-  padding: 0.5rem;
+  padding: 0.75rem;
+  font-size: 1.125rem;
 
   svg:not(button svg) {
     /* Buttons have a left/right padding of 6px */
@@ -42,7 +43,7 @@ body {
     color: var(--active-color);
     border: 0;
     border-radius: 5px;
-    padding: 0.2rem 0.4rem;
+    padding: 0.3rem 0.6rem;
     text-transform: uppercase;
     &:hover {
       cursor: pointer;
@@ -51,7 +52,7 @@ body {
   }
 
   .dismissButton {
-    padding: 0.2rem;
+    padding: 0 0.1rem;
     svg {
       font-size: 1rem;
       vertical-align: bottom;
@@ -353,7 +354,7 @@ body {
   }
 
   [role="banner"]:not([hidden]) + .companion-window-component-body {
-    --auth-bar-height: 40px;
+    --auth-bar-height: 48px;
   }
 
   .companion-window-component-body {


### PR DESCRIPTION
[Figma designs](https://www.figma.com/design/LhMpFAHNwF6tPo53p2xzyz/Embed-Viewer-Components?node-id=148-896&t=RKK3CauCQbdVZHLm-0)

Increases font size to 1.125 rem (18px)
With padding increases overall height from 40px to 48px.
Adjust dismiss button so it doesn't change the height of the auth bar.

<img width="1228" alt="Screenshot 2025-03-10 at 4 51 08 PM" src="https://github.com/user-attachments/assets/ad5244e6-c336-4319-9763-b86a131367b3" />
<img width="1238" alt="Screenshot 2025-03-10 at 4 50 45 PM" src="https://github.com/user-attachments/assets/802458b6-7b5e-4883-a74f-76cd400f36cc" />
<img width="1228" alt="Screenshot 2025-03-10 at 4 50 19 PM" src="https://github.com/user-attachments/assets/5ab72da0-ae99-47a1-a239-1aa59e0589f7" />

I'll fix the `companion-window-component-body` height selector in a separate PR.