### PR TITLE
fix stanford only icon css to be after text, not background image

### DIFF
--- a/app/assets/stylesheets/content_list.css
+++ b/app/assets/stylesheets/content_list.css
@@ -44,6 +44,17 @@
       background: url("stanford_s.svg") no-repeat;
       background-position: bottom left;
       padding-right: 20px;
+
+      .label-text {
+        display: -webkit-box;
+        height: 2.5rem;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        max-width: 150px;
+      }
+
       &.text {
         height: calc(
           100% - 0.75rem

--- a/app/javascript/src/modules/thumbnail.js
+++ b/app/javascript/src/modules/thumbnail.js
@@ -41,7 +41,7 @@ export default class {
         ${thumbnailIcon}
         <span class="${labelClass} su-underline">
           ${stanfordOnlyScreenreaderText}${restrictedTextMarkup}
-          ${this.truncateWithEllipsis(this.fileLabel, maxFileLabelLength)}
+          <span class="label-text">${this.truncateWithEllipsis(this.fileLabel, maxFileLabelLength)}</span>
         </span>
       </li>`
   }


### PR DESCRIPTION
closes #2975 

Before:
<img width="388" height="408" alt="Screenshot 2026-01-29 at 4 53 38 PM" src="https://github.com/user-attachments/assets/7b1faf29-9634-48b2-a518-37f1d4445284" />
After:

<img width="261" height="393" alt="Screenshot 2026-01-30 at 2 00 03 PM" src="https://github.com/user-attachments/assets/48adef07-eecc-4257-8f17-1cf4fe932dcb" />


Before:
<img width="251" height="98" alt="Screenshot 2026-01-30 at 2 00 25 PM" src="https://github.com/user-attachments/assets/ef82a55e-9b69-4ae2-b201-7dc286e475ea" />


After:
<img width="269" height="384" alt="Screenshot 2026-01-30 at 2 00 15 PM" src="https://github.com/user-attachments/assets/67dec49d-1384-4020-b115-35fa5cf94fb2" />

