### PR TITLE
fix scroll for stanford 3d locked image

### DIFF
--- a/app/assets/stylesheets/model.css
+++ b/app/assets/stylesheets/model.css
@@ -2,6 +2,11 @@
 @import url("common.css");
 @import url("locked_status.css");
 
+/* stops scroll for lock icon which is caused by sul-embed-3d position: relative */
+#main-display {
+  overflow: hidden;
+}
+
 .sul-embed-3d {
   display: inline-block;
   position: relative;

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -143,6 +143,8 @@ sandbox:
       purl: fs892sr8080
     - label: MTL, OBJ, PLY, PNG
       purl: qf794pv6287
+    - label: stanford only 3d
+      purl: bx715my3000
   web_archive:
     - label: Warc-seed
       purl: gb089bd2251


### PR DESCRIPTION
before
<img width="1278" alt="Screenshot 2025-03-19 at 3 18 35 PM" src="https://github.com/user-attachments/assets/7f1933cc-1105-426e-9bd1-999aa4a4f982" />

after
<img width="1276" alt="Screenshot 2025-03-19 at 3 18 14 PM" src="https://github.com/user-attachments/assets/85dcbccd-edb0-41c7-9b30-baace5215e2d" />
