### PR TITLE
preload media when videojs is initialized

### DIFF
--- a/app/javascript/controllers/media_player_controller.js
+++ b/app/javascript/controllers/media_player_controller.js
@@ -6,6 +6,7 @@ export default class extends Controller {
     this.videoElement().classList.add('video-js', 'vjs-default-skin')
     this.player = videojs(this.videoElement().id,
                           { responsive: true,
+                            preload: 'auto', // we need to preload video for the transcript panel
                             userActions: { hotkeys: true }
                           })
     this.player.on('loadedmetadata', (evt) => {


### PR DESCRIPTION
closes #2836 


By default if the video isn't restricted we set preload=auto. We set preload=none for stanford restricted because we don't want to preload a video that can't be accessed. This is causing issues for the transcript panel because loadeddata doesn't fire until there is a frame available which when preload=none means the user needs to hit play. This PR updates the preload on restricted items when the videojs player initializes  