### PR TITLE
Allow linking to a specific page in a document (PDF)

### DIFF
--- a/app/components/pdf_component.html.erb
+++ b/app/components/pdf_component.html.erb
@@ -19,6 +19,9 @@
       <div style="display: flex; flex-direction: column; height: 100%">
         <div class="sul-embed-pdf" style="height: 100%"
           data-controller="pdf"
+          <% if viewer.page %>
+            data-pdf-page-value="<%= viewer.page %>"
+          <% end %>
           data-action="thumbnail-clicked@window->file-auth#authFileAndDisplay iiif-manifest-received@window->file-auth#parseFiles auth-success@window->pdf#show">
         </div>
       </div>

--- a/app/javascript/controllers/pdf_controller.js
+++ b/app/javascript/controllers/pdf_controller.js
@@ -1,10 +1,16 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
+  static values = { page: Number }
+
   show(evt) {
     const fileUri = evt.detail.fileUri
+    const objectUrl = new URL(fileUri)
+    objectUrl.searchParams.set("time", Date.now())
+    if (this.hasPageValue) objectUrl.searchParams.set("page", this.pageValue)
+
     this.element.innerHTML = `
-      <object data="${fileUri}?time=${Date.now()}" type="application/pdf" style="height: 100%; width: 100%">
+      <object data="${objectUrl}" type="application/pdf" style="height: 100%; width: 100%">
         <div class="authLinkWrapper">
           <svg class="MuiSvgIcon-root WarningAmberSharp" focusable="false" aria-hidden="true" viewBox="0 0 24 24">
             <path d="M12 5.99 19.53 19H4.47zM12 2 1 21h22zm1 14h-2v2h2zm0-6h-2v4h2z"/>

--- a/app/viewers/embed/viewer/document_viewer.rb
+++ b/app/viewers/embed/viewer/document_viewer.rb
@@ -22,6 +22,11 @@ module Embed
       def fullscreen?
         true
       end
+
+      def page
+        canvas_index = Integer(embed_request.canvas_index, exception: false)
+        canvas_index + 1 if canvas_index && canvas_index >= 0
+      end
     end
   end
 end

--- a/spec/components/pdf_component_spec.rb
+++ b/spec/components/pdf_component_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe PdfComponent, type: :component do
     end
   end
 
+  context 'when a canvas index is passed' do
+    let(:embed_request) { Embed::Request.new(url:, canvas_index: '3') }
+
+    it 'passes the one-based PDF page to the PDF controller' do
+      expect(page).to have_css('.sul-embed-pdf[data-pdf-page-value="4"]', visible: :all)
+    end
+  end
+
   context 'when the browser is chrome' do
     let(:user_agent_string) { 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36' }
 

--- a/spec/features/document_viewer_spec.rb
+++ b/spec/features/document_viewer_spec.rb
@@ -5,14 +5,34 @@ require 'rails_helper'
 RSpec.describe 'PDF Viewer', :js do
   before do
     allow(Embed::Purl).to receive(:find).and_return(purl)
-    visit_iframe_response
+    visit iframe_path(url: "#{Settings.purl_url}/ignored", canvas_index:)
   end
+
+  let(:canvas_index) { nil }
 
   context 'when world visible' do
     let(:purl) { build(:purl, :document, download: 'world') }
 
     it 'renders the PDF viewer for documents' do
       expect(page).to have_css('.sul-embed-pdf')
+    end
+
+    context 'with a canvas index' do
+      let(:canvas_index) { 3 }
+
+      it 'opens the PDF to the corresponding one-based page' do
+        expect(page).to have_css('.sul-embed-pdf[data-pdf-page-value="4"]')
+
+        page.execute_script <<~JAVASCRIPT
+          window.dispatchEvent(new CustomEvent("auth-success", {
+            detail: {
+              fileUri: "https://stacks.stanford.edu/file/xk848ts1579/Forecasting_Effective_Digital_Libs.pdf"
+            }
+          }))
+        JAVASCRIPT
+
+        expect(page).to have_css('object[data$="&page=4"]', visible: :all)
+      end
     end
   end
 end

--- a/spec/lib/embed/viewer/document_viewer_spec.rb
+++ b/spec/lib/embed/viewer/document_viewer_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Embed::Viewer::DocumentViewer do
+  subject(:viewer) { described_class.new(request) }
+
+  let(:request) { Embed::Request.new(url: 'http://purl.stanford.edu/abc123', canvas_index:) }
+  let(:canvas_index) { '3' }
+  let(:purl) { build(:purl, :document) }
+
+  before do
+    allow(Embed::Purl).to receive(:find).and_return(purl)
+  end
+
+  describe '#page' do
+    it 'converts the zero-based canvas index to a one-based PDF page' do
+      expect(viewer.page).to eq 4
+    end
+
+    context 'without a canvas index' do
+      let(:canvas_index) { nil }
+
+      it 'does not select a PDF page' do
+        expect(viewer.page).to be_nil
+      end
+    end
+
+    context 'with an invalid canvas index' do
+      let(:canvas_index) { 'invalid' }
+
+      it 'does not select a PDF page' do
+        expect(viewer.page).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
This brings parity with the book viewer which also uses canvas_index to link to a specific page.