### PR TITLE
setting minimum height on td to ensure folder row is correct height

### DIFF
--- a/app/assets/stylesheets/file.css
+++ b/app/assets/stylesheets/file.css
@@ -137,6 +137,7 @@
   .folder-title {
     display: flex;
     align-items: flex-start;
+    min-height: 38px;
     svg {
       margin-left: 0.25rem;
       flex-shrink: 0;


### PR DESCRIPTION
What this PR does:
Sets a minimum height for the folder name cell in the folder label row so that the folder name rows and file item rows are the same height (i.e. 38 px currently).  The minimum height should still allow wrapping if the folder name is very long.

For https://purl.stanford.edu/fg478vy8624, the changes now look like 

![Screenshot 2025-03-17 at 5 23 19 PM](https://github.com/user-attachments/assets/ffa60c93-be8e-498a-8057-3dfeab3b1fa3)
 