### PR TITLE
don't check probe service if public geo

### DIFF
--- a/app/components/geo_component.html.erb
+++ b/app/components/geo_component.html.erb
@@ -16,12 +16,12 @@
   <% end %>
 
   <% component.with_body do %>
-    <div class='sul-embed-geo' data-controller="geo" data-action="iiif-manifest-received@window->file-auth#parseFiles auth-success@window->geo#show">
+    <%= content_tag :div, class: 'sul-embed-geo', data: {controller: 'geo', action: data_actions} do %>
       <div id="sul-embed-geo-sidebar" class="" style="display: none;">
       </div>
       <%= content_tag :div, viewer.map_element_options do %>
 
       <% end %>
-    </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/components/geo_component.rb
+++ b/app/components/geo_component.rb
@@ -8,5 +8,11 @@ class GeoComponent < ViewComponent::Base
   attr_reader :viewer
 
   delegate :purl_object, to: :viewer
-  delegate :druid, to: :purl_object
+  delegate :druid, :public?, to: :purl_object
+
+  def data_actions
+    return if public?
+
+    'iiif-manifest-received@window->file-auth#parseFiles auth-success@window->geo#show'
+  end
 end


### PR DESCRIPTION
We are query probe service for all geo not just restricted geo items. The map rendering isn't tied to probe service so we are just rendering and calling the probe service that doesn't do anything.