### PR TITLE
Validate IIIF Auth v2 messageId

### DIFF
--- a/app/javascript/controllers/file_auth_controller.js
+++ b/app/javascript/controllers/file_auth_controller.js
@@ -4,34 +4,53 @@ export default class extends Controller {
   resources = {} // Hash of messageIds to resources
 
   addPostCallbackListener() {
+    if (this.postCallbackListener) return
+
+    this.postCallbackListener = event => this.handlePostCallback(event)
+    window.addEventListener("message", this.postCallbackListener, false)
+  }
+
+  disconnect() {
+    if (!this.postCallbackListener) return
+
+    window.removeEventListener("message", this.postCallbackListener, false)
+    this.postCallbackListener = undefined
+  }
+
+  handlePostCallback(event) {
     const permittedOrigins = [
       "https://stacks.stanford.edu",
       "https://sul-stacks-stage.stanford.edu",
       "https://stacks-uat.stanford.edu",
     ]
-    window.addEventListener(
-      "message",
-      event => {
-        console.debug("Post message", event.data)
-        if (!permittedOrigins.includes(event.origin)) {
-          console.error(`${event.origin} is not a permitted origin`)
-          return
-        }
-        this.iframe.remove()
-        if (event.data.type === "AuthAccessTokenError2") {
-          this.displayAccessTokenError(event.data)
-        } else {
-          this.cacheToken(event.data.accessToken, event.data.expiresIn)
-          window.dispatchEvent(
-            new CustomEvent("show-message-panel", { detail: {} }),
-          )
-          this.queryProbeService(event.data.messageId, event.data.accessToken)
-            .then(result => this.renderViewer(result))
-            .catch(json => console.error("no access", json))
-        }
-      },
-      false,
+    console.debug("Post message", event.data)
+    if (!permittedOrigins.includes(event.origin)) {
+      console.error(`${event.origin} is not a permitted origin`)
+      return
+    }
+
+    const tokenResponseTypes = ["AuthAccessToken2", "AuthAccessTokenError2"]
+    // `message` is a shared channel. Embedded content may post unrelated messages
+    // from the same origin, and IIIF Auth requires ignoring unrecognized messageIds.
+    if (
+      !tokenResponseTypes.includes(event.data?.type) ||
+      !this.resources[event.data.messageId]
     )
+      return
+
+    this.iframe?.remove()
+    this.iframe = undefined
+    if (event.data.type === "AuthAccessTokenError2") {
+      this.displayAccessTokenError(event.data)
+    } else {
+      this.cacheToken(event.data.accessToken, event.data.expiresIn)
+      window.dispatchEvent(
+        new CustomEvent("show-message-panel", { detail: {} }),
+      )
+      this.queryProbeService(event.data.messageId, event.data.accessToken)
+        .then(result => this.renderViewer(result))
+        .catch(json => console.error("no access", json))
+    }
   }
 
   // iterate over all files in the IIIF manifest and try to draw them

--- a/spec/javascript/fileAuthController.test.js
+++ b/spec/javascript/fileAuthController.test.js
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { default: FileAuthController } =
+  await import("../../app/javascript/controllers/file_auth_controller.js")
+
+describe("FileAuthController", () => {
+  let controller
+
+  beforeEach(() => {
+    controller = Object.create(FileAuthController.prototype)
+    controller.resources = {}
+  })
+
+  it("ignores unrelated messages from a permitted origin", () => {
+    controller.handlePostCallback({
+      origin: "https://stacks.stanford.edu",
+      data: { cmd: "setTEIdentifier", teIdentifier: "abc123" },
+    })
+
+    expect(controller.iframe).toBeUndefined()
+  })
+
+  it("handles a token response for a requested resource", async () => {
+    const iframe = document.createElement("iframe")
+    document.body.appendChild(iframe)
+    controller.iframe = iframe
+    controller.resources.message123 = {}
+    controller.cacheToken = vi.fn()
+    controller.queryProbeService = vi.fn().mockResolvedValue({
+      fileUri: "https://stacks.stanford.edu/file/example.pdf",
+    })
+    controller.renderViewer = vi.fn()
+
+    controller.handlePostCallback({
+      origin: "https://stacks.stanford.edu",
+      data: {
+        type: "AuthAccessToken2",
+        messageId: "message123",
+        accessToken: "token",
+        expiresIn: 300,
+      },
+    })
+    await vi.waitFor(() => expect(controller.renderViewer).toHaveBeenCalled())
+
+    expect(iframe).not.toBeInTheDocument()
+    expect(controller.cacheToken).toHaveBeenCalledWith("token", 300)
+    expect(controller.queryProbeService).toHaveBeenCalledWith(
+      "message123",
+      "token",
+    )
+  })
+})

--- a/spec/javascript/stubs/stimulus.js
+++ b/spec/javascript/stubs/stimulus.js
@@ -1,0 +1,1 @@
+export class Controller {}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -38,6 +38,10 @@ export default defineConfig({
         __dirname,
         "spec/javascript/stubs/deck-gl-web.js",
       ),
+      "@hotwired/stimulus": path.resolve(
+        __dirname,
+        "spec/javascript/stubs/stimulus.js",
+      ),
     },
   },
   test: {


### PR DESCRIPTION
The file authorization controller treated every postMessage from Stacks as a IIIF authentication response. A plugin in a users browser (Chrome 150) sent an unrelated `setTEIdentifier` message when no authentication iframe existed, causing the controller to call remove() on an undefined value. The fix processes only recognized IIIF Auth response types with a known request messageId and safely removes the iframe when present. This prevents unrelated embedded-content messages from triggering errors or interfering with authentication.