### PR TITLE
remove iframe margin

### DIFF
--- a/app/views/embed/iframe.html.erb
+++ b/app/views/embed/iframe.html.erb
@@ -15,7 +15,7 @@
     <%= stylesheet_link_tag @embed_response.viewer.stylesheet %>
     <%= tag :link, rel: "up", href: @embed_response.request.purl_object.first_collection_url if @embed_response && @embed_response.request.purl_object.first_collection_url %>
   </head>
-  <body>
+  <body style="margin: 0">
     <%= render @embed_response.viewer.component.new(viewer: @embed_response.viewer) %>
   </body>
 </html>

--- a/spec/features/geo_viewer_spec.rb
+++ b/spec/features/geo_viewer_spec.rb
@@ -76,12 +76,12 @@ RSpec.describe 'geo viewer', :js do
 
   context 'with an index map' do
     let(:purl) do
-      build(:purl, :geo, druid: 'ts545zc6250',
+      build(:purl, :geo, druid: 'mf519gg2738',
                          contents: [
                            build(:resource, :file, files: [
                                    build(:resource_file, filename: 'data.zip'),
                                    build(:resource_file, filename: 'data_EPSG_4326.zip'),
-                                   build(:resource_file, druid: 'ts545zc6250', filename:)
+                                   build(:resource_file, druid: 'mf519gg2738', filename:)
                                  ]),
                            build(:resource, :image)
                          ])
@@ -96,11 +96,11 @@ RSpec.describe 'geo viewer', :js do
           # find this svg element on the page.
           # We also need to explicitly wait for the JS to run.
           expect(page).to have_css('.sul-embed-geo', count: 1, visible: :visible)
-          expect(page).to have_css "[data-index-map=\"https://stacks.stanford.edu/file/ts545zc6250/#{filename}\"]"
+          expect(page).to have_css "[data-index-map=\"https://stacks.stanford.edu/file/mf519gg2738/#{filename}\"]"
           # only count paths within .leaflet-overlay-pane for testing
           # (page.body contains SVG logos we don't care to count)
           find '.leaflet-overlay-pane'
-          expect(Nokogiri::HTML.parse(page.body).search('.leaflet-overlay-pane').css('path').length).to eq 480
+          expect(Nokogiri::HTML.parse(page.body).search('.leaflet-overlay-pane').css('path').length).to eq 22
         end
       end
     end
@@ -114,7 +114,7 @@ RSpec.describe 'geo viewer', :js do
           # find this svg element on the page.
           # We also need to explicitly wait for the JS to run.
           expect(page).to have_css('.sul-embed-geo', count: 1, visible: :visible)
-          expect(page).to have_css "[data-index-map=\"https://stacks.stanford.edu/file/ts545zc6250/#{filename}\"]"
+          expect(page).to have_css "[data-index-map=\"https://stacks.stanford.edu/file/mf519gg2738/#{filename}\"]"
         end
       end
     end


### PR DESCRIPTION
This seems to only happen with mirador viewers:
https://embed.stanford.edu/iframe?url=https://purl.stanford.edu/zv721jk5876&hide_title=true&maxheight=500

Before:
<img width="1050" height="501" alt="Screenshot 2025-07-16 at 5 05 33 PM" src="https://github.com/user-attachments/assets/4746d86c-d894-49fa-a30a-064f8645eab1" />

After:
<img width="1042" height="486" alt="Screenshot 2025-07-16 at 5 06 18 PM" src="https://github.com/user-attachments/assets/cb5f8938-4aad-4d82-84ca-f05d4ea3fb16" />

