### PR TITLE
show text for no_download? file items

### DIFF
--- a/app/assets/stylesheets/common.css
+++ b/app/assets/stylesheets/common.css
@@ -43,7 +43,7 @@ a:focus {
   --vertical-align-position: sub;
 }
 
-.sul-embed-location-restricted-text {
+.sul-embed-location-restricted-text, .stanford-digital-red {
   color: var(--stanford-digital-red);
 }
 

--- a/app/components/embed/file/file_row_component.html.erb
+++ b/app/components/embed/file/file_row_component.html.erb
@@ -20,6 +20,8 @@
         <span class="sul-embed-sr-only visually-hidden"><%= title %></span>
       </a>
       <%= render DownloadAccessComponent.new(file:) %>
+    <% else %>
+      <span class="stanford-digital-red">(Download unavailable)</span>
     <% end %>
   </td>
 </tr>


### PR DESCRIPTION
closes #2787 

![Screenshot 2025-03-14 at 4 27 40 PM](https://github.com/user-attachments/assets/0f1aef6d-d9eb-4ef7-a8f8-9afcde438e34)
