### PR TITLE
have transcript button showing on load

### DIFF
--- a/app/components/media_component.html.erb
+++ b/app/components/media_component.html.erb
@@ -15,7 +15,7 @@
   <% end %>
 
   <% component.with_drawer_button do %>
-    <%= render CompanionWindows::ControlButtonComponent.new(action: 'click->tab#switch', controller: 'tab', aria: { label: 'Transcript', controls: 'transcript' }, role: 'tab', data: { transcript_target: 'button' }, hidden: true) do %>
+    <%= render CompanionWindows::ControlButtonComponent.new(action: 'click->tab#switch', controller: 'tab', aria: { label: 'Transcript', controls: 'transcript' }, role: 'tab', data: { transcript_target: 'button' }, hidden: !downloadable_caption_files?) do %>
       <%= render Icons::DescriptionComponent.new %>
     <% end %>
   <% end %>
@@ -38,6 +38,7 @@
       <% end %>
       <% component.with_body do %>
         <div class="transcript" data-action="media-loaded@window->transcript#persistPlayer switch-transcript@window->transcript#switchTranscript media-data-loaded@window->transcript#load time-update@window->transcript#highlightCue" data-transcript-target="outlet">
+          <%= transcript_message %>
         </div>
       <% end %>
     <% end %>

--- a/app/components/media_component.rb
+++ b/app/components/media_component.rb
@@ -8,7 +8,15 @@ class MediaComponent < ViewComponent::Base
   attr_reader :viewer
 
   delegate :purl_object, to: :viewer
-  delegate :druid, :downloadable_transcript_files?, to: :purl_object
+  delegate :druid, :downloadable_transcript_files?, :downloadable_caption_files?, :downloadable_files, to: :purl_object
+
+  def transcript_message
+    return unless downloadable_caption_files?
+
+    return unless downloadable_files.any? { it.caption? && it.stanford_only? }
+
+    'Login in to view transcript'
+  end
 
   def resources_with_primary_file
     @resources_with_primary_file ||= purl_object.contents.select do |purl_resource|

--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -69,6 +69,10 @@ module Embed
       downloadable_files.any?(&:transcript?)
     end
 
+    def downloadable_caption_files?
+      downloadable_files.any?(&:caption?)
+    end
+
     def purl_url
       return "#{Settings.purl_url}/#{@druid}" if @version_id.blank?
 

--- a/spec/components/media_component_spec.rb
+++ b/spec/components/media_component_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe MediaComponent, type: :component do
     render_inline(described_class.new(viewer:))
   end
 
+  let(:downloadable_caption_files) { true }
+  let(:downloadable_files) { [] }
   let(:embed_request) { Embed::Request.new({}) }
   let(:viewer) do
     Embed::Viewer::Media.new(embed_request)
@@ -24,7 +26,8 @@ RSpec.describe MediaComponent, type: :component do
                     version_id: nil,
                     contents: [],
                     restricted_location: 'reading room',
-                    downloadable_files: [],
+                    downloadable_files:,
+                    downloadable_caption_files?: :downloadable_caption_files,
                     downloadable_transcript_files?: false)
   end
 
@@ -41,6 +44,28 @@ RSpec.describe MediaComponent, type: :component do
     expect(page).to have_content 'Access is restricted to the reading room. See Access conditions for more information.'
     expect(page).to have_content 'Stanford users: log in to access all available features'
     expect(page).to have_content 'Access is restricted until the embargo has elapsed'
+
+    within '.sul-embed-container' do
+      click_on 'Toggle sidebar'
+      expect(page).to have_css('[aria-label="Transcript"]', visible: :visible)
+    end
+  end
+
+  context 'when it has stanford only caption files' do
+    let(:downloadable_files) { [instance_double(Embed::Purl::MediaFile, caption?: true, stanford_only?: true)] }
+
+    it 'displays transcript sidebar with login message' do
+      expect(page).to have_css('[aria-label="Transcript"]', visible: :all)
+      expect(page).to have_content('Login in to view transcript')
+    end
+  end
+
+  context 'when it does not have caption files' do
+    let(:downloadable_caption_files?) { false }
+
+    it 'does not display transcript sidebar' do
+      expect(page).to have_css('[aria-label="Transcript"]', visible: :hidden)
+    end
   end
 
   context 'when hide_title is passed' do


### PR DESCRIPTION
closes #2757 

I kept the revealButton() in the controller because downloadable_caption_files? doesn't account for location restricted captions. If the user is in the correct location then the button will not show up. If we tried to make downloadable_caption_files? include location restricted, viewers will be getting an empty transcript sidebar when they aren't in the location. This makes it work for stanford and world viewable captions