### PR TITLE
Allowing items with view set to location restriction to show restriction message in the media contents list

### DIFF
--- a/app/components/media/wrapper_component.rb
+++ b/app/components/media/wrapper_component.rb
@@ -21,7 +21,7 @@ module Media
                 media_wrapper_index_value: @resource_index,
                 action: 'thumbnail-clicked@window->media-wrapper#toggleVisibility',
                 stanford_only: @file.stanford_only?,
-                location_restricted: @file.location_restricted?,
+                location_restricted: @file.location_restricted? || @file.view_location_restricted?,
                 file_label: @file.label_or_filename,
                 media_tag_target: 'mediaWrapper',
                 thumbnail_url: @thumbnail.presence,

--- a/app/components/media/wrapper_component.rb
+++ b/app/components/media/wrapper_component.rb
@@ -21,7 +21,7 @@ module Media
                 media_wrapper_index_value: @resource_index,
                 action: 'thumbnail-clicked@window->media-wrapper#toggleVisibility',
                 stanford_only: @file.stanford_only?,
-                location_restricted: @file.location_restricted? || @file.view_location_restricted?,
+                location_restricted: @file.view_location_restricted?,
                 file_label: @file.label_or_filename,
                 media_tag_target: 'mediaWrapper',
                 thumbnail_url: @thumbnail.presence,

--- a/app/models/embed/purl/resource_file.rb
+++ b/app/models/embed/purl/resource_file.rb
@@ -67,6 +67,10 @@ module Embed
         download == 'location-based'
       end
 
+      def view_location_restricted?
+        view == 'location-based'
+      end
+
       def world_downloadable?
         download == 'world'
       end

--- a/spec/components/media/wrapper_component_spec.rb
+++ b/spec/components/media/wrapper_component_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Media::WrapperComponent, type: :component do
   end
 
   describe 'data-default-icon attribute' do
-    let(:file) { instance_double(Embed::Purl::ResourceFile, stanford_only?: false, location_restricted?: false, label_or_filename: 'ignored') }
+    let(:file) { instance_double(Embed::Purl::ResourceFile, stanford_only?: false, location_restricted?: false, view_location_restricted?: false, label_or_filename: 'ignored') }
 
     context 'with audio' do
       it 'renders the page' do
@@ -48,7 +48,7 @@ RSpec.describe Media::WrapperComponent, type: :component do
 
   describe 'data-stanford-only attribute' do
     context 'with Stanford only files' do
-      let(:file) { instance_double(Embed::Purl::ResourceFile, stanford_only?: true, location_restricted?: false, label_or_filename: 'ignored') }
+      let(:file) { instance_double(Embed::Purl::ResourceFile, stanford_only?: true, location_restricted?: false, view_location_restricted?: false, label_or_filename: 'ignored') }
 
       it 'renders the page' do
         expect(page).to have_css('[data-stanford-only="true"]')
@@ -59,7 +59,7 @@ RSpec.describe Media::WrapperComponent, type: :component do
     end
 
     context 'with public files' do
-      let(:file) { instance_double(Embed::Purl::ResourceFile, stanford_only?: false, location_restricted?: false, label_or_filename: 'ignored') }
+      let(:file) { instance_double(Embed::Purl::ResourceFile, stanford_only?: false, location_restricted?: false, view_location_restricted?: false, label_or_filename: 'ignored') }
 
       it 'renders the page' do
         expect(page).to have_css('[data-stanford-only="false"]')
@@ -71,8 +71,19 @@ RSpec.describe Media::WrapperComponent, type: :component do
   end
 
   describe 'data-location-restricted attribute' do
-    context 'when location restricted' do
-      let(:file) { instance_double(Embed::Purl::ResourceFile, stanford_only?: false, location_restricted?: true, label_or_filename: 'ignored') }
+    context 'when download and view location restricted' do
+      let(:file) { instance_double(Embed::Purl::ResourceFile, stanford_only?: false, location_restricted?: true, view_location_restricted?: true, label_or_filename: 'ignored') }
+
+      it 'renders the page' do
+        expect(page).to have_css('[data-location-restricted="true"]')
+        expect(page).to have_css('button[aria-label="Previous item"][disabled]')
+        expect(page).to have_css('button[aria-label="Next item"]')
+        expect(page).to have_no_css('button[aria-label="Next item"][disabled]')
+      end
+    end
+
+    context 'when only view location restricted' do
+      let(:file) { instance_double(Embed::Purl::ResourceFile, stanford_only?: false, location_restricted?: false, view_location_restricted?: true, label_or_filename: 'ignored') }
 
       it 'renders the page' do
         expect(page).to have_css('[data-location-restricted="true"]')
@@ -83,7 +94,7 @@ RSpec.describe Media::WrapperComponent, type: :component do
     end
 
     context 'when not location restricted' do
-      let(:file) { instance_double(Embed::Purl::ResourceFile, stanford_only?: true, location_restricted?: false, label_or_filename: 'ignored') }
+      let(:file) { instance_double(Embed::Purl::ResourceFile, stanford_only?: true, location_restricted?: false, view_location_restricted?: false, label_or_filename: 'ignored') }
 
       it 'renders the page' do
         expect(page).to have_css('[data-location-restricted="false"]')

--- a/spec/components/media/wrapper_component_spec.rb
+++ b/spec/components/media/wrapper_component_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Media::WrapperComponent, type: :component do
     end
 
     context 'with public files' do
