### PR TITLE
fix ahoy url

### DIFF
--- a/app/views/embed/_analytics.html.erb
+++ b/app/views/embed/_analytics.html.erb
@@ -17,7 +17,7 @@
   gtag('config', 'G-80J719XWE5', args)
 </script>
 <% if Settings.metrics_api_url %>
-<script src="https://unpkg.com/ahoy.js@0.4.3"
+<script src="https://cdn.jsdelivr.net/npm/ahoy.js@0.4.3/dist/ahoy.js"
   integrity="sha384-s9X57Wbu8jIIErBMhudZJEAS1ZkelgbMI7/HUqsgjFBBm9IXyfbpKQ+ZoWUUvpgE"
   crossorigin="anonymous"></script>
 <script>


### PR DESCRIPTION
fixes failing analytics tests. https://unpkg.com/ahoy.js@0.4.3 doesn't lead anywhere anymore.