### PR TITLE
Remove old PMTile fixture

### DIFF
--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -115,8 +115,6 @@ sandbox:
       purl: kh860qj3406
     - label: PMTiles
       purl: jx110jn7648
-    - label: PMTiles
-      purl: hf224mw4004
     - label: GeoJSON points
       purl: nz577hv6134
     - label: GeoJSON lines


### PR DESCRIPTION
This object was uploaded outside of the normal accessioning process
and also contains data that we normally won't want to represent,
like multiple data layers in the PMTile.
