### PR TITLE
updating readme for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ purl_url: 'http://localhost:3000/'
 stacks_url: 'http://localhost:3000/'
 ```
 
-Then you will need to place the "public XML" metadata for an object in the `public` directory `public/{druid}.xml` and the items stacks files in a directory `public/file/druid:{druid}`. For example, for a druid `bk914zc7842` you would have a `public` directory structure that looks something like:
+Then you will need to place the "public XML" metadata for an object in the `public` directory `public/{druid}.xml` and the items stacks files in a directory `public/file/{druid}`. For example, for a druid `bk914zc7842` you would have a `public` directory structure that looks something like:
 
 ```
 public
 ├── bk914zc7842.xml
 └── file
-    └── druid:bk914zc7842
+    └── bk914zc7842
         ├── bk914zc7842_low.glb
         ├── bk914zc7842_low.mtl
         ├── bk914zc7842_low.obj


### PR DESCRIPTION
When trying to get embed to run locally, I noticed that the file directory structure mentioned in the readme was no longer working.  Now, we no longer seem to need "druid:" in the folder name under "file". This PR updates the README to reflect that change. 