### PR TITLE
allow for a/v material not to have a poster

### DIFF
--- a/app/javascript/controllers/locked_media_poster_controller.js
+++ b/app/javascript/controllers/locked_media_poster_controller.js
@@ -3,7 +3,7 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   hide() {
     document.querySelectorAll('video').forEach(video => {
-      if(video.getAttribute("poster").includes('locked'))
+      if(video.getAttribute("poster")?.includes('locked'))
         video.removeAttribute("poster")
     })
   }


### PR DESCRIPTION
closes #2903 

This happens when there is no poster for a video, we have the assumption that all the videos have a poster which isn't true with https://purl.stanford.edu/br879xp7332. 