### PR TITLE
Set a default opacity of 20% for index map polygons

### DIFF
--- a/app/javascript/controllers/geo_controller.js
+++ b/app/javascript/controllers/geo_controller.js
@@ -161,7 +161,7 @@ export default class extends Controller {
       type: "fill",
       source: "index-map-source",
       filter: ["==", ["geometry-type"], "Polygon"],
-      paint: { "fill-color": colorExpr, "fill-opacity": 0.75 }
+      paint: { "fill-color": colorExpr, "fill-opacity": 0.2 }
     })
 
     this.map.addLayer({


### PR DESCRIPTION
This matches the old setting we had for Leaflet.