-      let(:file) { instance_double(Embed::Purl::ResourceFile, stanford_only?: false, location_restricted?: false, view_location_restricted?: false, label_or_filename: 'ignored') }
+      let(:file) { instance_double(Embed::Purl::ResourceFile, stanford_only?: false, view_location_restricted?: false, label_or_filename: 'ignored') }
 
       it 'renders the page' do
         expect(page).to have_css('[data-stanford-only="false"]')
@@ -71,19 +71,8 @@ RSpec.describe Media::WrapperComponent, type: :component do
   end
 
   describe 'data-location-restricted attribute' do
-    context 'when download and view location restricted' do
-      let(:file) { instance_double(Embed::Purl::ResourceFile, stanford_only?: false, location_restricted?: true, view_location_restricted?: true, label_or_filename: 'ignored') }
-
-      it 'renders the page' do
-        expect(page).to have_css('[data-location-restricted="true"]')
-        expect(page).to have_css('button[aria-label="Previous item"][disabled]')
-        expect(page).to have_css('button[aria-label="Next item"]')
-        expect(page).to have_no_css('button[aria-label="Next item"][disabled]')
-      end
-    end
-
-    context 'when only view location restricted' do
-      let(:file) { instance_double(Embed::Purl::ResourceFile, stanford_only?: false, location_restricted?: false, view_location_restricted?: true, label_or_filename: 'ignored') }
+    context 'when view location restricted' do
+      let(:file) { instance_double(Embed::Purl::ResourceFile, stanford_only?: false, view_location_restricted?: true, label_or_filename: 'ignored') }
 
       it 'renders the page' do
         expect(page).to have_css('[data-location-restricted="true"]')
@@ -94,7 +83,7 @@ RSpec.describe Media::WrapperComponent, type: :component do
     end
 
     context 'when not location restricted' do
-      let(:file) { instance_double(Embed::Purl::ResourceFile, stanford_only?: true, location_restricted?: false, view_location_restricted?: false, label_or_filename: 'ignored') }
+      let(:file) { instance_double(Embed::Purl::ResourceFile, stanford_only?: true, view_location_restricted?: false, label_or_filename: 'ignored') }
 
       it 'renders the page' do
         expect(page).to have_css('[data-location-restricted="false"]')

--- a/spec/factories/files.rb
+++ b/spec/factories/files.rb
@@ -120,4 +120,8 @@ FactoryBot.define do
   trait :view_location_restricted do
     view { 'location-based' }
   end
+
+  trait :view_world do
+    view { 'world' }
+  end
 end

--- a/spec/factories/files.rb
+++ b/spec/factories/files.rb
@@ -116,4 +116,8 @@ FactoryBot.define do
   trait :location_restricted do
     download { 'location-based' }
   end
+
+  trait :view_location_restricted do
+    view { 'location-based' }
+  end
 end

--- a/spec/factories/purls.rb
+++ b/spec/factories/purls.rb
@@ -53,7 +53,8 @@ FactoryBot.define do
       type { 'geo' }
       bounding_box { [['-1.478794', '29.572742'], ['4.234077', '35.000308']] }
       download { 'world' }
-      contents { [build(:resource, :file, files: [build(:resource_file, :world_downloadable, filename: 'data.zip'), build(:resource_file, :world_downloadable, filename: 'data_EPSG_4326.zip')]), build(:resource, :image)] }
+      view { 'world' }
+      contents { [build(:resource, :file, files: [build(:resource_file, :world_downloadable, :view_world, filename: 'data.zip'), build(:resource_file, :world_downloadable, :view_world, filename: 'data_EPSG_4326.zip')]), build(:resource, :image)] }
     end
 
     trait :media do

--- a/spec/features/geo_viewer_spec.rb
+++ b/spec/features/geo_viewer_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'geo viewer', :js do
   end
 
   context 'with restricted purl' do
-    let(:purl) { build(:purl, :geo, download: 'stanford') }
+    let(:purl) { build(:purl, :geo, download: 'stanford', view: 'stanford') }
 
     before do
       visit_iframe_response

--- a/spec/features/media_viewer_spec.rb
+++ b/spec/features/media_viewer_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Media viewer', :js do
   let(:purl) do
     build(:purl, :video, contents: [
-            build(:resource, :video, files: [build(:media_file, :video, :location_restricted, label: 'First Video')]),
+            build(:resource, :video, files: [build(:media_file, :video, :view_location_restricted, label: 'First Video')]),
             build(:resource, :video, files: [build(:media_file, :video, :stanford_only, label: 'Second Video')]),
             build(:resource, :file),
             build(:resource, :video, files: [build(:media_file, :video, :world_downloadable)])
@@ -105,7 +105,7 @@ RSpec.describe 'Media viewer', :js do
     let(:purl) do
       build(:purl, :video, contents: [
               build(:resource, :video, files: [
-                      build(:media_file, :video, :location_restricted,
+                      build(:media_file, :video, :view_location_restricted,
                             label: 'The First Video Has An Overly Long Title, With More Words Than Can Practically Be Displayed')
                     ]),
               build(:resource, :video, files: [build(:media_file, :video, label: '2nd Video Has A Long Title, But Not Too Long')])


### PR DESCRIPTION
Closes #2815.

What this pull request does:

Adds a method to return if the view is location based (b/c the file method for location_restricted? looks only at download values). 

Ensures that the wrapper component adds the data attributed for location restriction set to true in the case where view is location restricted (regardless of the value of the download property).  

Updates the wrapper component tests to include a case when file returns location restricted = false (based on download) and view location restricted true. 