### PR TITLE
decoding uris no longer necessary

### DIFF
--- a/app/javascript/controllers/media_player_controller.js
+++ b/app/javascript/controllers/media_player_controller.js
@@ -66,7 +66,7 @@ export default class extends Controller {
     console.log("Looking for ", `source[src="${fileUri}"]`)
 
     // The current event may be for a different video on the page, so see if it's ours
-    const source = this.videoElement().querySelector(`source[src="${decodeURIComponent(fileUri)}"]`)
+    const source = this.videoElement().querySelector(`source[src="${fileUri}"]`)
     console.log("Found", source)
     source?.setAttribute('src', location)
   }


### PR DESCRIPTION
The old version of this set the  src = "#{Settings.stacks_url}/file/#{druid}/#{file.filename}". We updated it to file_url to match everywhere else and file_url encodes the titles https://github.com/sul-dlss/sul-embed/blob/b5180b8728055681710e6ac5de1623c372064d73/app/models/embed/purl/resource_file.rb#L28. The decoding is breaking files with spaces: closes https://github.com/sul-dlss/sul-embed/pull/2871