### PR TITLE
fix table stripes when drawer is opened

### DIFF
--- a/app/components/file_component.html.erb
+++ b/app/components/file_component.html.erb
@@ -25,7 +25,7 @@
 
   <% component.with_body do %>
     <% # background-color: white must be set for full screen when the browser prefers dark mode %>
-    <div data-action="resize@window->tree#updateStripesHeight" style="overflow-y: scroll; flex-basis: 100%;">
+    <div data-action="resize@window->tree#updateStripes drawer-toggled@window->tree#updateStripes" style="overflow-y: scroll; flex-basis: 100%;">
       <table class="sul-embed-treegrid" role="treegrid" aria-label="File list" data-action="keydown->tree#navigate" data-tree-target="table">
         <colgroup>
           <col class="sul-embed-treegrid-name">

--- a/app/javascript/controllers/companion_window_controller.js
+++ b/app/javascript/controllers/companion_window_controller.js
@@ -24,7 +24,12 @@ export default class extends Controller {
     } else {
       action = this.openLeftDrawer()
     }
-    action.then(() => button.disabled = false) // reenable the button
+    action.then(() => {
+      button.disabled = false // reenable the button
+      this.leftDrawerTarget.addEventListener('transitionend', () => {
+        window.dispatchEvent(new CustomEvent('drawer-toggled')) // send event for table stripes
+      });
+    })
   }
 
   openLeftDrawer() {

--- a/app/javascript/file_controllers/tree_controller.js
+++ b/app/javascript/file_controllers/tree_controller.js
@@ -254,10 +254,10 @@ export default class extends Controller {
     const stripesClass = (this.visibleRows.length % 2) === 0 ? 'even': 'odd'
     this.stripesTarget.className = "stripes-background-" + stripesClass
     // Update the height as well
-    this.updateStripesHeight()
+    this.updateStripes()
   }
 
-  updateStripesHeight() {
+  updateStripes() {
     // Get distance between top of window and bottom of table
     const boundingRecY = this.tableTarget.getBoundingClientRect().bottom
     // Get distance between top of window and the bottom of the parent div for stripes background
@@ -266,5 +266,7 @@ export default class extends Controller {
     const diff = parentY - boundingRecY
     // Set height for stripes div to fill in the remaining space
     this.stripesTarget.style.height = diff + "px"
+    // set width of stripes (needed when drawer is opened/closed)
+    this.stripesTarget.style.width = this.tableTarget.getBoundingClientRect().width + 'px';
   }
 }


### PR DESCRIPTION
closes #2864 
I don't love this solution because of the slight flash of the stripes but we do need to add a listener for the drawer open/close because we are getting a weird vertical scroll because the row height is changing when the drawer is opening.

Before: 

https://github.com/user-attachments/assets/13507ae8-5b84-4237-ac97-f534e2d25495

After

https://github.com/user-attachments/assets/2c82755d-93b5-491f-9164-2f462a7e50a8

