### PR TITLE
fix tooltip breaking map look inside

### DIFF
--- a/app/javascript/controllers/geo_controller.js
+++ b/app/javascript/controllers/geo_controller.js
@@ -59,7 +59,8 @@ export default class extends Controller {
               layer.customProperty = { geoJSON: true }
               // Add a hover label for the label property
               if (feature.properties.label !== null) {
-                layer.bindTooltip(feature.properties.label)
+                // without String, numbers break tooltip
+                layer.bindTooltip(String(feature.properties.label))
               }
               // If it is available add clickable info
               if (feature.properties.available !== null) {


### PR DESCRIPTION
https://earthworks.stanford.edu/catalog/stanford-cf800gc3842 is breaking because the feature.properties.label is a number and leaflet does not like that.

https://earthworks.stanford.edu/catalog/stanford-nz504hc9042