### PR TITLE
Support specifying both a canvas and a search to run for Mirador

### DIFF
--- a/app/javascript/src/mirador/init.js
+++ b/app/javascript/src/mirador/init.js
@@ -11,6 +11,7 @@ import {
 
 import { sulTheme, viewerViews, defaultWorkspace } from "@/mirador/config.js"
 import { handleViewerPostMessage } from "@/mirador/postMessageHandler.js"
+import { keepRequestedCanvasThroughInitialSearch } from "@/mirador/initialSearchCanvas.js"
 
 import comparisonPlugin from "@/mirador/plugins/comparisonPlugin.jsx"
 import analyticsPlugin from "@/mirador/plugins/analyticsPlugin.js"
@@ -31,6 +32,12 @@ export default {
     if (data.search?.length > 0) sideBarPanel = "search"
     if (showAttribution) sideBarPanel = "attribution"
 
+    // An embed that asks for both a starting canvas and a search term wants to
+    // land on that canvas with the term highlighted, but Mirador would jump to
+    // the first hit in the document instead. See initialSearchCanvas.js.
+    const searchWithinRequestedCanvas =
+      data.search?.length > 0 && Boolean(data.canvasId || data.canvasIndex)
+
     const viewerInstance = Mirador.viewer(
       {
         id: "sul-embed-mirador",
@@ -39,6 +46,9 @@ export default {
         windows: [
           {
             id: "main",
+            ...(searchWithinRequestedCanvas && {
+              switchCanvasOnSearch: false,
+            }),
             loadedManifest: data.miradorUri,
             canvasIndex: Number(data.canvasIndex),
             canvasId: data.canvasId,
@@ -105,6 +115,10 @@ export default {
         miradorDownloadDialogPlugin,
       ],
     )
+
+    if (searchWithinRequestedCanvas) {
+      keepRequestedCanvasThroughInitialSearch(viewerInstance.store, "main")
+    }
 
     handleViewerPostMessage(viewerInstance)
   },

--- a/app/javascript/src/mirador/initialSearchCanvas.js
+++ b/app/javascript/src/mirador/initialSearchCanvas.js
@@ -1,0 +1,62 @@
+import {
+  getSearchForWindow,
+  getSearchIsFetching,
+  getSortedSearchAnnotationsForCompanionWindow,
+  getVisibleCanvasIds,
+  selectAnnotation,
+  updateWindow,
+} from "mirador"
+
+/**
+ * Finds the search companion window that has started fetching results. Search
+ * state is keyed by companion window id, and an entry only grows a `data` key
+ * once a query has been requested for it.
+ */
+const startedSearchCompanionWindowId = (state, windowId) => {
+  const searches = getSearchForWindow(state, { windowId }) || {}
+
+  return Object.keys(searches).find(companionWindowId =>
+    Boolean(searches[companionWindowId]?.data),
+  )
+}
+
+/**
+ * Mirador's `switchCanvasOnSearch` config moves the viewer to the first hit in
+ * the document as soon as content search results arrive, which discards the
+ * canvas an embed asked for. When an embed requests a canvas *and* a search
+ * term, init.js opens the window with `switchCanvasOnSearch` off and calls
+ * this, which waits for the initial search to settle and then:
+ *
+ *   - selects the first hit on the requested canvas, when the term occurs
+ *     there, so it highlights and reads as selected just like a hit the user
+ *     clicked in the search panel
+ *   - hands `switchCanvasOnSearch` back, so searches the user runs afterwards
+ *     navigate the way they do in a stock viewer
+ *
+ * Returns the store's unsubscribe function so callers can bail out early.
+ */
+export function keepRequestedCanvasThroughInitialSearch(store, windowId) {
+  const unsubscribe = store.subscribe(() => {
+    const state = store.getState()
+    const companionWindowId = startedSearchCompanionWindowId(state, windowId)
+
+    if (!companionWindowId) return
+    if (getSearchIsFetching(state, { companionWindowId, windowId })) return
+
+    // The initial search has landed (or failed). Either way we are done
+    // watching, and dispatching below would otherwise re-enter this callback.
+    unsubscribe()
+
+    const visibleCanvasIds = getVisibleCanvasIds(state, { windowId })
+    const hit = getSortedSearchAnnotationsForCompanionWindow(state, {
+      companionWindowId,
+      windowId,
+    }).find(annotation => visibleCanvasIds.includes(annotation.targetId))
+
+    if (hit) store.dispatch(selectAnnotation(windowId, hit.id))
+
+    store.dispatch(updateWindow(windowId, { switchCanvasOnSearch: true }))
+  })
+
+  return unsubscribe
+}

--- a/spec/javascript/initialSearchCanvas.test.js
+++ b/spec/javascript/initialSearchCanvas.test.js
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi } from "vitest"
+import { keepRequestedCanvasThroughInitialSearch } from "@/mirador/initialSearchCanvas.js"
+
+const MANIFEST_ID = "https://example.edu/iiif/manifest"
+const SEARCH_ID = "https://example.edu/search?q=cats"
+const canvasId = n => `https://example.edu/iiif/canvas/${n}`
+const annotationId = n => `https://example.edu/search/annotation/${n}`
+
+const manifestJson = {
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": MANIFEST_ID,
+  "@type": "sc:Manifest",
+  label: "A document",
+  sequences: [
+    {
+      "@id": "https://example.edu/iiif/sequence-1",
+      "@type": "sc:Sequence",
+      canvases: [1, 2, 3, 4].map(n => ({
+        "@id": canvasId(n),
+        "@type": "sc:Canvas",
+        height: 1000,
+        images: [],
+        label: `Page ${n}`,
+        width: 800,
+      })),
+    },
+  ],
+}
+
+// IIIF Content Search 1.0 response with hits on pages 2 and 3, deliberately
+// listed out of canvas order so we can tell sorted-first from response-first.
+const searchJson = {
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": SEARCH_ID,
+  "@type": "sc:AnnotationList",
+  resources: [
+    { canvas: 3, id: 30 },
+    { canvas: 2, id: 20 },
+    { canvas: 3, id: 31 },
+  ].map(({ canvas, id }) => ({
+    "@id": annotationId(id),
+    "@type": "oa:Annotation",
+    motivation: "sc:painting",
+    on: `${canvasId(canvas)}#xywh=10,10,50,20`,
+    resource: { "@type": "cnt:ContentAsText", chars: "cats" },
+  })),
+}
+
+const COMPANION_WINDOW_ID = "cw-search"
+
+const buildState = ({
+  canvasIndex,
+  isFetching = false,
+  json = searchJson,
+}) => ({
+  manifests: {
+    [MANIFEST_ID]: { id: MANIFEST_ID, isFetching: false, json: manifestJson },
+  },
+  searches: {
+    main: {
+      [COMPANION_WINDOW_ID]: {
+        data: { [SEARCH_ID]: { isFetching, json } },
+        query: "cats",
+      },
+    },
+  },
+  windows: {
+    main: {
+      canvasId: canvasId(canvasIndex),
+      id: "main",
+      manifestId: MANIFEST_ID,
+      switchCanvasOnSearch: false,
+      visibleCanvases: [canvasId(canvasIndex)],
+    },
+  },
+})
+
+/** A minimal store stand-in that lets a test drive subscriber notifications. */
+const fakeStore = initialState => {
+  const subscribers = []
+
+  return {
+    dispatch: vi.fn(),
+    getState: () => initialState,
+    notify: () => subscribers.slice().forEach(fn => fn()),
+    setState: next => {
+      initialState = next
+    },
+    subscribe: fn => {
+      subscribers.push(fn)
+      return () => subscribers.splice(subscribers.indexOf(fn), 1)
+    },
+    subscribers,
+  }
+}
+
+describe("keepRequestedCanvasThroughInitialSearch", () => {
+  it("selects the first hit on the requested canvas and restores switchCanvasOnSearch", () => {
+    const store = fakeStore(buildState({ canvasIndex: 3 }))
+    keepRequestedCanvasThroughInitialSearch(store, "main")
+    store.notify()
+
+    expect(store.dispatch.mock.calls.map(([action]) => action)).toEqual([
+      {
+        annotationId: annotationId(30),
+        type: "mirador/SELECT_ANNOTATION",
+        windowId: "main",
+      },
+      {
+        id: "main",
+        payload: { switchCanvasOnSearch: true },
+        type: "mirador/UPDATE_WINDOW",
+      },
+    ])
+  })
+
+  it("does not select a hit from another canvas, but still restores switchCanvasOnSearch", () => {
+    const store = fakeStore(buildState({ canvasIndex: 1 }))
+    keepRequestedCanvasThroughInitialSearch(store, "main")
+    store.notify()
+
+    expect(store.dispatch).toHaveBeenCalledTimes(1)
+    expect(store.dispatch).toHaveBeenCalledWith({
+      id: "main",
+      payload: { switchCanvasOnSearch: true },
+      type: "mirador/UPDATE_WINDOW",
+    })
+  })
+
+  it("restores switchCanvasOnSearch when the search returns no hits", () => {
+    const store = fakeStore(
+      buildState({ canvasIndex: 3, json: { ...searchJson, resources: [] } }),
+    )
+    keepRequestedCanvasThroughInitialSearch(store, "main")
+    store.notify()
+
+    expect(store.dispatch).toHaveBeenCalledTimes(1)
+    expect(store.dispatch).toHaveBeenCalledWith({
+      id: "main",
+      payload: { switchCanvasOnSearch: true },
+      type: "mirador/UPDATE_WINDOW",
+    })
+  })
+
+  it("waits for the search to settle before acting", () => {
+    const store = fakeStore(buildState({ canvasIndex: 3, isFetching: true }))
+    keepRequestedCanvasThroughInitialSearch(store, "main")
+    store.notify()
+
+    expect(store.dispatch).not.toHaveBeenCalled()
+
+    store.setState(buildState({ canvasIndex: 3 }))
+    store.notify()
+
+    expect(store.dispatch).toHaveBeenCalled()
+  })
+
+  it("ignores state changes before the search has been requested", () => {
+    const store = fakeStore({
+      ...buildState({ canvasIndex: 3 }),
+      searches: {},
+    })
+    keepRequestedCanvasThroughInitialSearch(store, "main")
+    store.notify()
+
+    expect(store.dispatch).not.toHaveBeenCalled()
+  })
+
+  it("unsubscribes once the initial search has been handled", () => {
+    const store = fakeStore(buildState({ canvasIndex: 3 }))
+    keepRequestedCanvasThroughInitialSearch(store, "main")
+    store.notify()
+
+    const dispatchCount = store.dispatch.mock.calls.length
+    expect(store.subscribers).toHaveLength(0)
+
+    store.notify()
+    expect(store.dispatch.mock.calls).toHaveLength(dispatchCount)
+  })
+})

--- a/spec/javascript/miradorInit.test.js
+++ b/spec/javascript/miradorInit.test.js
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+const viewerInstance = { store: { subscribe: vi.fn() } }
+const viewer = vi.fn(() => viewerInstance)
+const keepRequestedCanvasThroughInitialSearch = vi.fn()
+
+vi.mock("mirador", () => ({ default: { viewer } }))
+vi.mock("mirador-image-tools", () => ({ miradorImageToolsPlugin: [] }))
+vi.mock("mirador-share-plugin", () => ({
+  miradorShareDialogPlugin: {},
+  miradorSharePlugin: {},
+}))
+vi.mock("mirador-dl-plugin", () => ({
+  miradorDownloadDialogPlugin: {},
+  miradorDownloadPlugin: {},
+}))
+vi.mock("@/mirador/plugins/comparisonPlugin.jsx", () => ({ default: [] }))
+vi.mock("@/mirador/plugins/analyticsPlugin.js", () => ({ default: {} }))
+vi.mock("@/mirador/plugins/xywhPlugin.js", () => ({ default: [] }))
+vi.mock("@/mirador/plugins/customMenuPlugin.jsx", () => ({ default: [] }))
+vi.mock("@/mirador/postMessageHandler.js", () => ({
+  handleViewerPostMessage: vi.fn(),
+}))
+vi.mock("@/mirador/initialSearchCanvas.js", () => ({
+  keepRequestedCanvasThroughInitialSearch,
+}))
+
+const { default: init } = await import("@/mirador/init.js")
+
+/** Renders the container div the way mirador_component.html.erb does. */
+const renderContainer = (attributes = {}) => {
+  const el = document.createElement("div")
+  el.id = "sul-embed-mirador"
+
+  // The template always emits these attributes, empty when the param is absent
+  const dataset = {
+    canvasId: "",
+    canvasIndex: "",
+    miradorUri: "https://example.edu/iiif/manifest",
+    search: "",
+    suggestedSearch: "",
+    ...attributes,
+  }
+
+  Object.assign(el.dataset, dataset)
+  document.body.appendChild(el)
+}
+
+const windowConfig = () => viewer.mock.calls[0][0].windows[0]
+
+describe("mirador init", () => {
+  beforeEach(() => {
+    viewer.mockClear()
+    keepRequestedCanvasThroughInitialSearch.mockClear()
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  it("leaves switchCanvasOnSearch alone when only a search is requested", () => {
+    renderContainer({ search: "cats" })
+    init.init()
+
+    expect(windowConfig()).not.toHaveProperty("switchCanvasOnSearch")
+    expect(keepRequestedCanvasThroughInitialSearch).not.toHaveBeenCalled()
+  })
+
+  it("leaves switchCanvasOnSearch alone when only a canvas is requested", () => {
+    renderContainer({ canvasIndex: "11" })
+    init.init()
+
+    expect(windowConfig()).not.toHaveProperty("switchCanvasOnSearch")
+    expect(keepRequestedCanvasThroughInitialSearch).not.toHaveBeenCalled()
+  })
+
+  it("holds the requested canvas when canvas_index and search are combined", () => {
+    renderContainer({ canvasIndex: "11", search: "Net assets" })
+    init.init()
+
+    expect(windowConfig()).toMatchObject({
+      canvasIndex: 11,
+      defaultSearchQuery: "Net assets",
+      switchCanvasOnSearch: false,
+    })
+    expect(keepRequestedCanvasThroughInitialSearch).toHaveBeenCalledWith(
+      viewerInstance.store,
+      "main",
+    )
+  })
+
+  it("holds the requested canvas when canvas_id and search are combined", () => {
+    renderContainer({
+      canvasId: "https://example.edu/iiif/canvas/12",
+      search: "Net assets",
+    })
+    init.init()
+
+    expect(windowConfig()).toMatchObject({ switchCanvasOnSearch: false })
+    expect(keepRequestedCanvasThroughInitialSearch).toHaveBeenCalledWith(
+      viewerInstance.store,
+      "main",
+    )
+  })
+
+  it("treats canvas_index=0 as a requested canvas", () => {
+    renderContainer({ canvasIndex: "0", search: "cats" })
+    init.init()
+
+    expect(windowConfig()).toMatchObject({
+      canvasIndex: 0,
+      switchCanvasOnSearch: false,
+    })
+    expect(keepRequestedCanvasThroughInitialSearch).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Right now you can use the canvas_id or canvas_index params to
open an embed to a particular page, and you can use the search
param to open an embed with a search active.

Nothing prevents you from doing both – and Mirador supports it –
but existing behavior is to open to the requested canvas, then
run the search, which causes you to be navigated to the first
search hit, away from your requested canvas.

This plugin reconciles the two by respecting the requested canvas
if one is present alongside a search, and then immediately returning
to the default behavior of "go to the canvas where the search hits
are" after the initial load.
