### PR TITLE
Remove deprecated image_tools param (replaced by enable_comparison)

### DIFF
--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -57,7 +57,7 @@ class EmbedController < ApplicationController
     params.permit(:url, :maxwidth, :maxheight, :format, :fullheight, :iiif_initial_viewer_config,
                   :hide_title, :hide_embed, :hide_download, :hide_search, :min_files_to_search,
                   :canvas_id, :canvas_index, :search, :suggested_search,
-                  :enable_comparison, :image_tools, :cdl_hold_record_id)
+                  :enable_comparison, :cdl_hold_record_id)
   end
 
   rescue_from Embed::Request::NoURLProvided do |e|

--- a/lib/embed/request.rb
+++ b/lib/embed/request.rb
@@ -90,7 +90,6 @@ module Embed
         :canvas_id, :canvas_index,
         :search, :suggested_search,
         :enable_comparison,
-        :image_tools,
         :iiif_initial_viewer_config
       )
 
@@ -117,9 +116,8 @@ module Embed
       params[:suggested_search]
     end
 
-    # TODO: Remove deprecated image_tools parameter when exhibits is updated to use enable_comparison
     def enable_comparison?
-      params[:enable_comparison] == 'true' || params[:image_tools] == 'true'
+      params[:enable_comparison] == 'true'
     end
 
     def iiif_initial_viewer_config

--- a/spec/features/iiif_embed_spec.rb
+++ b/spec/features/iiif_embed_spec.rb
@@ -20,10 +20,4 @@ RSpec.describe 'IIIF Embed', :js do
 
     expect(page).to have_css('[data-enable-comparison="true"]')
   end
-
-  it 'sets the enable-comparison data attribute when image_tools (deprecated) is requested' do
-    visit iiif_path(url: 'https://purl.stanford.edu/fr426cg9537/iiif/manifest', image_tools: 'true')
-
-    expect(page).to have_css('[data-enable-comparison="true"]')
-  end
 end

--- a/spec/lib/embed/request_spec.rb
+++ b/spec/lib/embed/request_spec.rb
@@ -94,10 +94,6 @@ RSpec.describe Embed::Request do
     it 'is true when the incoming request asks to enable_comparison' do
       expect(described_class.new(url: purl, enable_comparison: 'true')).to be_enable_comparison
     end
-
-    it 'is true when the incoming request uses the deprecated image_tools parameter' do
-      expect(described_class.new(url: purl, image_tools: 'true')).to be_enable_comparison
-    end
   end
 
   describe 'as_url_params' do


### PR DESCRIPTION
When https://github.com/sul-dlss/exhibits/pull/2879 is merged and in production we can remove the deprecated `image_tools` parameter.