### PR TITLE
bug fix transcript panel with multiple captions

### DIFF
--- a/app/javascript/controllers/media_player_controller.js
+++ b/app/javascript/controllers/media_player_controller.js
@@ -20,12 +20,9 @@ export default class extends Controller {
                             preload: 'auto', // we need to preload video for the transcript panel
                             userActions: { hotkeys: true }
                           })
-    this.player.on('loadedmetadata', (evt) => {
-      // for multiple media items, we only want to load the first (visible) item
-      if (evt.target.dataset.index == '0'){
-        const event = new CustomEvent('media-loaded', { detail: this.player })
-        window.dispatchEvent(event)
-      }
+    this.player.on('loadedmetadata', () => {
+      const event = new CustomEvent('media-loaded', { detail: this.player })
+      window.dispatchEvent(event)
     })
 
     // occurs when time of the video changes.
@@ -37,11 +34,9 @@ export default class extends Controller {
 
     // The loadeddata event occurs when the first frame of the video is available, and
     // happens after loadedmetadata
-    this.player.on('loadeddata', (evt) => {
-      if (evt.target.dataset.index == '0'){
-        const event = new CustomEvent('media-data-loaded');
-        window.dispatchEvent(event);
-      }
+    this.player.on('loadeddata', () => {
+      const event = new CustomEvent('media-data-loaded');
+      window.dispatchEvent(event);
     })
   }
 

--- a/app/javascript/controllers/transcript_controller.js
+++ b/app/javascript/controllers/transcript_controller.js
@@ -19,13 +19,13 @@ export default class extends Controller {
     // Return if this method has already been called, there are no caption tracks
     // or no cues for the tracks.  In the case of Safari, we need to wait to check,
     // hence the async/await combination for checkCues.
-    if (this.loaded || !(await this.checkCues()))
+    if (this.player.loaded || !(await this.checkCues()))
       return
 
     this.revealButton()
     this.setupTranscriptLanguageSwitching()
     this.renderCues()
-    this.loaded = true
+    this.player.loaded = true
   }
 
   // event called when switch-transcript event is fired.


### PR DESCRIPTION
The change is happening because we used to initialize all video players on auth-success. Now it only happens when the thumbnail loads. We want the trigger the event on load because it is no longer happening all at once.

Before:
https://github.com/user-attachments/assets/cf5704c3-83ee-4768-99f0-7f516d51dc4a

After:

https://github.com/user-attachments/assets/ca4ca8f5-5d40-4c31-8db3-bec9c9762b5f

