### PR TITLE
Disable eager loading of external resources

### DIFF
--- a/app/models/embed/purl.rb
+++ b/app/models/embed/purl.rb
@@ -14,8 +14,8 @@ module Embed
       end
     end
 
-    attr_accessor :druid, :version_id, :type, :title, :use_and_reproduction, :copyright, :contents, :collections,
-                  :license, :bounding_box, :embargo_release_date, :archived_site_url, :external_url,
+    attr_accessor :druid, :version_id, :type, :title, :use_and_reproduction, :copyright, :contents, :constituents,
+                  :collections, :license, :bounding_box, :embargo_release_date, :archived_site_url, :external_url,
                   :embargoed, :download, :view, :controlled_digital_lending,
                   :etag, :last_modified, :location_restriction, :restricted_location
 
@@ -30,7 +30,7 @@ module Embed
 
     # @returns [Bool] does this have any resources that can be embeded?
     def valid?
-      contents.any?
+      contents.any? || constituents.any?
     end
 
     def stanford_download?

--- a/app/models/embed/purl_json_loader.rb
+++ b/app/models/embed/purl_json_loader.rb
@@ -18,6 +18,7 @@ module Embed
         type:,
         title:,
         contents:,
+        constituents:, # identifiers for virtual object members
         collections:,
         copyright:,
         license:,
@@ -113,20 +114,12 @@ module Embed
 
       Array(json.dig('structural', 'contains')).map do |file_set_json|
         Purl::ResourceJsonDeserializer.new(@druid, file_set_json).deserialize
-      end + external_resources(Array(json.dig('structural', 'hasMemberOrders', 0, 'members')))
+      end
     end
 
-    def external_resources(identifiers)
-      identifiers.map do |identifier|
-        druid = identifier.delete_prefix('druid:')
-        component = Embed::Purl.find(druid)
-        Purl::Resource.new(
-          druid:,
-          type: component.type,
-          description: component.title,
-          files: []
-        )
-      end
+    # @return [Array<String>] the list of identifiers for virtual object constituents
+    def constituents
+      Array(json.dig('structural', 'hasMemberOrders', 0, 'members'))
     end
 
     def license

--- a/spec/factories/purls.rb
+++ b/spec/factories/purls.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :purl, class: 'Embed::Purl' do
     druid { 'abc123' }
     contents { [build(:resource, :file)] }
+    constituents { [] }
     collections { [] }
     etag { "W/\"#{Time.zone.now.to_f}\"" }
     last_modified { Time.zone.now }
@@ -57,6 +58,10 @@ FactoryBot.define do
 
     trait :media do
       type { 'media' }
+    end
+
+    trait :image do
+      type { 'image' }
     end
 
     trait :video do

--- a/spec/lib/embed/viewer_factory_spec.rb
+++ b/spec/lib/embed/viewer_factory_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Embed::ViewerFactory do
     subject { instance }
 
     context 'invalid Purl object' do
-      let(:purl) { Embed::Purl.new(type: 'image', contents: []) }
+      let(:purl) { Embed::Purl.new(type: 'image', contents: [], constituents: []) }
 
       it 'raises an error' do
         expect { subject }.to raise_error(Embed::Purl::ResourceNotEmbeddable)

--- a/spec/models/embed/purl_json_loader_spec.rb
+++ b/spec/models/embed/purl_json_loader_spec.rb
@@ -97,8 +97,8 @@ RSpec.describe Embed::PurlJsonLoader do
           allow(Embed::Purl).to receive(:find).with('kq126jw7402').and_return(associate)
         end
 
-        it 'has contents' do
-          expect(data[:contents].first.druid).to eq 'kq126jw7402'
+        it 'has constituents' do
+          expect(data[:constituents]).to eq ['druid:kq126jw7402']
         end
       end
 

--- a/spec/models/embed/purl_spec.rb
+++ b/spec/models/embed/purl_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Embed::Purl do
 
   describe 'valid?' do
     context 'with empty content metadata' do
-      let(:purl) { described_class.new(contents: []) }
+      let(:purl) { described_class.new(contents: [], constituents: []) }
 
       it 'is false' do
         expect(purl).not_to be_valid

--- a/spec/requests/embed_spec.rb
+++ b/spec/requests/embed_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Embed requests' do
       end
     end
 
-    context 'when a Purl that is not embeddable is requested' do
+    context 'when a Purl that is not embeddable (no contents) is requested' do
       let(:purl) do
         build(:purl, contents: [])
       end
@@ -28,6 +28,17 @@ RSpec.describe 'Embed requests' do
       it 'has a 400 status' do
         get '/embed', params: { url: 'http://purl.stanford.edu/tz959sb6952' }
         expect(response).to have_http_status(:bad_request)
+      end
+    end
+
+    context 'when a Purl is a virual object (no contents) is requested' do
+      let(:purl) do
+        build(:purl, :image, contents: [], constituents: ['druid:gw001pr5505'])
+      end
+
+      it 'has a 200 status' do
+        get '/embed', params: { url: 'http://purl.stanford.edu/tz959sb6952' }
+        expect(response).to have_http_status(:ok)
       end
     end
 


### PR DESCRIPTION
This can cause sul-embed to overwhelm purl with requests for objects with a long content list